### PR TITLE
[Schema Update] Add Version Support and Delta/Full Message Type

### DIFF
--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -35,14 +35,14 @@ enum OperationType {
     GET = 2;
     DELETE = 3;
     INFO = 4;
-    NEIGHBOR_CREATE = 5;
-    NEIGHBOR_UPDATE = 6;
-    NEIGHBOR_GET = 7;
-    NEIGHBOR_DELETE = 8;
-    CREATE_UPDATE_GATEWAY = 9;
-    FINALIZE = 10;             // For Mizar only
-    CREATE_UPDATE_SWITCH = 11; // For Mizar only
-    CREATE_UPDATE_ROUTER = 12; // For Mizar only
+    NEIGHBOR_CREATE_UPDATE = 5;
+    NEIGHBOR_GET = 6;
+    NEIGHBOR_DELETE = 7;
+    CREATE_UPDATE_GATEWAY = 8;
+
+    FINALIZE = 9;              // For Mizar only
+    CREATE_UPDATE_SWITCH = 10; // For Mizar only
+    CREATE_UPDATE_ROUTER = 11; // For Mizar only
 }
 
 enum OperationStatus {

--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -71,8 +71,3 @@ enum NetworkType {
     GENEVE = 3;
     VXLAN_GPE = 4;
 }
-
-enum MessageType { 
-    DELTA = 0; // the default type
-    FULL = 1;
-}

--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -71,3 +71,8 @@ enum NetworkType {
     GENEVE = 3;
     VXLAN_GPE = 4;
 }
+
+enum MessageType { 
+    DELTA = 0; // the default type
+    FULL = 1;
+}

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message DHCPConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2
+    uint32 content_version = 2;
 
     string mac_address = 3;
     string ipv4_address = 4;

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -24,12 +24,13 @@ option java_outer_classname = "DHCP";
 import "common.proto";
 
 message DHCPConfiguration {
-    uint32 version = 1;
+    uint32 format_version = 1;
+    uint32 content_version = 2
 
-    string mac_address = 2;
-    string ipv4_address = 3;
-    string ipv6_address = 4;
-    string port_host_name = 5; // for local DNS response
+    string mac_address = 3;
+    string ipv4_address = 4;
+    string ipv6_address = 5;
+    string port_host_name = 6; // for local DNS response
 
     message ExtraDhcpOption {
         string name = 1;
@@ -40,8 +41,8 @@ message DHCPConfiguration {
         string entry = 1;
     }
 
-    repeated ExtraDhcpOption extra_dhcp_options = 6;
-    repeated DnsEntry dns_entry_list = 7;
+    repeated ExtraDhcpOption extra_dhcp_options = 7;
+    repeated DnsEntry dns_entry_list = 8;
 }
 
 message DHCPState {

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message DHCPConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2;
+    uint32 revision_number = 2;
 
     string mac_address = 3;
     string ipv4_address = 4;

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -26,9 +26,14 @@ import "port.proto";
 import "securitygroup.proto";
 import "dhcp.proto";
 
+enum MessageType { 
+    DELTA = 0; // the default type
+    FULL = 1;
+}
+
 message GoalState {
     uint32 format_version = 1;
-    MessageType message_type = 2
+    MessageType message_type = 2;
 
     repeated VpcState vpc_states = 3;
     repeated SubnetState subnet_states = 4;

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -27,11 +27,12 @@ import "securitygroup.proto";
 import "dhcp.proto";
 
 message GoalState {
-    uint32 version = 1;
+    uint32 format_version = 1;
+    MessageType message_type = 2
 
-    repeated VpcState vpc_states = 2;
-    repeated SubnetState subnet_states = 3;
-    repeated PortState port_states = 4;
-    repeated SecurityGroupState security_group_states = 5;
-    repeated DHCPState dhcp_states = 6;
+    repeated VpcState vpc_states = 3;
+    repeated SubnetState subnet_states = 4;
+    repeated PortState port_states = 5;
+    repeated SecurityGroupState security_group_states = 6;
+    repeated DHCPState dhcp_states = 7;
 }

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -26,18 +26,12 @@ import "port.proto";
 import "securitygroup.proto";
 import "dhcp.proto";
 
-enum MessageType { 
-    DELTA = 0; // the default type
-    FULL = 1;
-}
-
 message GoalState {
     uint32 format_version = 1;
-    MessageType message_type = 2;
 
-    repeated VpcState vpc_states = 3;
-    repeated SubnetState subnet_states = 4;
-    repeated PortState port_states = 5;
-    repeated SecurityGroupState security_group_states = 6;
-    repeated DHCPState dhcp_states = 7;
+    repeated VpcState vpc_states = 2;
+    repeated SubnetState subnet_states = 3;
+    repeated PortState port_states = 4;
+    repeated SecurityGroupState security_group_states = 5;
+    repeated DHCPState dhcp_states = 6;
 }

--- a/schema/proto3/goalstateprovisioner.proto
+++ b/schema/proto3/goalstateprovisioner.proto
@@ -41,7 +41,7 @@ service GoalStateProvisioner {
 }
 
 message GoalStateRequest {
-    uint32 version = 1;
+    uint32 format_version = 1;
 
     message ResourceStateRequest {
         string resource_id = 1;

--- a/schema/proto3/goalstateprovisioner.proto
+++ b/schema/proto3/goalstateprovisioner.proto
@@ -52,7 +52,7 @@ message GoalStateRequest {
 }
 
 message GoalStateOperationReply {
-    uint32 version = 1;
+    uint32 format_version = 1;
 
     message GoalStateOperationStatus {
         string resource_id = 1;

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -26,16 +26,15 @@ import "common.proto";
 message PortConfiguration {
     uint32 version = 1;
     
-    NetworkType network_type = 2;
-    string project_id = 3;
-    string subnet_id = 4;
-    uint32 mq_subscription_index = 5;
-    string id = 6;
+    string id = 2;
+    NetworkType network_type = 3;
+    string project_id = 4;
+    string subnet_id = 5;
+    uint32 mq_subscription_index = 6;
     string name = 7;
     string network_ns = 8;
     string mac_address = 9;
-    string veth_name = 10;
-    bool admin_state_up = 11;
+    bool admin_state_up = 10;
 
     message HostInfo {
         string ip_address = 1;
@@ -56,10 +55,14 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 12;
-    repeated FixedIp fixed_ips = 13;
-    repeated AllowAddressPair allow_address_pairs = 14;
-    repeated SecurityGroupId security_group_ids = 15;
+    HostInfo host_info = 11;
+    repeated FixedIp fixed_ips = 12;
+    repeated AllowAddressPair allow_address_pairs = 13;
+    repeated SecurityGroupId security_group_ids = 14;
+
+    // start Mizar specific session
+    string veth_name = 15;
+    // end Mizar specific session
 }
 
 message PortState {

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -36,11 +36,10 @@ message PortConfiguration {
     string id = 4;
     NetworkType network_type = 5;
     string project_id = 6;
-    string subnet_id = 7;
+    string vpc_id = 7;
     string name = 8;
     string network_ns = 9;
-    string mac_address = 10;
-    bool admin_state_up = 11;
+    bool admin_state_up = 10;
 
     message HostInfo {
         string ip_address = 1;
@@ -48,8 +47,9 @@ message PortConfiguration {
     }
 
     message FixedIp {
-        string subnet_id = 1;
-        string ip_address = 2;
+        string ip_address = 1;
+        string mac_address = 2;
+        string subnet_id = 3;
     }
 
     message AllowAddressPair {
@@ -61,13 +61,13 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 12;
-    repeated FixedIp fixed_ips = 13;
-    repeated AllowAddressPair allow_address_pairs = 14;
-    repeated SecurityGroupId security_group_ids = 15;
+    HostInfo host_info = 11;
+    repeated FixedIp fixed_ips = 12;
+    repeated AllowAddressPair allow_address_pairs = 13;
+    repeated SecurityGroupId security_group_ids = 14;
 
     // start Mizar specific session
-    string veth_name = 16;
+    string veth_name = 15;
     // end Mizar specific session
 }
 

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -30,7 +30,7 @@ enum MessageType {
 
 message PortConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2;
+    uint32 revision_number = 2;
     MessageType message_type = 3;
 
     string id = 4;

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -39,7 +39,8 @@ message PortConfiguration {
     string vpc_id = 7;
     string name = 8;
     string network_ns = 9;
-    bool admin_state_up = 10;
+    string mac_address = 10;
+    bool admin_state_up = 11;
 
     message HostInfo {
         string ip_address = 1;
@@ -47,9 +48,8 @@ message PortConfiguration {
     }
 
     message FixedIp {
-        string ip_address = 1;
-        string mac_address = 2;
-        string subnet_id = 3;
+        string subnet_id = 1;
+        string ip_address = 2;
     }
 
     message AllowAddressPair {
@@ -61,13 +61,13 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 11;
-    repeated FixedIp fixed_ips = 12;
-    repeated AllowAddressPair allow_address_pairs = 13;
-    repeated SecurityGroupId security_group_ids = 14;
+    HostInfo host_info = 12;
+    repeated FixedIp fixed_ips = 13;
+    repeated AllowAddressPair allow_address_pairs = 14;
+    repeated SecurityGroupId security_group_ids = 15;
 
     // start Mizar specific session
-    string veth_name = 15;
+    string veth_name = 16;
     // end Mizar specific session
 }
 

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message PortConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2
+    uint32 content_version = 2;
 
     string id = 3;
     NetworkType network_type = 4;
@@ -33,7 +33,7 @@ message PortConfiguration {
     string subnet_id = 6;
     uint32 mq_subscription_index = 7;
     string name = 8;
-    optional string network_ns = 9;
+    string network_ns = 9;
     string mac_address = 10;
     bool admin_state_up = 11;
 
@@ -62,7 +62,7 @@ message PortConfiguration {
     repeated SecurityGroupId security_group_ids = 15;
 
     // start Mizar specific session
-    optional string veth_name = 16;
+    string veth_name = 16;
     // end Mizar specific session
 }
 

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -28,13 +28,14 @@ message PortConfiguration {
     
     NetworkType network_type = 2;
     string project_id = 3;
-    string network_id = 4;
-    string id = 5;
-    string name = 6;
-    string network_ns = 7;
-    string mac_address = 8;
-    string veth_name = 9;
-    bool admin_state_up = 10;
+    string subnet_id = 4;
+    uint32 mq_subscription_index = 5;
+    string id = 6;
+    string name = 7;
+    string network_ns = 8;
+    string mac_address = 9;
+    string veth_name = 10;
+    bool admin_state_up = 11;
 
     message HostInfo {
         string ip_address = 1;
@@ -55,10 +56,10 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 11;
-    repeated FixedIp fixed_ips = 12;
-    repeated AllowAddressPair allow_address_pairs = 13;
-    repeated SecurityGroupId security_group_ids = 14;
+    HostInfo host_info = 12;
+    repeated FixedIp fixed_ips = 13;
+    repeated AllowAddressPair allow_address_pairs = 14;
+    repeated SecurityGroupId security_group_ids = 15;
 }
 
 message PortState {

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -23,15 +23,20 @@ option java_outer_classname = "Port";
 
 import "common.proto";
 
+enum MessageType { 
+    DELTA = 0; // the default type
+    FULL = 1;
+}
+
 message PortConfiguration {
     uint32 format_version = 1;
     uint32 content_version = 2;
+    MessageType message_type = 3;
 
-    string id = 3;
-    NetworkType network_type = 4;
-    string project_id = 5;
-    string subnet_id = 6;
-    uint32 mq_subscription_index = 7;
+    string id = 4;
+    NetworkType network_type = 5;
+    string project_id = 6;
+    string subnet_id = 7;
     string name = 8;
     string network_ns = 9;
     string mac_address = 10;

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -24,17 +24,18 @@ option java_outer_classname = "Port";
 import "common.proto";
 
 message PortConfiguration {
-    uint32 version = 1;
-    
-    string id = 2;
-    NetworkType network_type = 3;
-    string project_id = 4;
-    string subnet_id = 5;
-    uint32 mq_subscription_index = 6;
-    string name = 7;
-    string network_ns = 8;
-    string mac_address = 9;
-    bool admin_state_up = 10;
+    uint32 format_version = 1;
+    uint32 content_version = 2
+
+    string id = 3;
+    NetworkType network_type = 4;
+    string project_id = 5;
+    string subnet_id = 6;
+    uint32 mq_subscription_index = 7;
+    string name = 8;
+    optional string network_ns = 9;
+    string mac_address = 10;
+    bool admin_state_up = 11;
 
     message HostInfo {
         string ip_address = 1;
@@ -55,13 +56,13 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 11;
-    repeated FixedIp fixed_ips = 12;
-    repeated AllowAddressPair allow_address_pairs = 13;
-    repeated SecurityGroupId security_group_ids = 14;
+    HostInfo host_info = 12;
+    repeated FixedIp fixed_ips = 13;
+    repeated AllowAddressPair allow_address_pairs = 14;
+    repeated SecurityGroupId security_group_ids = 15;
 
     // start Mizar specific session
-    string veth_name = 15;
+    optional string veth_name = 16;
     // end Mizar specific session
 }
 

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message SecurityGroupConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2;
+    uint32 revision_number = 2;
 
     string id = 3;
     string project_id = 4;

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message SecurityGroupConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2
+    uint32 content_version = 2;
 
     string project_id = 3;
     string vpc_id = 4;

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -27,9 +27,9 @@ message SecurityGroupConfiguration {
     uint32 format_version = 1;
     uint32 content_version = 2;
 
-    string project_id = 3;
-    string vpc_id = 4;
-    string id = 5;
+    string id = 3;
+    string project_id = 4;
+    string vpc_id = 5;
     string name = 6;
 
     enum Direction {

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -24,12 +24,13 @@ option java_outer_classname = "SecurityGroup";
 import "common.proto";
 
 message SecurityGroupConfiguration {
-    uint32 version = 1;
+    uint32 format_version = 1;
+    uint32 content_version = 2
 
-    string project_id = 2;
-    string vpc_id = 3;
-    string id = 4;
-    string name = 5;
+    string project_id = 3;
+    string vpc_id = 4;
+    string id = 5;
+    string name = 6;
 
     enum Direction {
         EGRESS = 0;
@@ -48,7 +49,7 @@ message SecurityGroupConfiguration {
         string remote_group_id = 9;
     }
 
-    repeated SecurityGroupRule security_group_rules = 6;
+    repeated SecurityGroupRule security_group_rules = 7;
 }
 
 message SecurityGroupState {

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -26,9 +26,9 @@ import "common.proto";
 message SubnetConfiguration {
     uint32 version = 1;
 
-    string project_id = 2;
-    string vpc_id = 3;
-    string id = 4;
+    string id = 2;
+    string project_id = 3;
+    string vpc_id = 4;
     string name = 5;
     string cidr = 6;
     int64 tunnel_id = 7;

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message SubnetConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2
+    uint32 content_version = 2;
 
     string id = 3;
     string project_id = 4;

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -24,14 +24,15 @@ option java_outer_classname = "Subnet";
 import "common.proto";
 
 message SubnetConfiguration {
-    uint32 version = 1;
+    uint32 format_version = 1;
+    uint32 content_version = 2
 
-    string id = 2;
-    string project_id = 3;
-    string vpc_id = 4;
-    string name = 5;
-    string cidr = 6;
-    int64 tunnel_id = 7;
+    string id = 3;
+    string project_id = 4;
+    string vpc_id = 5;
+    string name = 6;
+    string cidr = 7;
+    int64 tunnel_id = 8;
 
     message Gateway {
         string vpc_id = 1;
@@ -40,11 +41,11 @@ message SubnetConfiguration {
         string mac_address = 4;
     }
 
-    Gateway gateway = 8;
-    bool dhcp_enable = 9;
-    string availability_zone = 10;
-    string primary_dns = 11;
-    string secondary_dns = 12;
+    Gateway gateway = 9;
+    bool dhcp_enable = 10;
+    string availability_zone = 11;
+    string primary_dns = 12;
+    string secondary_dns = 13;
 
     // start Mizar specific session
     // note that repeated field are inherently optional
@@ -54,7 +55,7 @@ message SubnetConfiguration {
         string ip_address = 3;
         string mac_address = 4;
     }
-    repeated TransitSwitch transit_switches = 13;
+    repeated TransitSwitch transit_switches = 14;
     // end Mizar specific session
 }
 

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message SubnetConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2;
+    uint32 revision_number = 2;
 
     string id = 3;
     string project_id = 4;

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -24,13 +24,14 @@ option java_outer_classname = "Vpc";
 import "common.proto";
 
 message VpcConfiguration {
-    uint32 version = 1;
+    uint32 format_version = 1;
+    uint32 content_version = 2
 
-    string id = 2;
-    string project_id = 3;
-    string name = 4;
-    string cidr = 5;
-    int64 tunnel_id = 6;
+    string id = 3;
+    string project_id = 4;
+    string name = 5;
+    string cidr = 6;
+    int64 tunnel_id = 7;
 
     message SubnetId {
         string id = 1;
@@ -41,8 +42,8 @@ message VpcConfiguration {
         string next_hop = 2;
     }
 
-    repeated SubnetId subnet_ids = 7;
-    repeated Route routes = 8;
+    repeated SubnetId subnet_ids = 8;
+    repeated Route routes = 9;
 
     // start Mizar specific session
     // note that repeated field are inherently optional
@@ -51,7 +52,7 @@ message VpcConfiguration {
         string ip_address = 2;
         string mac_address = 3;
     }
-    repeated TransitRouter transit_routers = 9;
+    repeated TransitRouter transit_routers = 10;
     // end Mizar specific session
 }
 

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message VpcConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2;
+    uint32 revision_number = 2;
 
     string id = 3;
     string project_id = 4;

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -25,7 +25,7 @@ import "common.proto";
 
 message VpcConfiguration {
     uint32 format_version = 1;
-    uint32 content_version = 2
+    uint32 content_version = 2;
 
     string id = 3;
     string project_id = 4;

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -26,8 +26,8 @@ import "common.proto";
 message VpcConfiguration {
     uint32 version = 1;
 
-    string project_id = 2;
-    string id = 3;
+    string id = 2;
+    string project_id = 3;
     string name = 4;
     string cidr = 5;
     int64 tunnel_id = 6;


### PR DESCRIPTION
This schema update PR includes the following changes:

* Reorder fields, and move up important fields 
* Add two version fields, format_version to mark the version of message format, and revision_number to mark the version of message content
* Add a new field call MessageType which could represent full configuration or delta configuration 

Note that this is a breaking change for Alcor Control Agent.