### PR TITLE
[Schema Update] Schema Support for OVS and DHCP

### DIFF
--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -36,8 +36,8 @@ enum OperationType {
     DELETE = 3;
     INFO = 4;
     FINALIZE = 5; // FIXME: we will try to the whole port operation in the FINALIZE call
-    CREATE_UPDATE_SWITCH = 6; // FIXME: I don't think we need this for OVS?
-    CREATE_UPDATE_ROUTER = 7;
+    CREATE_UPDATE_SWITCH = 6; // For Mizar only
+    CREATE_UPDATE_ROUTER = 7; // For Mizar only
     CREATE_UPDATE_GATEWAY = 8;
     // FIXME: we will likely need an operation to create/update neighbor info
 }
@@ -66,4 +66,5 @@ enum NetworkType {
     VLAN = 1;
     GRE = 2;
     GENEVE = 3;
+    VXLAN_GPE = 4;
 }

--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -35,11 +35,14 @@ enum OperationType {
     GET = 2;
     DELETE = 3;
     INFO = 4;
-    NEIGHBOR_INFO = 5; // FIXME: we may need CRUD for NEIGHBOR_INFO
-    CREATE_UPDATE_GATEWAY = 6;
-    FINALIZE = 7;             // For Mizar only
-    CREATE_UPDATE_SWITCH = 8; // For Mizar only
-    CREATE_UPDATE_ROUTER = 9; // For Mizar only
+    NEIGHBOR_CREATE = 5;
+    NEIGHBOR_UPDATE = 6;
+    NEIGHBOR_GET = 7;
+    NEIGHBOR_DELETE = 8;
+    CREATE_UPDATE_GATEWAY = 9;
+    FINALIZE = 10;             // For Mizar only
+    CREATE_UPDATE_SWITCH = 11; // For Mizar only
+    CREATE_UPDATE_ROUTER = 12; // For Mizar only
 }
 
 enum OperationStatus {

--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -35,11 +35,11 @@ enum OperationType {
     GET = 2;
     DELETE = 3;
     INFO = 4;
-    FINALIZE = 5; // FIXME: we will try to the whole port operation in the FINALIZE call
-    CREATE_UPDATE_SWITCH = 6; // For Mizar only
-    CREATE_UPDATE_ROUTER = 7; // For Mizar only
-    CREATE_UPDATE_GATEWAY = 8;
-    // FIXME: we will likely need an operation to create/update neighbor info
+    NEIGHBOR_INFO = 5; // FIXME: we may need CRUD for NEIGHBOR_INFO
+    CREATE_UPDATE_GATEWAY = 6;
+    FINALIZE = 7;             // For Mizar only
+    CREATE_UPDATE_SWITCH = 8; // For Mizar only
+    CREATE_UPDATE_ROUTER = 9; // For Mizar only
 }
 
 enum OperationStatus {

--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -26,6 +26,7 @@ enum ResourceType {
     SUBNET = 1;
     PORT = 2;
     SECURITYGROUP = 3;
+    DHCP = 4;
 }
 
 enum OperationType {
@@ -34,10 +35,11 @@ enum OperationType {
     GET = 2;
     DELETE = 3;
     INFO = 4;
-    FINALIZE = 5;
-    CREATE_UPDATE_SWITCH = 6;
+    FINALIZE = 5; // FIXME: we will try to the whole port operation in the FINALIZE call
+    CREATE_UPDATE_SWITCH = 6; // FIXME: I don't think we need this for OVS?
     CREATE_UPDATE_ROUTER = 7;
     CREATE_UPDATE_GATEWAY = 8;
+    // FIXME: we will likely need an operation to create/update neighbor info
 }
 
 enum OperationStatus {
@@ -57,4 +59,11 @@ enum Protocol {
     ICMP = 2;
     HTTP = 3;
     ARP = 4;
+}
+
+enum NetworkType { 
+    VXLAN = 0; // the default type
+    VLAN = 1;
+    GRE = 2;
+    GENEVE = 3;
 }

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -19,17 +19,27 @@ syntax = "proto3";
 package alcor.schema;
 
 option java_package = "com.futurewei.alcor.schema";
+option java_outer_classname = "DHCP";
 
-import "vpc.proto";
-import "subnet.proto";
-import "port.proto";
-import "securitygroup.proto";
-import "dhcp.proto";
+import "common.proto";
 
-message GoalState {
-    repeated VpcState vpc_states = 1;
-    repeated SubnetState subnet_states = 2;
-    repeated PortState port_states = 3;
-    repeated SecurityGroupState security_group_states = 4;
-    repeated DHCPState dhcp_states = 5;
+message DHCPConfiguration {
+    int32 version = 1;
+
+    string mac_address = 2;
+    string ipv4_address = 3;
+    string ipv6_address = 4;
+    string port_host_name = 5; // for local DNS response
+
+    message ExtraDhcpOption {
+        string name = 1;
+        string value = 2;
+    }
+
+    repeated ExtraDhcpOption extra_dhcp_options = 6;
+}
+
+message DHCPState {
+    OperationType operation_type = 1;
+    DHCPConfiguration configuration = 2;
 }

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -24,7 +24,7 @@ option java_outer_classname = "DHCP";
 import "common.proto";
 
 message DHCPConfiguration {
-    int32 version = 1;
+    uint32 version = 1;
 
     string mac_address = 2;
     string ipv4_address = 3;
@@ -36,7 +36,12 @@ message DHCPConfiguration {
         string value = 2;
     }
 
+    message DnsEntry {
+        string entry = 1;
+    }
+
     repeated ExtraDhcpOption extra_dhcp_options = 6;
+    repeated DnsEntry dns_entry_list = 7;
 }
 
 message DHCPState {

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -27,9 +27,11 @@ import "securitygroup.proto";
 import "dhcp.proto";
 
 message GoalState {
-    repeated VpcState vpc_states = 1;
-    repeated SubnetState subnet_states = 2;
-    repeated PortState port_states = 3;
-    repeated SecurityGroupState security_group_states = 4;
-    repeated DHCPState dhcp_states = 5;
+    uint32 version = 1;
+
+    repeated VpcState vpc_states = 2;
+    repeated SubnetState subnet_states = 3;
+    repeated PortState port_states = 4;
+    repeated SecurityGroupState security_group_states = 5;
+    repeated DHCPState dhcp_states = 6;
 }

--- a/schema/proto3/goalstateprovisioner.proto
+++ b/schema/proto3/goalstateprovisioner.proto
@@ -41,24 +41,18 @@ service GoalStateProvisioner {
 }
 
 message GoalStateRequest {
-
-    repeated ResourceStateRequest state_requests = 1;
+    uint32 version = 1;
 
     message ResourceStateRequest {
         string resource_id = 1;
         ResourceType resource_type = 2;
     }
+
+    repeated ResourceStateRequest state_requests = 2;
 }
 
 message GoalStateOperationReply {
-
-    repeated GoalStateOperationStatus operation_statuses = 1;
-
-    // Total operation time (in nanoseconds)
-    //    1. to process the message (consisting of multiple operations)
-    //    2. to program data plane
-    // Note: The list of operation_statuses details the time spent at each operation
-    uint32 message_total_operation_time = 2;
+    uint32 version = 1;
 
     message GoalStateOperationStatus {
         string resource_id = 1;
@@ -69,4 +63,12 @@ message GoalStateOperationReply {
         uint32 network_configuration_time = 6;
         uint32 state_elapse_time = 7;
     }
+
+    repeated GoalStateOperationStatus operation_statuses = 2;
+
+    // Total operation time (in nanoseconds)
+    //    1. to process the message (consisting of multiple operations)
+    //    2. to program data plane
+    // Note: The list of operation_statuses details the time spent at each operation
+    uint32 message_total_operation_time = 3;
 }

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -26,6 +26,11 @@ import "common.proto";
 message PortConfiguration {
     int32 version = 1;
 
+    // FIXME: the options for NetworkType are:
+    // 1. put in PortConfiguration here since only useful for Port, ACA programming will be direct and easier
+    // 2. put in VPC configuration since it is a "network level" configuration, 
+    //      that mean every port configuration needs to go with VPC config for ACA to look up
+    NetworkType network_type = 13;  // TODO: the ID will be update after discussion
     string project_id = 2;
     string network_id = 3;
     string id = 4;
@@ -53,16 +58,14 @@ message PortConfiguration {
         string mac_address = 2;
     }
 
-    message ExtraDhcpOption {
-        string name = 1;
-        string value = 2;
-    }
-
-    HostInfo host_info = 9;
+    HostInfo host_info = 9; // FIXME: will be used to populate neighbor info only
     repeated FixedIp fixed_ips = 10;
     repeated SecurityGroupId security_group_ids = 11;
     repeated AllowAddressPair allow_address_pairs = 12;
-    repeated ExtraDhcpOption extra_dhcp_options = 13;
+
+    // FIXME: note that for neutron, it sends down more stuff than this
+    // please review and see if there is anything else we needed now:
+    // https://github.com/openstack/neutron/blob/93e9dc5426764b791ac69e62c6d60be7591c16ab/neutron/plugins/ml2/rpc.py#L150
 }
 
 message PortState {

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -24,20 +24,21 @@ option java_outer_classname = "Port";
 import "common.proto";
 
 message PortConfiguration {
-    int32 version = 1;
+    uint32 version = 1;
 
     // FIXME: the options for NetworkType are:
     // 1. put in PortConfiguration here since only useful for Port, ACA programming will be direct and easier
     // 2. put in VPC configuration since it is a "network level" configuration, 
     //      that mean every port configuration needs to go with VPC config for ACA to look up
-    NetworkType network_type = 13;  // TODO: the ID will be update after discussion
-    string project_id = 2;
-    string network_id = 3;
-    string id = 4;
-    string name = 5;
-    string network_ns = 6;
-    string mac_address = 7;
-    string veth_name = 8;
+    NetworkType network_type = 2;
+    string project_id = 3;
+    string network_id = 4;
+    string id = 5;
+    string name = 6;
+    string network_ns = 7;
+    string mac_address = 8;
+    string veth_name = 9;
+    bool admin_state_up = 10;
 
     message HostInfo {
         string ip_address = 1;
@@ -49,19 +50,19 @@ message PortConfiguration {
         string ip_address = 2;
     }
 
-    message SecurityGroupId {
-        string id = 1;
-    }
-
     message AllowAddressPair {
         string ip_address = 1;
         string mac_address = 2;
     }
 
-    HostInfo host_info = 9; // FIXME: will be used to populate neighbor info only
-    repeated FixedIp fixed_ips = 10;
-    repeated SecurityGroupId security_group_ids = 11;
-    repeated AllowAddressPair allow_address_pairs = 12;
+    message SecurityGroupId {
+        string id = 1;
+    }
+
+    HostInfo host_info = 11;
+    repeated FixedIp fixed_ips = 12;
+    repeated AllowAddressPair allow_address_pairs = 13;
+    repeated SecurityGroupId security_group_ids = 14;
 
     // FIXME: note that for neutron, it sends down more stuff than this
     // please review and see if there is anything else we needed now:

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -25,11 +25,7 @@ import "common.proto";
 
 message PortConfiguration {
     uint32 version = 1;
-
-    // FIXME: the options for NetworkType are:
-    // 1. put in PortConfiguration here since only useful for Port, ACA programming will be direct and easier
-    // 2. put in VPC configuration since it is a "network level" configuration, 
-    //      that mean every port configuration needs to go with VPC config for ACA to look up
+    
     NetworkType network_type = 2;
     string project_id = 3;
     string network_id = 4;
@@ -63,10 +59,6 @@ message PortConfiguration {
     repeated FixedIp fixed_ips = 12;
     repeated AllowAddressPair allow_address_pairs = 13;
     repeated SecurityGroupId security_group_ids = 14;
-
-    // FIXME: note that for neutron, it sends down more stuff than this
-    // please review and see if there is anything else we needed now:
-    // https://github.com/openstack/neutron/blob/93e9dc5426764b791ac69e62c6d60be7591c16ab/neutron/plugins/ml2/rpc.py#L150
 }
 
 message PortState {

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -24,7 +24,7 @@ option java_outer_classname = "SecurityGroup";
 import "common.proto";
 
 message SecurityGroupConfiguration {
-    int32 version = 1;
+    uint32 version = 1;
 
     string project_id = 2;
     string vpc_id = 3;
@@ -42,9 +42,8 @@ message SecurityGroupConfiguration {
         Direction direction = 3;
         EtherType ethertype = 4;
         Protocol protocol = 5;
-
-        int32 port_range_min = 6;
-        int32 port_range_max = 7;
+        uint32 port_range_min = 6;
+        uint32 port_range_max = 7;
         string remote_ip_prefix = 8;
         string remote_group_id = 9;
     }

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -46,12 +46,6 @@ message SubnetConfiguration {
     string primary_dns = 11;
     string secondary_dns = 12;
 
-    message SecurityGroupId {
-        string id = 1;
-    }
-
-    repeated SecurityGroupId security_group_ids = 14; // FIXME: why to store in subnet level? 
-
     // start Mizar specific session
     // note that repeated field are inherently optional
     message TransitSwitch {
@@ -60,7 +54,7 @@ message SubnetConfiguration {
         string ip_address = 3;
         string mac_address = 4;
     }
-    repeated TransitSwitch transit_switches = 15;
+    repeated TransitSwitch transit_switches = 13;
     // end Mizar specific session
 }
 

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -24,7 +24,7 @@ option java_outer_classname = "Subnet";
 import "common.proto";
 
 message SubnetConfiguration {
-    int32 version = 1;
+    uint32 version = 1;
 
     string project_id = 2;
     string vpc_id = 3;
@@ -46,25 +46,24 @@ message SubnetConfiguration {
     string primary_dns = 11;
     string secondary_dns = 12;
 
-    message DnsEntry {
-        string entry = 1;
-    }
-
     message SecurityGroupId {
         string id = 1;
     }
 
+    repeated SecurityGroupId security_group_ids = 14; // FIXME: why to store in subnet level? 
+
+    // start Mizar specific session
+    // note that repeated field are inherently optional
     message TransitSwitch {
         string vpc_id = 1;
         string subnet_id = 2;
         string ip_address = 3;
         string mac_address = 4;
     }
-
-    repeated DnsEntry dns_list = 13; // FIXME: what is this for?
-    repeated SecurityGroupId security_group_ids = 14; // FIXME: why to store in subnet level? 
-    repeated TransitSwitch transit_switches = 15; // FIXME: to be removed
+    repeated TransitSwitch transit_switches = 15;
+    // end Mizar specific session
 }
+
 message SubnetState {
     OperationType operation_type = 1;
     SubnetConfiguration configuration = 2;

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -61,9 +61,9 @@ message SubnetConfiguration {
         string mac_address = 4;
     }
 
-    repeated DnsEntry dns_list = 13;
-    repeated SecurityGroupId security_group_ids = 14;
-    repeated TransitSwitch transit_switches = 15;
+    repeated DnsEntry dns_list = 13; // FIXME: what is this for?
+    repeated SecurityGroupId security_group_ids = 14; // FIXME: why to store in subnet level? 
+    repeated TransitSwitch transit_switches = 15; // FIXME: to be removed
 }
 message SubnetState {
     OperationType operation_type = 1;

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -31,10 +31,6 @@ message VpcConfiguration {
     string name = 4;
     string cidr = 5;
     int64 tunnel_id = 6;
-    // FIXME: MTU info would be part VPC right?
-    // OVS neutron agent doesn't look at MTU except
-    // during the construction of physical bridge
-    // and it get the MTU info from its config
 
     message SubnetId {
         string id = 1;

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -24,7 +24,7 @@ option java_outer_classname = "Vpc";
 import "common.proto";
 
 message VpcConfiguration {
-    int32 version = 1;
+    uint32 version = 1;
 
     string project_id = 2;
     string id = 3;
@@ -45,15 +45,18 @@ message VpcConfiguration {
         string next_hop = 2;
     }
 
+    repeated SubnetId subnet_ids = 7;
+    repeated Route routes = 8;
+
+    // start Mizar specific session
+    // note that repeated field are inherently optional
     message TransitRouter {
         string vpc_id = 1;
         string ip_address = 2;
         string mac_address = 3;
     }
-
-    repeated SubnetId subnet_ids = 7;
-    repeated Route routes = 8;
-    repeated TransitRouter transit_routers = 9; // FIXME: to be removed
+    repeated TransitRouter transit_routers = 9;
+    // end Mizar specific session
 }
 
 message VpcState {

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -31,6 +31,10 @@ message VpcConfiguration {
     string name = 4;
     string cidr = 5;
     int64 tunnel_id = 6;
+    // FIXME: MTU info would be part VPC right?
+    // OVS neutron agent doesn't look at MTU except
+    // during the construction of physical bridge
+    // and it get the MTU info from its config
 
     message SubnetId {
         string id = 1;
@@ -49,7 +53,7 @@ message VpcConfiguration {
 
     repeated SubnetId subnet_ids = 7;
     repeated Route routes = 8;
-    repeated TransitRouter transit_routers = 9;
+    repeated TransitRouter transit_routers = 9; // FIXME: to be removed
 }
 
 message VpcState {


### PR DESCRIPTION
This is the initial schema update to support OVS. The high-level ideas are:

* Added fields needed to support OVS port configuration update
* Added DHCP configuration
* Keep mizar support for so that it is not a major breaking change for Alcor Control Agent, because ACA still using it for its unit/functional tests

NOTE: It is a draft with a lot of "FIXME" comments for internal discussions.
