### PR TITLE
[Build Fix] Reduce Controller Build Time from 45+ to <5 minutes

### DIFF
--- a/services/mac_manager/src/main/resources/application.properties
+++ b/services/mac_manager/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 spring.redis.host=localhost
 spring.redis.port=6380
 #Ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800
 ignite.key-store-path=keystore.jks
 ignite.key-store-password=123456

--- a/services/node_manager/src/main/resources/application.properties
+++ b/services/node_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 spring.redis.host=localhost
 spring.redis.port=6380
 #ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800
 ignite.key-store-path=keystore.jks
 ignite.key-store-password=123456

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -4,17 +4,17 @@
 #spring.redis.port=6379
 #apache.kafka.address=172.17.0.1:9092
 #Ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800
 #Logging configuration
 #logging.file.path=./
 #logging.file.name=ip-manager.log
 #logging.level.root=INFO
 #Microservice url configuration
-microservices.vpc.service.url=http://192.168.137.1:9001
-microservices.subnet.service.url=http://192.168.137.1:9002
-microservices.ip.service.url=http://192.168.137.1:9004/ips
-microservices.mac.service.url=http://192.168.137.1:9005/macs
+microservices.vpc.service.url=http://localhost:9001
+microservices.subnet.service.url=http://localhost:9002
+microservices.ip.service.url=http://localhost:9004/ips
+microservices.mac.service.url=http://localhost:9005/macs
 microservices.sg.service.url=http://127.0.0.1:8080/securitygroups
-microservices.route.service.url=http://192.168.137.1:9003/routes
-microservices.node.service.url=http://192.168.137.1:9007/nodes
+microservices.route.service.url=http://localhost:9003/routes
+microservices.node.service.url=http://localhost:9007/nodes

--- a/services/private_ip_manager/src/main/resources/application.properties
+++ b/services/private_ip_manager/src/main/resources/application.properties
@@ -5,7 +5,7 @@
 #apache.kafka.address=172.17.0.1:9092
 #server.port=9000
 #Ignite configuration
-#ignite.host=192.168.137.1
+#ignite.host=localhost
 ignite.host=localhost
 ignite.port=10801
 #Logging configuration

--- a/services/route_manager/src/main/resources/application.properties
+++ b/services/route_manager/src/main/resources/application.properties
@@ -10,5 +10,5 @@
 #logging.file.path=.
 #logging.type=file
 #Ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800

--- a/services/subnet_manager/src/main/resources/application.properties
+++ b/services/subnet_manager/src/main/resources/application.properties
@@ -4,7 +4,7 @@
 #spring.redis.host=10.109.127.248
 #spring.redis.port=6379
 #ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800
 apache.kafka.address=172.17.0.1:9092
 #Logging configuration
@@ -13,7 +13,7 @@ logging.level.org.springframework.web=info
 logging.file.path=.
 logging.type=file
 # URL
-microservices.vpc.service.url=http://192.168.137.1:9001/project/
-microservices.mac.service.url=http://192.168.137.1:9005/macs
-microservices.route.service.url=http://192.168.137.1:9003/
-microservices.ip.service.url=http://192.168.137.1:9004/ips/
+microservices.vpc.service.url=http://localhost:9001/project/
+microservices.mac.service.url=http://localhost:9005/macs
+microservices.route.service.url=http://localhost:9003/
+microservices.ip.service.url=http://localhost:9004/ips/

--- a/services/vpc_manager/src/main/resources/application.properties
+++ b/services/vpc_manager/src/main/resources/application.properties
@@ -14,10 +14,10 @@
 #logging.file.path=.
 #logging.type=file
 #Ignite configuration
-ignite.host=192.168.137.1
+ignite.host=localhost
 ignite.port=10800
 #ignite.key-store-path=F:\\work\\alcor\\git\\chenpp\\alcor\\src\\resources\\keystore.jks
 #ignite.key-store-password=123456de
 #ignite.trust-store-path=F:\\work\\alcor\\git\\chenpp\\alcor\\src\\resources\\truststore.jks
 #ignite.trust-store-password=123456
-microservices.route.service.url=http://192.168.137.1:9003/vpcs/
+microservices.route.service.url=http://localhost:9003/vpcs/


### PR DESCRIPTION
__Context__

It takes extensive time (45+ minutes) to complete one build and its test. This significantly reduce the development velocity as developer needs to wait that long to see if a build is successful.

__Fix__

The ignite server address is currently pointed to some local env, which delays the up-time of controller a few seconds for every UT that tests web layer. The fix is to revert the Ignite server address to a default localhost.

After the fix, the expected build/test time is reduced from 45+ minutes to less than 5 minutes.