### PR TITLE
Support host mac address, and fix/refactor UT codes

### DIFF
--- a/src/com/futurewei/alioth/controller/comm/config/DemoConfig.java
+++ b/src/com/futurewei/alioth/controller/comm/config/DemoConfig.java
@@ -1,0 +1,19 @@
+package com.futurewei.alioth.controller.comm.config;
+
+public interface DemoConfig {
+    String TRANSIT_SWTICH_1_HOST_ID = "ts-1";
+    byte[] TRANSIT_SWITCH_1_IP = new byte[]{127,0,0,5};
+    String TRANSIT_SWITCH_1_MAC = "fa:16:3e:d7:f1:04";
+
+    String TRANSIT_SWTICH_2_HOST_ID = "ts-2";
+    byte[] TRANSIT_SWITCH_2_IP = new byte[]{127,0,0,6};
+    String TRANSIT_SWITCH_2_MAC = "fa:16:3e:d7:f1:05";
+
+    String TRANSIT_ROUTER_1_HOST_ID = "tr-1";
+    byte[] TRANSIT_ROUTER_1_IP = new byte[]{127,0,0,7};
+    String TRANSIT_ROUTER_1_MAC = "fa:16:3e:d7:f1:06";
+
+    String TRANSIT_ROUTER_2_HOST_ID = "tr-2";
+    byte[] TRANSIT_ROUTER_2_IP = new byte[]{127,0,0,8};
+    String TRANSIT_ROUTER_2_MAC = "fa:16:3e:d7:f1:07";
+}

--- a/src/com/futurewei/alioth/controller/model/HostInfo.java
+++ b/src/com/futurewei/alioth/controller/model/HostInfo.java
@@ -1,33 +1,54 @@
 package com.futurewei.alioth.controller.model;
 
 import lombok.Data;
+import org.thymeleaf.util.StringUtils;
 
 import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Data
 public class HostInfo {
 
     private String id;
     private InetAddress localIp;
+    private String macAddress;
 
-    public HostInfo(String hostId, String hostName, byte ipAddress[]) {
+    public HostInfo(String hostId, String hostName, byte[] ipAddress, String macAddress) {
 
         this.id = hostId;
 
         try{
             this.localIp = InetAddress.getByAddress(hostName, ipAddress);
+            if(this.validate(macAddress)) {
+                this.macAddress = macAddress;
+            }else{
+                this.macAddress = null;
+            }
         }
         catch(UnknownHostException e){
             System.err.printf("Invalid ip address" + ipAddress);
         }
     }
 
+    public String getHostName(){
+        return this.localIp.getHostName();
+    }
+
     public String getHostIpAddress(){
         return this.localIp.getHostAddress();
     }
 
-    public String getHostName(){
-        return this.localIp.getHostName();
+    public String getHostMacAddress() {
+        return this.macAddress;
+    }
+
+    private boolean validate(String mac) {
+        Pattern p = Pattern.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$");
+        Matcher m = p.matcher(mac);
+        return m.find();
     }
 }

--- a/src/com/futurewei/alioth/controller/web/SubnetController.java
+++ b/src/com/futurewei/alioth/controller/web/SubnetController.java
@@ -1,6 +1,7 @@
 package com.futurewei.alioth.controller.web;
 
 import com.futurewei.alioth.controller.cache.repo.*;
+import com.futurewei.alioth.controller.comm.config.DemoConfig;
 import com.futurewei.alioth.controller.comm.message.*;
 import com.futurewei.alioth.controller.comm.message.MessageClient;
 import com.futurewei.alioth.controller.exception.*;
@@ -70,12 +71,12 @@ public class SubnetController {
 
             //TODO: Algorithm to allocate transit switches and routers
             HostInfo[] transitSwitches = {
-                    new HostInfo("ts-1", "transit switch host1", new byte[]{10,0,0,11}),
-                    new HostInfo("ts-2", "transit switch host2", new byte[]{10,0,0,12})
+                    new HostInfo(DemoConfig.TRANSIT_SWTICH_1_HOST_ID, "transit switch host1", DemoConfig.TRANSIT_SWITCH_1_IP, DemoConfig.TRANSIT_SWITCH_1_MAC),
+                    new HostInfo(DemoConfig.TRANSIT_SWTICH_2_HOST_ID, "transit switch host2", DemoConfig.TRANSIT_SWITCH_2_IP, DemoConfig.TRANSIT_SWITCH_2_MAC)
             };
             HostInfo[] transitRouters = {
-                    new HostInfo("tr-1", "transit router host1", new byte[]{10,0,0,1}),
-                    new HostInfo("tr-2", "transit router host2", new byte[]{10,0,0,2})
+                    new HostInfo(DemoConfig.TRANSIT_ROUTER_1_HOST_ID, "transit router host1", DemoConfig.TRANSIT_ROUTER_1_IP, DemoConfig.TRANSIT_ROUTER_1_MAC),
+                    new HostInfo(DemoConfig.TRANSIT_ROUTER_2_HOST_ID, "transit router host2", DemoConfig.TRANSIT_ROUTER_2_IP, DemoConfig.TRANSIT_ROUTER_2_MAC)
             };
             MessageClient client = new MessageClient(new GoalStateMessageConsumerFactory(), new GoalStateMessageProducerFactory());
 
@@ -87,8 +88,7 @@ public class SubnetController {
             GoalState subnetGoalState = GoalStateUtil.CreateGoalState(
                     Common.OperationType.CREATE_UPDATE_ROUTER,
                     subnetState,
-                    transitSwitches[0].getHostIpAddress(),
-                    transitSwitches[1].getHostIpAddress());
+                    transitSwitches);
             for(HostInfo transitRouter : transitRouters){
                 String topic = MessageClient.getGoalStateTopic(transitRouter.getId());
                 client.runProducer(topic, subnetGoalState);
@@ -99,8 +99,7 @@ public class SubnetController {
             GoalState vpcGoalstate = GoalStateUtil.CreateGoalState(
                     Common.OperationType.CREATE_UPDATE_SWITCH,
                     vpcState,
-                    transitRouters[0].getHostIpAddress(),
-                    transitRouters[1].getHostIpAddress());
+                    transitRouters);
             for(HostInfo transitSwitch : transitSwitches)
             {
                 String topic = MessageClient.getGoalStateTopic(transitSwitch.getId());

--- a/test/com/futurewei/alioth/controller/model/HostInfoTest.java
+++ b/test/com/futurewei/alioth/controller/model/HostInfoTest.java
@@ -5,10 +5,13 @@ import org.junit.Test;
 
 public class HostInfoTest {
     @Test
-    public void basicTest(){
+    public void basicTest() {
         HostInfo[] transitSwitches = {
-                new HostInfo("ts-1", "transit switch host1", new byte[]{10,0,0,11}),
-                new HostInfo("ts-2", "transit switch host2", new byte[]{10,0,0,12})
+                new HostInfo("ts-1", "transit switch host1", new byte[]{10,0,0,11},"3D:F2:C9:A6:B3:4F"),
+                new HostInfo("ts-2", "transit switch host2", new byte[]{10,0,0,12},"3D:F2:C9:A6:B3:50"),
+                new HostInfo("ts-3", "transit switch host3 with wrong mac", new byte[]{10,0,0,13}, "3D:F2:C9:A6:B3:50A"),
+                new HostInfo("ts-4", "transit switch host4", new byte[]{10,0,0,14}, "fa:16:3e:d7:f1:04"),
+                new HostInfo("ts-5", "transit switch host5", new byte[]{10,0,0,14}, "fa-16-3e-d7-f1-04")
         };
 
         Assert.assertEquals("invalid host1 id", "ts-1", transitSwitches[0].getId());
@@ -19,6 +22,12 @@ public class HostInfoTest {
 
         Assert.assertEquals("invalid ip address", "10.0.0.11", transitSwitches[0].getHostIpAddress());
         Assert.assertEquals("invalid ip address", "10.0.0.12", transitSwitches[1].getHostIpAddress());
+
+        Assert.assertEquals("invalid mac address", "3D:F2:C9:A6:B3:4F", transitSwitches[0].getHostMacAddress());
+        Assert.assertEquals("invalid mac address", "3D:F2:C9:A6:B3:50", transitSwitches[1].getHostMacAddress());
+        Assert.assertEquals("invalid mac address", null, transitSwitches[2].getHostMacAddress());
+        Assert.assertEquals("invalid mac address", "fa:16:3e:d7:f1:04", transitSwitches[3].getHostMacAddress());
+        Assert.assertEquals("invalid mac address", "fa-16-3e-d7-f1-04", transitSwitches[4].getHostMacAddress());
     }
 
 }

--- a/test/com/futurewei/alioth/controller/schema/SubnetTest.java
+++ b/test/com/futurewei/alioth/controller/schema/SubnetTest.java
@@ -1,5 +1,8 @@
 package com.futurewei.alioth.controller.schema;
 
+import com.futurewei.alioth.controller.comm.config.DemoConfig;
+import com.futurewei.alioth.controller.model.HostInfo;
+import com.futurewei.alioth.controller.model.SubnetState;
 import com.futurewei.alioth.controller.utilities.GoalStateUtil;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.junit.Assert;
@@ -8,14 +11,20 @@ import org.junit.Test;
 public class SubnetTest {
     @Test
     public void basicSerializationVerification() {
-        final Subnet.SubnetState state = GoalStateUtil.CreateGSSubnetState(Common.OperationType.CREATE,
-                "dbf72700-5106-4a7a-918f-a016853911f8",
+        SubnetState customerSubnetState = new SubnetState("dbf72700-5106-4a7a-918f-a016853911f8",
                 "99d9d709-8478-4b46-9f3f-2206b1023fd3",
                 "d973934b-93e8-42fa-ac91-bf0cdb84fffc",
                 "Subnet1",
-                "192.168.0.0/28",
-                "192.168.0.1",
-                "192.168.0.2");
+                "192.168.0.0/28");
+
+        HostInfo[] transitSwitches = {
+                new HostInfo(DemoConfig.TRANSIT_SWTICH_1_HOST_ID, "transit switch host1", DemoConfig.TRANSIT_SWITCH_1_IP, DemoConfig.TRANSIT_SWITCH_1_MAC),
+                new HostInfo(DemoConfig.TRANSIT_SWTICH_2_HOST_ID, "transit switch host2", DemoConfig.TRANSIT_SWITCH_2_IP, DemoConfig.TRANSIT_SWITCH_2_MAC)
+        };
+
+        final Subnet.SubnetState state = GoalStateUtil.CreateGSSubnetState(Common.OperationType.CREATE,
+                customerSubnetState,
+                transitSwitches);
 
         final byte[] binaryState = state.toByteArray();
 

--- a/test/com/futurewei/alioth/controller/schema/TestUtil.java
+++ b/test/com/futurewei/alioth/controller/schema/TestUtil.java
@@ -19,18 +19,18 @@ public class TestUtil {
 
         Assert.assertEquals("routes mismatched", expected.getConfiguration().getRoutesCount(), result.getConfiguration().getRoutesCount());
 
-        Assert.assertEquals("transit router ips mismatched", expected.getConfiguration().getTransitRouterIpsCount(), result.getConfiguration().getTransitRouterIpsCount());
-        TestUtil.AssertTransitRouterIps(expected.getConfiguration().getTransitRouterIpsList(), result.getConfiguration().getTransitRouterIpsList());
+        Assert.assertEquals("transit router ips mismatched", expected.getConfiguration().getTransitRoutersCount(), result.getConfiguration().getTransitRoutersCount());
+        TestUtil.AssertTransitRouters(expected.getConfiguration().getTransitRoutersList(), result.getConfiguration().getTransitRoutersList());
     }
 
-    public static void AssertTransitRouterIps(List<VpcConfiguration.TransitRouterIp> expected, List<VpcConfiguration.TransitRouterIp> result){
+    public static void AssertTransitRouters(List<VpcConfiguration.TransitRouter> expected, List<VpcConfiguration.TransitRouter> result){
         Assert.assertEquals(expected.size(), result.size());
         for (int i = 0; i < expected.size(); i++) {
-            TestUtil.AssertTransitRouterIp(expected.get(i), result.get(i));
+            TestUtil.AssertTransitRouter(expected.get(i), result.get(i));
         }
     }
 
-    private static void AssertTransitRouterIp(VpcConfiguration.TransitRouterIp expected, VpcConfiguration.TransitRouterIp result) {
+    private static void AssertTransitRouter(VpcConfiguration.TransitRouter expected, VpcConfiguration.TransitRouter result) {
         Assert.assertEquals("vip id mismatched", expected.getVpcId(), result.getVpcId());
         Assert.assertEquals("router ip mismatched", expected.getIpAddress(), result.getIpAddress());
     }
@@ -43,18 +43,18 @@ public class TestUtil {
         Assert.assertEquals("subnet name mismatched", expected.getConfiguration().getName(), result.getConfiguration().getName());
         Assert.assertEquals("cidr mismatched", expected.getConfiguration().getCidr(), result.getConfiguration().getCidr());
 
-        Assert.assertEquals("transit router ips mismatched", expected.getConfiguration().getTransitSwitchIpsCount(), result.getConfiguration().getTransitSwitchIpsCount());
-        TestUtil.AssertTransitSwitchIps(expected.getConfiguration().getTransitSwitchIpsList(), result.getConfiguration().getTransitSwitchIpsList());
+        Assert.assertEquals("transit router ips mismatched", expected.getConfiguration().getTransitSwitchesCount(), result.getConfiguration().getTransitSwitchesCount());
+        TestUtil.AssertTransitSwitches(expected.getConfiguration().getTransitSwitchesList(), result.getConfiguration().getTransitSwitchesList());
     }
 
-    public static void AssertTransitSwitchIps(List<SubnetConfiguration.TransitSwitchIp> expected, List<SubnetConfiguration.TransitSwitchIp> result){
+    public static void AssertTransitSwitches(List<SubnetConfiguration.TransitSwitch> expected, List<SubnetConfiguration.TransitSwitch> result){
         Assert.assertEquals(expected.size(), result.size());
         for (int i = 0; i < expected.size(); i++) {
-            TestUtil.AssertTransitSwitchIp(expected.get(i), result.get(i));
+            TestUtil.AssertTransitSwitch(expected.get(i), result.get(i));
         }
     }
 
-    private static void AssertTransitSwitchIp(SubnetConfiguration.TransitSwitchIp expected, SubnetConfiguration.TransitSwitchIp result) {
+    private static void AssertTransitSwitch(SubnetConfiguration.TransitSwitch expected, SubnetConfiguration.TransitSwitch result) {
         Assert.assertEquals("vip id mismatched", expected.getVpcId(), result.getVpcId());
         Assert.assertEquals("subnet id mismatched", expected.getSubnetId(), result.getSubnetId());
         Assert.assertEquals("router ip mismatched", expected.getIpAddress(), result.getIpAddress());

--- a/test/com/futurewei/alioth/controller/schema/VpcTest.java
+++ b/test/com/futurewei/alioth/controller/schema/VpcTest.java
@@ -1,5 +1,7 @@
 package com.futurewei.alioth.controller.schema;
 
+import com.futurewei.alioth.controller.comm.config.DemoConfig;
+import com.futurewei.alioth.controller.model.HostInfo;
 import com.futurewei.alioth.controller.schema.Vpc.VpcState;
 import com.futurewei.alioth.controller.utilities.GoalStateUtil;
 import com.google.protobuf.ByteString;
@@ -49,13 +51,19 @@ public class VpcTest {
 
     @Test
     public void serializationVerificationWithTransitRouterIps() {
-        final VpcState state = GoalStateUtil.CreateGSVpcState(Common.OperationType.CREATE,
-                "dbf72700-5106-4a7a-918f-a016853911f8",
+        com.futurewei.alioth.controller.model.VpcState customerVpcState =
+                new com.futurewei.alioth.controller.model.VpcState("dbf72700-5106-4a7a-918f-a016853911f8",
                 "99d9d709-8478-4b46-9f3f-2206b1023fd3",
                 "SuperVpc",
-                "10.0.0.0/24",
-                "10.0.0.1",
-                "10.0.0.3");
+                "10.0.0.0/24");
+        HostInfo[] transitRouterHosts = {
+                new HostInfo(DemoConfig.TRANSIT_ROUTER_1_HOST_ID, "transit router host1", DemoConfig.TRANSIT_ROUTER_1_IP, DemoConfig.TRANSIT_ROUTER_1_MAC),
+                new HostInfo(DemoConfig.TRANSIT_ROUTER_2_HOST_ID, "transit router host2", DemoConfig.TRANSIT_ROUTER_2_IP, DemoConfig.TRANSIT_ROUTER_2_MAC)
+        };
+
+        final VpcState state = GoalStateUtil.CreateGSVpcState(Common.OperationType.CREATE,
+                customerVpcState,
+                transitRouterHosts);
 
         final byte[] binaryState = state.toByteArray();
 

--- a/test/com/futurewei/alioth/controller/web/DebugControllerTest.java
+++ b/test/com/futurewei/alioth/controller/web/DebugControllerTest.java
@@ -1,11 +1,13 @@
 package com.futurewei.alioth.controller.web;
 
+import com.futurewei.alioth.controller.app.AliothControllerApp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DebugController.class)
+@ContextConfiguration(classes={AliothControllerApp.class})
 @AutoConfigureRestDocs(outputDir = "target/generated-snippets")
 public class DebugControllerTest {
 


### PR DESCRIPTION
This PR includes the following changes:
(1) Add a new field hostMacAddress in the HostInfo class with mac validation, and add UT test cases to cover the new field;
(2) Fix broken model UTs caused by last breaking scheme change to incorporate host mac address;
(3) Enhance VPC and subnet UTs with possibility of testing random number of transit routers and switches in VPC and subnets, respectively;
(4) Fix DebugControllerTest UT issue caused by the missing ContextConfiguration. 