### PR TITLE
update GoalStateOperationStatus schema 

### DIFF
--- a/src/schema/proto3/goalstateprovisioner.proto
+++ b/src/schema/proto3/goalstateprovisioner.proto
@@ -38,7 +38,7 @@ message GoalStateOperationReply {
    repeated GoalStateOperationStatus operation_statuses = 1;    
 
    // total time taken (in nanoseconds) to update this goal state configurations
-   uint32 goal_state_operation_total_time = 2;
+   uint32 message_total_operation_time = 2;
 
    message GoalStateOperationStatus {
 	string resource_id = 1;
@@ -47,6 +47,6 @@ message GoalStateOperationReply {
 	OperationStatus operation_status = 4;
 	uint32 dataplane_programming_time = 5;
 	uint32 network_configuration_time = 6;    
-	uint32 total_operation_time = 7;
+	uint32 state_elapse_time = 7;
    }
 }


### PR DESCRIPTION
This PR updates the GoalStateOperationReply schema to include:
- goal_state_operation_total_time

and the below for each repeated GoalStateOperationStatus message
- dataplane_programming_time
- network_configuration_time    
- total_operation_time