### PR TITLE
Update build scripts to support microservices build on Linux/MacOsX/Windows

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -15,4 +15,33 @@ mvn clean
 mvn compile
 mvn install
 
+Write-Host "Clean build common library project"
+cd lib
+mvn clean
+mvn compile
+mvn install
+cd ..
+
+Write-Host "Clean build web project"
+cd web
+mvn clean
+mvn compile
+mvn install
+cd ..
+
+Write-Host "Build service one by one under services directory"
+cd services
+$service_subdirectories = Get-ChildItem -Directory -Force -ErrorAction SilentlyContinue
+foreach($subdirectory in $service_subdirectories)
+{
+    Write-Host "Build service -  $($subdirectory.name)"
+    cd $subdirectory.name
+    mvn clean
+    mvn compile
+    mvn install
+    cd ..
+    Write-Host "Build service -  $($subdirectory.name) completed" -ForegroundColor green
+}
+
+cd ..
 Write-Host "Build completed" -ForegroundColor green

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,19 +7,75 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   sudo apt-get install maven
   sudo apt-get install openjdk-8-jdk
 
-  # Clean build controller project
+  echo "Clean build controller project"
   mvn clean
   mvn compile
   mvn install
+
+  echo "Clean build common library project"
+  cd lib
+  mvn clean
+  mvn compile
+  mvn install
+  cd ..
+
+  echo "Clean build web project"
+  cd web
+  mvn clean
+  mvn compile
+  mvn install
+  cd ..
+
+  echo "Build service one by one under services directory"
+  cd services
+  for d in ./*/;
+  do
+      echo "Build service -  $d"
+      cd $d
+      mvn clean
+      mvn compile
+      mvn install
+      cd ..
+      echo "Build service -  $d completed"
+  done
+
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   echo "Install prerequisites in Mac OSX"
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   brew install maven
 
-  # Clean build controller project
+  echo "Clean build controller project"
   mvn clean
   mvn compile
   mvn install -DskipTests
+
+  echo "Clean build common library project"
+  cd lib
+  mvn clean
+  mvn compile
+  mvn install -DskipTests
+  cd ..
+
+  echo "Clean build web project"
+  cd web
+  mvn clean
+  mvn compile
+  mvn install -DskipTests
+  cd ..
+
+  echo "Build service one by one under services directory"
+  cd services
+  for d in ./*/;
+  do
+      echo "Build service -  $d"
+      cd $d
+      mvn clean
+      mvn compile
+      mvn install -DskipTests
+      cd ..
+      echo "Build service -  $d completed"
+  done
+
 elif [[ "$OSTYPE" == "cygwin" ]]; then
   # POSIX compatibility layer and Linux environment emulation for Windows
   echo "Install prerequisites in Linux environment of Windows"
@@ -29,3 +85,5 @@ elif [[ "$OSTYPE" == "msys" ]]; then
 else
   echo "Unknown supported OS"
 fi
+
+echo "Build completed"


### PR DESCRIPTION
This PR is to update build scripts in order to support building new microservices for various OS:
- Linux OS (test for Ubuntu 18.04)
- Mac OsX (test for Mac OsX Mojava v10.14)
- Windows 10