### PR TITLE
[Port Manager] Fix bug where rest client is unachievable from SpringContextUtil

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.*;
 
 @Service
 @ComponentScan(value="com.futurewei.alcor.common.utils")
+@ComponentScan(value="com.futurewei.alcor.web.restclient")
 public class PortServiceImpl implements PortService {
     private static final Logger LOG = LoggerFactory.getLogger(PortServiceImpl.class);
 


### PR DESCRIPTION
__Bug Description__

Port Manager uses a set of RestClients to connect to various microservices to achieve or verify network resources. Those RestClients were in AlcorPortManager project but later moved to the AlcorWeb project intended for sharing by other microservices (PR #180). This move causes that those RestClients cannot be scanned by Spring, as a result, they cannot be obtained through SpringContextUtil.

__Proposed Fix__
In order to repair the bug, we propose to add the annotation @componentscan (value= "com.futurewei.alcor.web.restclient") where the RestClient is needed.