### PR TITLE
Add a new operation type INFO to support multi-level information retrieval

### DIFF
--- a/src/com/futurewei/alioth/controller/schema/Common.java
+++ b/src/com/futurewei/alioth/controller/schema/Common.java
@@ -35,6 +35,10 @@ public final class Common {
      * <code>DELETE = 3;</code>
      */
     DELETE(3),
+    /**
+     * <code>INFO = 4;</code>
+     */
+    INFO(4),
     UNRECOGNIZED(-1),
     ;
 
@@ -54,6 +58,10 @@ public final class Common {
      * <code>DELETE = 3;</code>
      */
     public static final int DELETE_VALUE = 3;
+    /**
+     * <code>INFO = 4;</code>
+     */
+    public static final int INFO_VALUE = 4;
 
 
     public final int getNumber() {
@@ -78,6 +86,7 @@ public final class Common {
         case 1: return UPDATE;
         case 2: return GET;
         case 3: return DELETE;
+        case 4: return INFO;
         default: return null;
       }
     }
@@ -245,6 +254,14 @@ public final class Common {
      * <code>ICMP = 2;</code>
      */
     ICMP(2),
+    /**
+     * <code>HTTP = 3;</code>
+     */
+    HTTP(3),
+    /**
+     * <code>ARP = 4;</code>
+     */
+    ARP(4),
     UNRECOGNIZED(-1),
     ;
 
@@ -260,6 +277,14 @@ public final class Common {
      * <code>ICMP = 2;</code>
      */
     public static final int ICMP_VALUE = 2;
+    /**
+     * <code>HTTP = 3;</code>
+     */
+    public static final int HTTP_VALUE = 3;
+    /**
+     * <code>ARP = 4;</code>
+     */
+    public static final int ARP_VALUE = 4;
 
 
     public final int getNumber() {
@@ -283,6 +308,8 @@ public final class Common {
         case 0: return TCP;
         case 1: return UDP;
         case 2: return ICMP;
+        case 3: return HTTP;
+        case 4: return ARP;
         default: return null;
       }
     }
@@ -344,12 +371,13 @@ public final class Common {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\014common.proto\022\020aliothcontroller*<\n\rOper" +
+      "\n\014common.proto\022\020aliothcontroller*F\n\rOper" +
       "ationType\022\n\n\006CREATE\020\000\022\n\n\006UPDATE\020\001\022\007\n\003GET" +
-      "\020\002\022\n\n\006DELETE\020\003*\037\n\tEtherType\022\010\n\004IPV4\020\000\022\010\n" +
-      "\004IPV6\020\001*&\n\010Protocol\022\007\n\003TCP\020\000\022\007\n\003UDP\020\001\022\010\n" +
-      "\004ICMP\020\002B0\n&com.futurewei.alioth.controll" +
-      "er.schemaB\006Commonb\006proto3"
+      "\020\002\022\n\n\006DELETE\020\003\022\010\n\004INFO\020\004*\037\n\tEtherType\022\010\n" +
+      "\004IPV4\020\000\022\010\n\004IPV6\020\001*9\n\010Protocol\022\007\n\003TCP\020\000\022\007" +
+      "\n\003UDP\020\001\022\010\n\004ICMP\020\002\022\010\n\004HTTP\020\003\022\007\n\003ARP\020\004B0\n&" +
+      "com.futurewei.alioth.controller.schemaB\006" +
+      "Commonb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/src/schema/proto3/common.proto
+++ b/src/schema/proto3/common.proto
@@ -10,6 +10,7 @@ enum OperationType {
     UPDATE = 1;
     GET = 2;
     DELETE = 3;
+    INFO = 4;
 }
 
 enum EtherType {
@@ -21,4 +22,6 @@ enum Protocol {
     TCP = 0;
     UDP = 1;
     ICMP = 2;
+    HTTP = 3;
+    ARP = 4;
 }


### PR DESCRIPTION
When controller sends Goal states to agent, agent might need to retrieve information from multiple levels, for example, a port and its subnet, a subnet and its VPC. We propose a new operation type in Common schema to support this need. 

We also add two new protocol types.