### PR TITLE
[AlcorLib] Support Multi-Params Query

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/config/IgniteConfiguration.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/config/IgniteConfiguration.java
@@ -23,19 +23,16 @@ import org.apache.ignite.client.ClientException;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.configuration.ClientConfiguration;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
 
 import java.util.logging.Level;
 
-@Configuration
-@ComponentScan("com.futurewei.common.service")
-@EntityScan("com.futurewei.common.entity")
-@ConditionalOnProperty(prefix = "ignite", name = "host")
+//@Configuration
+//@ComponentScan("com.futurewei.common.service")
+//@EntityScan("com.futurewei.common.entity")
+//@ConditionalOnProperty(prefix = "ignite", name = "host")
+@Deprecated
 public class IgniteConfiguration {
     private static final Logger logger = LoggerFactory.getLogger();
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/CacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/CacheFactory.java
@@ -17,8 +17,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.common.db;
 
 import com.futurewei.alcor.common.db.ignite.IgniteCacheFactory;
+import com.futurewei.alcor.common.db.ignite.IgniteClientCacheFactory;
 import com.futurewei.alcor.common.db.redis.RedisCacheFactory;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.client.IgniteClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -30,15 +32,8 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class CacheFactory {
 
+    @Autowired
     private ICacheFactory iCacheFactory;
-
-    public CacheFactory(@Autowired(required=false) Ignite ignite, LettuceConnectionFactory lettuceConnectionFactory){
-        if(ignite == null){
-            this.iCacheFactory = new RedisCacheFactory(lettuceConnectionFactory);
-        }else{
-            this.iCacheFactory = new IgniteCacheFactory(ignite);
-        }
-    }
 
     public <K, V> ICache<K, V> getCache(Class<V> v) {
         return iCacheFactory.getCache(v);

--- a/lib/src/main/java/com/futurewei/alcor/common/db/CacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/CacheFactory.java
@@ -18,7 +18,7 @@ package com.futurewei.alcor.common.db;
 
 import com.futurewei.alcor.common.db.ignite.IgniteCacheFactory;
 import com.futurewei.alcor.common.db.redis.RedisCacheFactory;
-import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.Ignite;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -26,18 +26,17 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
-
 @ComponentScan
 @Component
 public class CacheFactory {
 
     private ICacheFactory iCacheFactory;
 
-    public CacheFactory(@Autowired(required=false)IgniteClient igniteClient, LettuceConnectionFactory lettuceConnectionFactory){
-        if(igniteClient == null){
+    public CacheFactory(@Autowired(required=false) Ignite ignite, LettuceConnectionFactory lettuceConnectionFactory){
+        if(ignite == null){
             this.iCacheFactory = new RedisCacheFactory(lettuceConnectionFactory);
         }else{
-            this.iCacheFactory = new IgniteCacheFactory(igniteClient);
+            this.iCacheFactory = new IgniteCacheFactory(ignite);
         }
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
@@ -17,7 +17,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.common.db;
 
 
-import com.futurewei.alcor.common.db.query.CachePredicate;
+import org.apache.ignite.lang.IgniteBiPredicate;
 
 import java.util.Map;
 
@@ -34,13 +34,13 @@ public interface ICache<K, V> {
     V get(Map<String, Object[]> filterParams) throws CacheException;
 
     /**
-     * Get Cache value from cache db by a {@link CachePredicate}
+     * Get Cache value from cache db by a {@link IgniteBiPredicate}
      *
-     * @param cachePredicate a implement of {@link CachePredicate}
+     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
      * @return cache value
      * @throws CacheException if any exception
      */
-    <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException;
+    <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
 
     void put(K var1, V var2) throws CacheException;
 
@@ -58,13 +58,13 @@ public interface ICache<K, V> {
     <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException;
 
     /**
-     * Get Cache values from cache db by a {@link CachePredicate}
+     * Get Cache values from cache db by a {@link IgniteBiPredicate}
      *
-     * @param cachePredicate a implement of {@link CachePredicate}
+     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
      * @return cache value
      * @throws CacheException if any exception
      */
-    <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException;
+    <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
 
     void putAll(Map<? extends K, ? extends V> var1) throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
@@ -16,9 +16,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.common.db;
 
-
-import org.apache.ignite.lang.IgniteBiPredicate;
-
 import java.util.Map;
 
 public interface ICache<K, V> {
@@ -32,15 +29,6 @@ public interface ICache<K, V> {
      * @throws CacheException if any exception
      */
     V get(Map<String, Object[]> filterParams) throws CacheException;
-
-    /**
-     * Get Cache value from cache db by a {@link IgniteBiPredicate}
-     *
-     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
-     * @return cache value
-     * @throws CacheException if any exception
-     */
-    <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
 
     void put(K var1, V var2) throws CacheException;
 
@@ -56,15 +44,6 @@ public interface ICache<K, V> {
      * @throws CacheException if any exception
      */
     <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException;
-
-    /**
-     * Get Cache values from cache db by a {@link IgniteBiPredicate}
-     *
-     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
-     * @return cache value
-     * @throws CacheException if any exception
-     */
-    <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
 
     void putAll(Map<? extends K, ? extends V> var1) throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
@@ -17,16 +17,56 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.common.db;
 
 
+import com.futurewei.alcor.common.db.query.CachePredicate;
+
 import java.util.Map;
 
 public interface ICache<K, V> {
     V get(K var1) throws CacheException;
+
+    /**
+     * Get Cache value from cache db by multi params
+     *
+     * @param var1 the cache key
+     * @param filterParams a map of params name and value
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    V get(Map<String, Object[]> filterParams) throws CacheException;
+
+    /**
+     * Get Cache value from cache db by a {@link CachePredicate}
+     *
+     * @param var1 the cache key
+     * @param cachePredicate a implement of {@link CachePredicate}
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException;
 
     void put(K var1, V var2) throws CacheException;
 
     boolean containsKey(K var1) throws CacheException;
 
     Map<K, V> getAll() throws CacheException;
+
+    /**
+     * Get Cache values from cache db by multi params
+     *
+     * @param filterParams a map of params name and value
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException;
+
+    /**
+     * Get Cache values from cache db by a {@link CachePredicate}
+     *
+     * @param cachePredicate a implement of {@link CachePredicate}
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException;
 
     void putAll(Map<? extends K, ? extends V> var1) throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ICache.java
@@ -27,7 +27,6 @@ public interface ICache<K, V> {
     /**
      * Get Cache value from cache db by multi params
      *
-     * @param var1 the cache key
      * @param filterParams a map of params name and value
      * @return cache value
      * @throws CacheException if any exception
@@ -37,7 +36,6 @@ public interface ICache<K, V> {
     /**
      * Get Cache value from cache db by a {@link CachePredicate}
      *
-     * @param var1 the cache key
      * @param cachePredicate a implement of {@link CachePredicate}
      * @return cache value
      * @throws CacheException if any exception

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteCacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteCacheFactory.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 public class IgniteCacheFactory implements ICacheFactory {
 
-    private Ignite ignite;
+    private final Ignite ignite;
 
     public IgniteCacheFactory(Ignite ignite) {
         this.ignite = ignite;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteCacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteCacheFactory.java
@@ -18,7 +18,8 @@ package com.futurewei.alcor.common.db.ignite;
 
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.ICacheFactory;
-import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.Ignite;
+
 import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
@@ -26,25 +27,26 @@ import java.util.concurrent.TimeUnit;
 
 public class IgniteCacheFactory implements ICacheFactory {
 
-    private IgniteClient igniteClient;
+    private Ignite ignite;
 
-    public IgniteCacheFactory(IgniteClient igniteClient) {
-        this.igniteClient = igniteClient;
+    public IgniteCacheFactory(Ignite ignite) {
+        this.ignite = ignite;
     }
 
     @Override
     public <K, V> ICache<K, V> getCache(Class<V> v) {
-        return new IgniteCache<>(igniteClient, v.getName());
+        return new IgniteDbCache<>(ignite, v.getName());
     }
 
     @Override
     public <K, V> ICache<K, V> getCache(Class<V> v, String cacheName) {
-        return new IgniteCache<>(igniteClient, cacheName);
+        return new IgniteDbCache<>(ignite, cacheName);
     }
 
     @Override
     public <K, V> ICache<K, V> getExpireCache(Class<V> v, long timeout, TimeUnit timeUnit) {
         ExpiryPolicy ep = CreatedExpiryPolicy.factoryOf(new Duration(timeUnit, timeout)).create();
-        return new IgniteCache<>(igniteClient, v.getName(), ep);
+        return new IgniteDbCache<K, V>(ignite, v.getName(), ep);
     }
+
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientCacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientCacheFactory.java
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.db.ignite;
+
+import com.futurewei.alcor.common.db.ICache;
+import com.futurewei.alcor.common.db.ICacheFactory;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.configuration.ClientConfiguration;
+
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Ignite thin client
+ * Should put AlcorLib jar in Ignite lib directory for this client working well
+ */
+public class IgniteClientCacheFactory implements ICacheFactory {
+
+    private final IgniteClient igniteClient;
+
+    public IgniteClientCacheFactory(IgniteClient igniteClient) {
+        this.igniteClient = igniteClient;
+    }
+
+    @Override
+    public <K, V> ICache<K, V> getCache(Class<V> v) {
+        return new IgniteClientDbCache<>(igniteClient, v.getName());
+    }
+
+    @Override
+    public <K, V> ICache<K, V> getCache(Class<V> v, String cacheName) {
+        return new IgniteClientDbCache<>(igniteClient, cacheName);
+    }
+
+    @Override
+    public <K, V> ICache<K, V> getExpireCache(Class<V> v, long timeout, TimeUnit timeUnit) {
+        ExpiryPolicy ep = CreatedExpiryPolicy.factoryOf(new Duration(timeUnit, timeout)).create();
+        return new IgniteClientDbCache<>(igniteClient, v.getName(), ep);
+    }
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDbCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDbCache.java
@@ -21,8 +21,8 @@ package com.futurewei.alcor.common.db.ignite;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.db.query.ScanQueryBuilder;
-import com.futurewei.alcor.common.db.query.impl.MapPredicate;
+import com.futurewei.alcor.common.db.ignite.query.ScanQueryBuilder;
+import com.futurewei.alcor.common.db.ignite.query.MapPredicate;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import org.apache.ignite.binary.BinaryObject;
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-public class IgniteClientDbCache<K, V> implements ICache<K, V> {
+public class IgniteClientDbCache<K, V> implements IgniteICache<K, V> {
     private static final Logger logger = LoggerFactory.getLogger();
 
     private static final int RESULT_THRESHOLD_SIZE = 100000;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientTransaction.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientTransaction.java
@@ -47,7 +47,7 @@ public class IgniteClientTransaction implements Transaction {
             clientTransaction = igniteClient.transactions().txStart(PESSIMISTIC, SERIALIZABLE);
         } catch (ClientServerError | ClientException e) {
             logger.log(Level.WARNING, "IgniteTransaction start error:" + e.getMessage());
-            throw new CacheException(e.getMessage());
+            throw new CacheException("IgniteTransaction start error:" + e.getMessage());
         }
 
         return this;
@@ -59,7 +59,7 @@ public class IgniteClientTransaction implements Transaction {
             clientTransaction.commit();
         } catch (ClientServerError | ClientException e) {
             logger.log(Level.WARNING, "IgniteTransaction commit error:" + e.getMessage());
-            throw new CacheException(e.getMessage());
+            throw new CacheException("IgniteTransaction commit error:" + e.getMessage());
         }
     }
 
@@ -69,7 +69,7 @@ public class IgniteClientTransaction implements Transaction {
             clientTransaction.rollback();
         } catch (ClientServerError | ClientException e) {
             logger.log(Level.WARNING, "IgniteTransaction rollback error:" + e.getMessage());
-            throw new CacheException(e.getMessage());
+            throw new CacheException("IgniteTransaction rollback error:" + e.getMessage());
         }
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
@@ -19,8 +19,8 @@ package com.futurewei.alcor.common.db.ignite;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.db.query.ScanQueryBuilder;
-import com.futurewei.alcor.common.db.query.impl.MapPredicate;
+import com.futurewei.alcor.common.db.ignite.query.ScanQueryBuilder;
+import com.futurewei.alcor.common.db.ignite.query.MapPredicate;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import org.apache.ignite.Ignite;
@@ -43,7 +43,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 
-public class IgniteDbCache<K, V> implements ICache<K, V> {
+public class IgniteDbCache<K, V> implements IgniteICache<K, V> {
     private static final Logger logger = LoggerFactory.getLogger();
 
     private static final int RESULT_THRESHOLD_SIZE = 100000;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
@@ -26,11 +26,13 @@ import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.cache.query.Query;
 import org.apache.ignite.cache.query.QueryCursor;
 import org.apache.ignite.cache.query.ScanQuery;
 import org.apache.ignite.client.ClientException;
+import org.apache.ignite.transactions.TransactionException;
 import org.springframework.util.Assert;
 
 import javax.cache.Cache;
@@ -83,7 +85,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
     public V get(K key) throws CacheException {
         try {
             return cache.get(key);
-        } catch (ClientException e) {
+        } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteCache get operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
@@ -93,7 +95,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
     public void put(K key, V value) throws CacheException {
         try {
             cache.put(key, value);
-        } catch (ClientException e) {
+        } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteCache put operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
@@ -103,7 +105,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
     public boolean containsKey(K key) throws CacheException {
         try {
             return cache.containsKey(key);
-        } catch (ClientException e) {
+        } catch (TransactionException e) {
             logger.log(Level.WARNING, "IgniteCache containsKey operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
@@ -117,7 +119,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
             QueryCursor<Cache.Entry<K, V>> cur = cache.query(qry);
             return cur.getAll().stream().collect(Collectors
                     .toMap(Cache.Entry::getKey, Cache.Entry::getValue));
-        } catch (Exception e) {
+        } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteCache getAll operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
@@ -127,7 +129,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
     public void putAll(Map<? extends K, ? extends V> items) throws CacheException {
         try {
             cache.putAll(items);
-        } catch (ClientException e) {
+        } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteCache putAll operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
@@ -137,7 +139,7 @@ public class IgniteDbCache<K, V> implements ICache<K, V> {
     public boolean remove(K key) throws CacheException {
         try {
             return cache.remove(key);
-        } catch (ClientException e) {
+        } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteCache remove operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteICache.java
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.db.ignite;
+
+import com.futurewei.alcor.common.db.CacheException;
+import com.futurewei.alcor.common.db.ICache;
+import org.apache.ignite.lang.IgniteBiPredicate;
+
+import java.util.Map;
+
+public interface IgniteICache<K, V> extends ICache<K, V> {
+
+    /**
+     * Get Cache value from cache db by a {@link IgniteBiPredicate}
+     *
+     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
+
+    /**
+     * Get Cache values from cache db by a {@link IgniteBiPredicate}
+     *
+     * @param igniteBiPredicate a implement of {@link IgniteBiPredicate}
+     * @return cache value
+     * @throws CacheException if any exception
+     */
+    <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException;
+
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteTransaction.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteTransaction.java
@@ -50,7 +50,7 @@ public class IgniteTransaction implements Transaction {
             transaction.commit();
         } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteTransaction commit error:" + e.getMessage());
-            throw new CacheException(e.getMessage());
+            throw new CacheException("IgniteTransaction commit error:" + e.getMessage());
         }
     }
 
@@ -60,14 +60,19 @@ public class IgniteTransaction implements Transaction {
             transaction.rollback();
         } catch (IgniteException e) {
             logger.log(Level.WARNING, "IgniteTransaction rollback error:" + e.getMessage());
-            throw new CacheException(e.getMessage());
+            throw new CacheException("IgniteTransaction rollback error:" + e.getMessage());
         }
     }
 
     @Override
-    public void close() {
+    public void close() throws CacheException {
         if (transaction != null) {
-            transaction.close();
+            try {
+                transaction.close();
+            } catch (IgniteException e) {
+                logger.log(Level.WARNING, "IgniteTransaction close error: " + e.getMessage());
+                throw new CacheException("IgniteTransaction close error: " + e.getMessage());
+            }
         }
     }
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/MockIgniteServer.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/MockIgniteServer.java
@@ -16,26 +16,45 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.common.db.ignite;
 
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.Ignition;
-import org.apache.ignite.configuration.ClientConnectorConfiguration;
+import org.apache.ignite.internal.IgniteKernal;
+import org.apache.ignite.internal.processors.cache.IgniteCacheProxyImpl;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Consumer;
+
 
 public class MockIgniteServer {
+
+    private static final String LOCAL_ADDRESS = "127.0.0.1";
+    private static final int LISTEN_PORT = 11801;
+    private static final int LISTEN_PORT_RANGE = 10;
+
     private static Ignite igniteServer = null;
-    private static int ListenPort = 10801;
 
     @BeforeClass
     public static void init() {
         if (igniteServer == null) {
             try {
-                ClientConnectorConfiguration clientConfig = new ClientConnectorConfiguration();
-                clientConfig.setPort(ListenPort);
-
                 org.apache.ignite.configuration.IgniteConfiguration cfg = new org.apache.ignite.configuration.IgniteConfiguration();
-                cfg.setClientConnectorConfiguration(clientConfig);
+                // make this ignite server isolated
+                TcpDiscoveryVmIpFinder ipFinder = new TcpDiscoveryVmIpFinder();
+                ipFinder.setAddresses(Collections.singletonList(LOCAL_ADDRESS + ":" +
+                        LISTEN_PORT + ".." + (LISTEN_PORT+LISTEN_PORT_RANGE)));
+                TcpDiscoverySpi tcpDiscoverySpi = new TcpDiscoverySpi();
+                tcpDiscoverySpi.setIpFinder(ipFinder);
+                tcpDiscoverySpi.setLocalAddress(LOCAL_ADDRESS);
+                tcpDiscoverySpi.setLocalPort(LISTEN_PORT);
+                tcpDiscoverySpi.setLocalPortRange(LISTEN_PORT_RANGE);
+                cfg.setDiscoverySpi(tcpDiscoverySpi);
+//                cfg.setPeerClassLoadingEnabled(true);
                 igniteServer = Ignition.start(cfg);
 
                 //Properties properties = System.getProperties();
@@ -44,9 +63,37 @@ public class MockIgniteServer {
                 throw new RuntimeException(e);
             }
         }
+
     }
 
     @AfterClass
     public static void close() {
+//        if(igniteServer != null){
+//            igniteServer.close();
+//            igniteServer = null;
+//        }
     }
+
+    public static Ignite getIgnite(){
+        if(igniteServer == null){
+            // if no need create a real ignite server, we return a mock Ignite client
+            return new IgniteNodeClientMock();
+        }
+        return igniteServer;
+    }
+
+    /**
+     * mock a {@link Ignite} class for unit test
+     *
+     */
+    private static class IgniteNodeClientMock extends IgniteKernal {
+        public IgniteNodeClientMock() {
+        }
+
+        @Override
+        public <K, V> IgniteCache<K, V> getOrCreateCache(String cacheName) {
+            return new IgniteCacheProxyImpl();
+        }
+    }
+
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/query/MapPredicate.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/query/MapPredicate.java
@@ -16,7 +16,7 @@
  * /
  */
 
-package com.futurewei.alcor.common.db.query.impl;
+package com.futurewei.alcor.common.db.ignite.query;
 
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.lang.IgniteBiPredicate;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/query/ScanQueryBuilder.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/query/ScanQueryBuilder.java
@@ -16,7 +16,7 @@
  * /
  */
 
-package com.futurewei.alcor.common.db.query;
+package com.futurewei.alcor.common.db.ignite.query;
 
 import org.apache.ignite.cache.query.ScanQuery;
 import org.apache.ignite.lang.IgniteBiPredicate;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/CachePredicate.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/CachePredicate.java
@@ -1,0 +1,77 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.db.query;
+
+import java.util.Objects;
+
+public interface CachePredicate<E1, E2>{
+
+    /**
+     * Predicate body.
+     *
+     * @param k cache entity key.
+     * @param v cache entity value.
+     * @return Return value.
+     */
+    public boolean apply(E1 k, E2 v);
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * AND of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code false}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param then a predicate that will be logically-ANDed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * AND of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default CachePredicate<E1, E2> and(CachePredicate<E1, E2> then){
+        Objects.requireNonNull(then);
+
+        return (k, v) -> apply(k, v) && then.apply(k, v);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical
+     * OR of this predicate and another.  When evaluating the composed
+     * predicate, if this predicate is {@code true}, then the {@code other}
+     * predicate is not evaluated.
+     *
+     * <p>Any exceptions thrown during evaluation of either predicate are relayed
+     * to the caller; if evaluation of this predicate throws an exception, the
+     * {@code other} predicate will not be evaluated.
+     *
+     * @param then a predicate that will be logically-ORed with this
+     *              predicate
+     * @return a composed predicate that represents the short-circuiting logical
+     * OR of this predicate and the {@code other} predicate
+     * @throws NullPointerException if other is null
+     */
+    default CachePredicate<E1, E2> or(CachePredicate<E1, E2> then){
+        Objects.requireNonNull(then);
+
+        return (k, v) -> apply(k, v) || then.apply(k, v);
+    }
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/ScanQueryBuilder.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/ScanQueryBuilder.java
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.db.query;
+
+import org.apache.ignite.cache.query.ScanQuery;
+
+public class ScanQueryBuilder {
+
+    public static <E1, E2> ScanQuery<E1, E2> newScanQuery(CachePredicate<E1, E2> cachePredicate){
+        return new ScanQuery<E1, E2>(cachePredicate::apply);
+    }
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/ScanQueryBuilder.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/ScanQueryBuilder.java
@@ -19,10 +19,11 @@
 package com.futurewei.alcor.common.db.query;
 
 import org.apache.ignite.cache.query.ScanQuery;
+import org.apache.ignite.lang.IgniteBiPredicate;
 
 public class ScanQueryBuilder {
 
-    public static <E1, E2> ScanQuery<E1, E2> newScanQuery(CachePredicate<E1, E2> cachePredicate){
-        return new ScanQuery<E1, E2>(cachePredicate::apply);
+    public static <E1, E2> ScanQuery<E1, E2> newScanQuery(IgniteBiPredicate<E1, E2> igniteBiPredicate){
+        return new ScanQuery<E1, E2>(igniteBiPredicate);
     }
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
@@ -19,23 +19,21 @@
 package com.futurewei.alcor.common.db.query.impl;
 
 import com.futurewei.alcor.common.db.query.CachePredicate;
-import com.google.common.collect.ImmutableMap;
 import org.apache.ignite.binary.BinaryObject;
-import org.apache.ignite.cache.query.ScanQuery;
 
 import java.util.Map;
 
 
 public class MapPredicate implements CachePredicate<String, BinaryObject> {
 
-    private ImmutableMap<String, Object[]> params;
+    private Map<String, Object[]> params;
 
     public static MapPredicate getInstance(Map<String, Object[]> params){
         return new MapPredicate(params);
     }
 
     public MapPredicate(Map<String, Object[]> params){
-        this.params = new ImmutableMap.Builder<String, Object[]>().putAll(params).build();
+        this.params = params;
     }
 
     @Override

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
@@ -18,15 +18,15 @@
 
 package com.futurewei.alcor.common.db.query.impl;
 
-import com.futurewei.alcor.common.db.query.CachePredicate;
 import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.lang.IgniteBiPredicate;
 
 import java.util.Map;
 
 
-public class MapPredicate implements CachePredicate<String, BinaryObject> {
+public class MapPredicate implements IgniteBiPredicate<String, BinaryObject> {
 
-    private Map<String, Object[]> params;
+    private final Map<String, Object[]> params;
 
     public static MapPredicate getInstance(Map<String, Object[]> params){
         return new MapPredicate(params);

--- a/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/query/impl/MapPredicate.java
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.db.query.impl;
+
+import com.futurewei.alcor.common.db.query.CachePredicate;
+import com.google.common.collect.ImmutableMap;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.cache.query.ScanQuery;
+
+import java.util.Map;
+
+
+public class MapPredicate implements CachePredicate<String, BinaryObject> {
+
+    private ImmutableMap<String, Object[]> params;
+
+    public static MapPredicate getInstance(Map<String, Object[]> params){
+        return new MapPredicate(params);
+    }
+
+    public MapPredicate(Map<String, Object[]> params){
+        this.params = new ImmutableMap.Builder<String, Object[]>().putAll(params).build();
+    }
+
+    @Override
+    public boolean apply(String k, BinaryObject v) {
+        boolean matched = true;
+        for(Map.Entry<String, Object[]> entry: params.entrySet()){
+            if(!v.hasField(entry.getKey())){
+                continue;
+            }
+
+            boolean fieldMatch = false;
+            for(Object obj: entry.getValue()){
+                fieldMatch |= obj.equals(v.field(entry.getKey()));
+            }
+
+            matched &= fieldMatch;
+        }
+        return matched;
+    }
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
@@ -109,17 +109,7 @@ public class RedisCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
-        return null;
-    }
-
-    @Override
     public <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException {
-        return null;
-    }
-
-    @Override
-    public <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.common.db.redis;
 
+import com.futurewei.alcor.common.db.query.CachePredicate;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
 import com.futurewei.alcor.common.db.CacheException;
@@ -101,6 +102,26 @@ public class RedisCache<K, V> implements ICache<K, V> {
             logger.log(Level.WARNING, "RedisCache remove operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
+    }
+
+    @Override
+    public V get(Map<String, Object[]> filterParams) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+        return null;
     }
 
     @Override

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCache.java
@@ -22,6 +22,7 @@ import com.futurewei.alcor.common.db.Transaction;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import org.apache.ignite.lang.IgniteBiPredicate;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -31,14 +32,12 @@ import java.util.logging.Level;
 public class RedisCache<K, V> implements ICache<K, V> {
     private static final Logger logger = LoggerFactory.getLogger();
 
-    private RedisTemplate<K, V> redisTemplate;
-    private HashOperations hashOperations;
-    private RedisTransaction transaction;
-    private String name;
+    private final HashOperations<String, K, V> hashOperations;
+    private final RedisTransaction transaction;
+    private final String name;
 
-    public RedisCache(RedisTemplate<K, V> redisTemplate, String name) {
-        this.redisTemplate = redisTemplate;
-        hashOperations = redisTemplate.opsForHash();
+    public RedisCache(RedisTemplate<String, Object> redisTemplate, String name) {
+        hashOperations = redisTemplate.<K, V>opsForHash();
         this.name = name;
 
         transaction = new RedisTransaction(redisTemplate);
@@ -47,7 +46,7 @@ public class RedisCache<K, V> implements ICache<K, V> {
     @Override
     public V get(K key) throws CacheException {
         try {
-            return (V) hashOperations.get(name, key);
+            return hashOperations.get(name, key);
         } catch (Exception e) {
             logger.log(Level.WARNING, "RedisCache get operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
@@ -110,7 +109,7 @@ public class RedisCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+    public <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 
@@ -120,7 +119,7 @@ public class RedisCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+    public <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCacheFactory.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.common.db.redis;
 
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.ICacheFactory;
+import com.futurewei.alcor.common.db.Transaction;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCacheFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisCacheFactory.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.common.db.redis;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.ICacheFactory;
 import com.futurewei.alcor.common.db.Transaction;
+import com.futurewei.alcor.common.entity.TokenEntity;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -28,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 public class RedisCacheFactory implements ICacheFactory {
 
-    private LettuceConnectionFactory lettuceConnectionFactory;
+    private final LettuceConnectionFactory lettuceConnectionFactory;
 
     public RedisCacheFactory(LettuceConnectionFactory lettuceConnectionFactory) {
         this.lettuceConnectionFactory = lettuceConnectionFactory;
@@ -36,13 +37,13 @@ public class RedisCacheFactory implements ICacheFactory {
 
     @Override
     public <K, V> ICache<K, V> getCache(Class<V> v) {
-        RedisTemplate<K, V> template = getRedisTemplate(v);
+        RedisTemplate<String, Object> template = getRedisTemplate(v);
         return new RedisCache<>(template, v.getName());
     }
 
     @Override
     public <K, V> ICache<K, V> getCache(Class<V> v, String cacheName) {
-        RedisTemplate<K, V> template = getRedisTemplate(v);
+        RedisTemplate<String, Object> template = getRedisTemplate(v);
         return new RedisCache<>(template, cacheName);
     }
 
@@ -52,7 +53,7 @@ public class RedisCacheFactory implements ICacheFactory {
         return new RedisExpireCache<>(template, timeout, timeUnit);
     }
 
-    private <K, V> RedisTemplate<K, V> getRedisTemplate(Class<V> v){
+    private <K, V> RedisTemplate<K, V> getRedisTemplate(Class<?> v){
 
         RedisTemplate<K, V> template = new RedisTemplate<>();
         template.setConnectionFactory(lettuceConnectionFactory);

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisConfiguration.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisConfiguration.java
@@ -17,6 +17,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.common.db.redis;
 
 
+import com.futurewei.alcor.common.db.ICacheFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -39,11 +40,11 @@ public class RedisConfiguration {
     private int redisHostPort;
 
     @Bean
-    LettuceConnectionFactory lettuceConnectionFactory() {
+    public ICacheFactory redisCacheFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
         configuration.setHostName(redisHostName);
         configuration.setPort(redisHostPort);
-        return new LettuceConnectionFactory(configuration);
+        return new RedisCacheFactory(new LettuceConnectionFactory(configuration));
     }
 }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
@@ -19,9 +19,9 @@ package com.futurewei.alcor.common.db.redis;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.db.query.CachePredicate;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import org.apache.ignite.lang.IgniteBiPredicate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -120,7 +120,7 @@ public class RedisExpireCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+    public <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 
@@ -130,7 +130,7 @@ public class RedisExpireCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+    public <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.common.db.redis;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
+import com.futurewei.alcor.common.db.query.CachePredicate;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -111,6 +112,26 @@ public class RedisExpireCache<K, V> implements ICache<K, V> {
             logger.log(Level.WARNING, "RedisCache remove operation error:" + e.getMessage());
             throw new CacheException(e.getMessage());
         }
+    }
+
+    @Override
+    public V get(Map<String, Object[]> filterParams) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> V get(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException {
+        return null;
+    }
+
+    @Override
+    public <E1, E2> Map<K, V> getAll(CachePredicate<E1, E2> cachePredicate) throws CacheException {
+        return null;
     }
 
     @Override

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisExpireCache.java
@@ -120,17 +120,7 @@ public class RedisExpireCache<K, V> implements ICache<K, V> {
     }
 
     @Override
-    public <E1, E2> V get(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
-        return null;
-    }
-
-    @Override
     public <E1, E2> Map<K, V> getAll(Map<String, Object[]> filterParams) throws CacheException {
-        return null;
-    }
-
-    @Override
-    public <E1, E2> Map<K, V> getAll(IgniteBiPredicate<E1, E2> igniteBiPredicate) throws CacheException {
         return null;
     }
 

--- a/lib/src/main/java/com/futurewei/alcor/common/db/repo/ICacheRepository.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/repo/ICacheRepository.java
@@ -18,7 +18,6 @@ package com.futurewei.alcor.common.db.repo;
 
 import com.futurewei.alcor.common.db.CacheException;
 
-import java.util.List;
 import java.util.Map;
 
 public interface ICacheRepository<T> {
@@ -26,6 +25,8 @@ public interface ICacheRepository<T> {
     T findItem(String id) throws CacheException;
 
     Map<String, T> findAllItems() throws CacheException;
+
+    Map<String, T> findAllItems(Map<String, Object[]> queryParams) throws CacheException;
 
     void addItem(T newItem) throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/entity/CustomerResource.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/entity/CustomerResource.java
@@ -22,11 +22,13 @@ import lombok.Data;
 import java.io.Serializable;
 import java.util.Objects;
 
-@Data
 public class CustomerResource implements Serializable {
 
     @JsonProperty("project_id")
     private String projectId;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
 
     @JsonProperty("id")
     private String id;
@@ -82,6 +84,14 @@ public class CustomerResource implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getTenantId() {
+        return this.tenantId == null ? this.projectId : this.tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     @Override

--- a/lib/src/main/java/com/futurewei/alcor/common/entity/CustomerResource.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/entity/CustomerResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 @Data
 public class CustomerResource implements Serializable {
@@ -81,5 +82,31 @@ public class CustomerResource implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CustomerResource that = (CustomerResource) o;
+        return Objects.equals(projectId, that.projectId) &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(projectId, id, name, description);
+    }
+
+    @Override
+    public String toString() {
+        return "CustomerResource{" +
+                "projectId='" + projectId + '\'' +
+                ", id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                '}';
     }
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/entity/TokenEntity.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/entity/TokenEntity.java
@@ -18,11 +18,12 @@ package com.futurewei.alcor.common.entity;
 
 import lombok.Data;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
 @Data
-public class TokenEntity {
+public class TokenEntity implements Serializable {
 
     String token;
     Date expireAt;

--- a/lib/src/main/java/com/futurewei/alcor/common/exception/QueryParamTypeNotSupportException.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/exception/QueryParamTypeNotSupportException.java
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.exception;
+
+public class QueryParamTypeNotSupportException extends Exception {
+
+    public QueryParamTypeNotSupportException(String message) {
+        super(message);
+    }
+
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/repo/AbstractFactory.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/repo/AbstractFactory.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.common.repo;
 
+@Deprecated
 public interface AbstractFactory<T> {
     T Create();
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/repo/ICache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/repo/ICache.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.common.exception.CacheException;
 
 import java.util.Map;
 
+@Deprecated
 public interface ICache<K, V> {
     V get(K var1) throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/repo/ICachePublisher.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/repo/ICachePublisher.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.common.repo;
 
+@Deprecated
 public interface ICachePublisher {
     void publish(final String message);
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/repo/ICacheRepository.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/repo/ICacheRepository.java
@@ -21,6 +21,7 @@ import com.futurewei.alcor.common.exception.ResourceNotFoundException;
 
 import java.util.Map;
 
+@Deprecated
 public interface ICacheRepository<T> {
 
     T findItem(String id) throws CacheException, ResourceNotFoundException;

--- a/lib/src/main/java/com/futurewei/alcor/common/repo/Transaction.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/repo/Transaction.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.common.repo;
 
 import com.futurewei.alcor.common.exception.CacheException;
 
+@Deprecated
 public interface Transaction {
     void start() throws CacheException;
 

--- a/lib/src/main/java/com/futurewei/alcor/common/test/TestBeanFactoryPostProcessor.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/test/TestBeanFactoryPostProcessor.java
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.test.config;
+
+import com.futurewei.alcor.common.logging.Logger;
+import com.futurewei.alcor.common.logging.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.stereotype.Component;
+
+import java.util.logging.Level;
+
+/**
+ * in unit test environment it try to init a real Ignite server, but lot of cases don't need
+ * a real Ignite server, so make Ignite BeanDefinition to null
+ */
+@Component
+public class TestBeanFactoryPostProcessor implements BeanDefinitionRegistryPostProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger();
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        try {
+            registry.removeBeanDefinition("igniteInstance");
+        } catch (NoSuchBeanDefinitionException e) {
+            LOG.log(Level.WARNING, "get ignite client bean failed : " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+    }
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/test/TestBeanPostProcessor.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/test/TestBeanPostProcessor.java
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.test.config;
+
+import com.futurewei.alcor.common.db.CacheFactory;
+import com.futurewei.alcor.common.db.ignite.IgniteCacheFactory;
+import com.futurewei.alcor.common.db.ignite.MockIgniteServer;
+import org.apache.ignite.Ignite;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+
+/**
+ * this class config {@link CacheFactory#iCacheFactory} to a mock ignite client for micro service use
+ *
+ */
+@Component
+public class TestBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName){
+        if(bean instanceof CacheFactory){
+            Field field = ReflectionUtils.findField(bean.getClass(), "iCacheFactory");
+            assert field != null;
+            ReflectionUtils.makeAccessible(field);
+            Ignite ignite = MockIgniteServer.getIgnite();
+            ReflectionUtils.setField(field, bean, new IgniteCacheFactory(ignite));
+        }
+
+        return bean;
+    }
+
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/test/config/TestBeanFactoryPostProcessor.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/test/config/TestBeanFactoryPostProcessor.java
@@ -18,15 +18,21 @@
 
 package com.futurewei.alcor.common.test.config;
 
+import com.futurewei.alcor.common.db.ignite.IgniteCacheFactory;
+import com.futurewei.alcor.common.db.ignite.MockIgniteServer;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.logging.Level;
 
 /**
@@ -37,11 +43,18 @@ import java.util.logging.Level;
 public class TestBeanFactoryPostProcessor implements BeanDefinitionRegistryPostProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger();
+    private static final String IGNITE_BEAN_FACTORY_NAME = "igniteClientFactoryInstance";
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
         try {
-            registry.removeBeanDefinition("igniteInstance");
+            System.out.println(Arrays.asList(registry.getBeanDefinitionNames()).toString());
+            registry.removeBeanDefinition(IGNITE_BEAN_FACTORY_NAME);
+            BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder
+                    .genericBeanDefinition(IgniteCacheFactory.class, () -> {
+                        return new IgniteCacheFactory(MockIgniteServer.getIgnite());
+                    });
+            registry.registerBeanDefinition(IGNITE_BEAN_FACTORY_NAME, beanDefinitionBuilder.getRawBeanDefinition());
         } catch (NoSuchBeanDefinitionException e) {
             LOG.log(Level.WARNING, "get ignite client bean failed : " + e.getMessage());
         }

--- a/lib/src/main/java/com/futurewei/alcor/common/test/config/TestBeanPostProcessor.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/test/config/TestBeanPostProcessor.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Field;
  * this class config {@link CacheFactory#iCacheFactory} to a mock ignite client for micro service use
  *
  */
-@Component
+//@Component
 public class TestBeanPostProcessor implements BeanPostProcessor {
 
     @Override

--- a/lib/src/main/java/com/futurewei/alcor/common/utils/CommonUtil.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/utils/CommonUtil.java
@@ -16,12 +16,24 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.common.utils;
 
+import com.google.common.collect.Lists;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.beans.BeansException;
+
+import java.beans.FeatureDescriptor;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public class CommonUtil {
+
+    private static final List<Class<?>> baseClasses = Lists.newArrayList(Byte.class, Short.class, Integer.class,
+            Long.class, Float.class, Double.class, Boolean.class, Character.class, String.class);
+
     public static byte[] fromIpAddressStringToByteArray(String ipAddressString) throws UnknownHostException {
         InetAddress ip = InetAddress.getByName(ipAddressString);
         byte[] bytes = ip.getAddress();
@@ -46,5 +58,36 @@ public class CommonUtil {
         } catch (Exception ex) {
             return false;
         }
+    }
+
+    /**
+     * Return true if class is byte short int long float double boolean char or String or base class type of packaging
+     * @param clasz
+     * @return Return true if class is byte short int long float double boolean
+     * char or String or base class type of packaging
+     */
+    public static boolean isBaseClass(Class<?> clasz){
+        if(clasz.isPrimitive()){
+            return true;
+        }
+        return baseClasses.contains(clasz);
+    }
+
+    /**
+     * Return a bean null property names
+     * @param bean a bean entity
+     * @return return a bean null property names
+     */
+    public static String[] getBeanNullPropertyNames(Object bean){
+        final BeanWrapper beanWrapper = new BeanWrapperImpl(bean);
+        return Stream.of(beanWrapper.getPropertyDescriptors())
+                .map(FeatureDescriptor::getName)
+                .filter(propertyName -> {
+                    try {
+                        return beanWrapper.getPropertyValue(propertyName) == null;
+                    } catch (BeansException e) {
+                        return true;
+                    }
+                }).toArray(String[]::new);
     }
 }

--- a/lib/src/test/java/com/futurewei/alcor/common/cache/ControllerUtilTest.java
+++ b/lib/src/test/java/com/futurewei/alcor/common/cache/ControllerUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.cache;
+
+import com.futurewei.alcor.common.cache.entity.TestEntity;
+import com.futurewei.alcor.common.exception.QueryParamTypeNotSupportException;
+import com.futurewei.alcor.common.utils.ControllerUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ControllerUtilTest {
+
+    @Test
+    public void transformUrlPathParamsTest() throws QueryParamTypeNotSupportException {
+        Map<String, String[]> params = new HashMap<>();
+        params.put("project_id", new String[]{"asdfasf", "asdfasdf"});
+        params.put("id", new String[]{"1"});
+        params.put("name", new String[]{"dsefad"});
+        params.put("description", new String[]{"desc1"});
+        params.put("shared", new String[]{"false"});
+        params.put("count", new String[]{"1", "2"});
+        params.put("revision_number", new String[]{"3", "4"});
+        params.put("egress_firewall_policy_id", new String[]{"abcdef", "abcdfe", "bacdef", "abdcef"});
+        params.put("enable_dhcp", new String[]{"true"});
+        params.put("ip_version", new String[]{"4", "6"});
+
+        Map<String, Object[]> tranformedMap = ControllerUtil.transformUrlPathParams(params, TestEntity.class);
+        System.out.println(tranformedMap.toString());
+
+        Assert.assertEquals("asdfasf", tranformedMap.get("projectId")[0]);
+        Assert.assertEquals(false, tranformedMap.get("shared")[0]);
+        Assert.assertEquals(1, tranformedMap.get("count")[0]);
+        Assert.assertEquals(4, tranformedMap.get("revisionNumber")[1]);
+        Assert.assertEquals("bacdef", tranformedMap.get("egressFirewallPolicyId")[2]);
+        Assert.assertEquals(Boolean.valueOf("true"), tranformedMap.get("enableDhcp")[0]);
+        Assert.assertEquals(Integer.valueOf(6), tranformedMap.get("ipVersion")[1]);
+        Assert.assertEquals("1", tranformedMap.get("id")[0]);
+        Assert.assertEquals("dsefad", tranformedMap.get("name")[0]);
+        Assert.assertEquals("desc1", tranformedMap.get("description")[0]);
+
+    }
+
+    @Test
+    public void testEntity(){
+        TestEntity testEntity = new TestEntity();
+        testEntity.setCount(1);
+        testEntity.setEgressFirewallPolicyId("abcdef");
+        testEntity.setShared(true);
+        testEntity.setProjectId("sdfasdffas");
+        testEntity.setRevisionNumber(6);
+        testEntity.setIpVersion(6);
+
+        Assert.assertTrue(String.valueOf(testEntity.getCount()).equals("1"));
+        Assert.assertTrue(String.valueOf(testEntity.getEgressFirewallPolicyId()).equals("abcdef"));
+        Assert.assertTrue(String.valueOf(testEntity.isShared()).equals("true"));
+        Assert.assertTrue(String.valueOf(testEntity.getProjectId()).equals("sdfasdffas"));
+        Assert.assertTrue(String.valueOf(testEntity.getRevisionNumber()).equals("6"));
+        Assert.assertTrue(String.valueOf(testEntity.getIpVersion()).equals("6"));
+
+    }
+
+    @Test
+    public void test(){
+        Annotation[] as = TestEntity.class.getDeclaredAnnotations();
+        for(Annotation a: as){
+            System.out.println(a.annotationType().getSimpleName());
+        }
+    }
+
+}

--- a/lib/src/test/java/com/futurewei/alcor/common/cache/IgniteCacheTest.java
+++ b/lib/src/test/java/com/futurewei/alcor/common/cache/IgniteCacheTest.java
@@ -1,0 +1,78 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.cache;
+
+import com.futurewei.alcor.common.db.CacheException;
+import com.futurewei.alcor.common.db.ICache;
+import com.futurewei.alcor.common.db.ignite.IgniteDbCache;
+import com.futurewei.alcor.common.db.ignite.MockIgniteServer;
+import com.futurewei.alcor.common.entity.CustomerResource;
+import com.google.common.collect.ImmutableMap;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class IgniteCacheTest extends MockIgniteServer{
+
+    private static final String CACHE_NAME = CustomerResource.class.getName();
+
+    @Test
+    public void multiParamsTest() throws CacheException {
+        ICache<String, CustomerResource> cache = new IgniteDbCache<>(MockIgniteServer.getIgnite(), CACHE_NAME);
+        Map<String, CustomerResource> map = new HashMap<>();
+        map.put("customerA", new CustomerResource("1", "1", "resourceA", "desc1"));
+        map.put("customerB", new CustomerResource("2", "2", "resourceB", "desc1"));
+        map.put("customerC", new CustomerResource("3", "3", "resourceC", "desc1"));
+        map.put("customerD", new CustomerResource("4", "4", "resourceD", "desc2"));
+        map.put("customerE", new CustomerResource("5", "5", "resourceE", "desc2"));
+        map.put("customerF", new CustomerResource("6", "6", "resourceF", "desc2"));
+        map.put("customerG", new CustomerResource("7", "7", "resourceG", "desc2"));
+        map.put("customerH", new CustomerResource("8", "8", "resourceH", "desc3"));
+        map.put("customerI", new CustomerResource("9", "9", "resourceI", "desc3"));
+        cache.putAll(map);
+        Map<String, Object[]> params =
+                new ImmutableMap.Builder<String, Object[]>().put("projectId", new String[]{"1"}).put("name", new String[]{"resourceA"}).build();
+        CustomerResource cr = cache.get(params);
+        System.out.println(cr);
+        Assert.assertEquals(new CustomerResource("1", "1", "resourceA", "desc1"), cr);
+
+        Map<String, Object[]> params1 =
+                new ImmutableMap.Builder<String, Object[]>().put("projectId", new String[]{"1"}).put("name", new String[]{"resourceB"}).build();
+        CustomerResource cr1 = cache.get(params1);
+        System.out.println(cr1);
+        Assert.assertNull(cr1);
+
+        Map<String, Object[]> params2 =
+                new ImmutableMap.Builder<String, Object[]>().put("description", new String[]{"desc1", "desc2"}).build();
+        Map<String, CustomerResource> crs1 = cache.getAll(params2);
+        System.out.println(crs1.toString());
+        Assert.assertEquals(7, crs1.size());
+
+    }
+
+    @After
+    public void clear(){
+        MockIgniteServer.getIgnite().close();
+    }
+}

--- a/lib/src/test/java/com/futurewei/alcor/common/cache/entity/TestEntity.java
+++ b/lib/src/test/java/com/futurewei/alcor/common/cache/entity/TestEntity.java
@@ -1,0 +1,91 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.common.cache.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.common.entity.CustomerResource;
+
+public class TestEntity extends CustomerResource {
+
+    private boolean shared;
+
+    private int count;
+
+    @JsonProperty("revision_number")
+    private int revisionNumber;
+
+    @JsonProperty("egress_firewall_policy_id")
+    private String egressFirewallPolicyId;
+
+    @JsonProperty("enable_dhcp")
+    private Boolean enableDhcp;
+
+    @JsonProperty("ip_version")
+    private Integer ipVersion;
+
+    public boolean isShared() {
+        return shared;
+    }
+
+    public void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public int getRevisionNumber() {
+        return revisionNumber;
+    }
+
+    public void setRevisionNumber(int revisionNumber) {
+        this.revisionNumber = revisionNumber;
+    }
+
+    public String getEgressFirewallPolicyId() {
+        return egressFirewallPolicyId;
+    }
+
+    public void setEgressFirewallPolicyId(String egressFirewallPolicyId) {
+        this.egressFirewallPolicyId = egressFirewallPolicyId;
+    }
+
+    public Boolean getEnableDhcp() {
+        return enableDhcp;
+    }
+
+    public void setEnableDhcp(Boolean enableDhcp) {
+        this.enableDhcp = enableDhcp;
+    }
+
+    public Integer getIpVersion() {
+        return ipVersion;
+    }
+
+    public void setIpVersion(Integer ipVersion) {
+        this.ipVersion = ipVersion;
+    }
+
+
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PostConstruct;
@@ -255,7 +256,7 @@ public class KeystoneClient {
             }else{
                 cache.put(token, new TokenEntity(token,true));
             }
-        } catch (IOException | CacheException | ParseException e) {
+        } catch (IOException | CacheException | ParseException | HttpClientErrorException e) {
             LOG.error("verify token failed, {}", e.getMessage());
         }
         return "";

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthGwFilter.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthGwFilter.java
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.apigateway.filter;
+
+import com.futurewei.alcor.apigateway.client.KeystoneClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+public class KeystoneAuthGwFilter implements GlobalFilter, Ordered {
+
+    private static final String AUTHORIZE_TOKEN = "X-Auth-Token";
+    private static final String VPC_NAME = "vpcs";
+    private static final String VPC_REPLACE_NAME = "networks";
+    private static final int KEYSTONE_FILTER_ORDERED = -100;
+
+    @Autowired
+    private KeystoneClient keystoneClient;
+
+    @Value("${neutron.url_prefix}")
+    private String neutronUrlPrefix;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String token = exchange.getRequest().getHeaders().getFirst(AUTHORIZE_TOKEN);
+        if(token == null){
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+        String projectId = keystoneClient.verifyToken(token);
+        if("".equals(projectId)){
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+        // rewrite uri path include project id
+        ServerHttpRequest req = exchange.getRequest();
+        ServerWebExchangeUtils.addOriginalRequestUrl(exchange, req.getURI());
+        String path = req.getURI().getRawPath();
+        path = path.replaceAll(neutronUrlPrefix, "/project/" + projectId);
+        path = path.replaceAll(VPC_REPLACE_NAME, VPC_NAME);
+        ServerHttpRequest request = req.mutate().path(path).build();
+        exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR, request.getURI());
+        return chain.filter(exchange.mutate().request(request).build());
+    }
+
+    @Override
+    public int getOrder() {
+        return KEYSTONE_FILTER_ORDERED;
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneConfiguration.java
@@ -34,12 +34,20 @@ public class KeystoneConfiguration {
     @Autowired
     private CacheFactory cacheFactory;
 
-    @Bean
+    //@Bean
     public KeystoneAuthWebFilter keystoneAuthWebFilter(){
         if(!keystoneEnable){
             return null;
         }
         return new KeystoneAuthWebFilter();
+    }
+
+    @Bean
+    public KeystoneAuthGwFilter keystoneAuthGwFilter(){
+        if(!keystoneEnable){
+            return null;
+        }
+        return new KeystoneAuthGwFilter();
     }
 
     @Bean

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/SubnetManagerServiceProxy.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/SubnetManagerServiceProxy.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-@Service
+//@Service
 public class SubnetManagerServiceProxy {
 
     private SubnetWebDestinations webDestinations;

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/VpcManagerServiceProxy.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/VpcManagerServiceProxy.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
-@Service
+//@Service
 public class VpcManagerServiceProxy {
 
     private VpcWebDestinations webDestinations;

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CommonRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CommonRouteConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import org.springframework.cloud.gateway.filter.NettyWriteResponseFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.support.BodyInserterContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+
+@Configuration
+public class CommonRouteConfiguration {
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public RouteLocator extensionRoute(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r.path("/v2.0/extensions")
+                    .filters(f -> f.filter((exchange, chain) -> {
+                        ServerHttpResponse response = exchange.getResponse();
+
+                        BodyInserter bodyInserter = BodyInserters.fromPublisher(Mono.just("{\"extensions\":{}}"), String.class);
+                        CustomerBodyOutputMessage outputMessage = new CustomerBodyOutputMessage(exchange);
+                        return bodyInserter.insert(outputMessage, new BodyInserterContext())
+                                .then(Mono.defer(() -> {
+                                    Flux<DataBuffer> messageBody = outputMessage.getBody();
+                                    return response.writeWith(messageBody);
+                                }));
+                    }, NettyWriteResponseFilter.WRITE_RESPONSE_FILTER_ORDER -1))
+                .uri("localhost:8080")).build();
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CommonRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CommonRouteConfiguration.java
@@ -43,7 +43,8 @@ public class CommonRouteConfiguration {
                     .filters(f -> f.filter((exchange, chain) -> {
                         ServerHttpResponse response = exchange.getResponse();
 
-                        BodyInserter bodyInserter = BodyInserters.fromPublisher(Mono.just("{\"extensions\":{}}"), String.class);
+                        System.out.println(response.getHeaders().getClass().getName());
+                        BodyInserter bodyInserter = BodyInserters.fromObject("{\"extensions\":{}}");
                         CustomerBodyOutputMessage outputMessage = new CustomerBodyOutputMessage(exchange);
                         return bodyInserter.insert(outputMessage, new BodyInserterContext())
                                 .then(Mono.defer(() -> {

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CustomerBodyOutputMessage.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CustomerBodyOutputMessage.java
@@ -46,7 +46,7 @@ public class CustomerBodyOutputMessage implements ReactiveHttpOutputMessage {
 
     public CustomerBodyOutputMessage(ServerWebExchange exchange) {
         this.bufferFactory = exchange.getResponse().bufferFactory();
-        this.httpHeaders = exchange.getRequest().getHeaders();
+        this.httpHeaders = exchange.getResponse().getHeaders();
     }
 
     @Override

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CustomerBodyOutputMessage.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/CustomerBodyOutputMessage.java
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Supplier;
+
+public class CustomerBodyOutputMessage implements ReactiveHttpOutputMessage {
+
+    private final DataBufferFactory bufferFactory;
+
+    private final HttpHeaders httpHeaders;
+
+    private Flux<DataBuffer> body = Flux.error(new IllegalArgumentException(
+            "The body is not set."
+    ));
+
+    public CustomerBodyOutputMessage(ServerWebExchange exchange, HttpHeaders httpHeaders) {
+        this.bufferFactory = exchange.getResponse().bufferFactory();
+        this.httpHeaders = httpHeaders;
+    }
+
+    public CustomerBodyOutputMessage(ServerWebExchange exchange) {
+        this.bufferFactory = exchange.getResponse().bufferFactory();
+        this.httpHeaders = exchange.getRequest().getHeaders();
+    }
+
+    @Override
+    public DataBufferFactory bufferFactory() {
+        return this.bufferFactory;
+    }
+
+    @Override
+    public void beforeCommit(Supplier<? extends Mono<Void>> action) {
+
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+        this.body = Flux.from(body);
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
+        return writeWith(Flux.from(body).flatMap(p -> p));
+    }
+
+    @Override
+    public Mono<Void> setComplete() {
+        return writeWith(Flux.empty());
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return this.httpHeaders;
+    }
+
+    /**
+     * Return the request body, or an error stream if the body was never set or when.
+     * @return body as {@link Flux}
+     */
+    public Flux<DataBuffer> getBody(){
+        return this.body;
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/PortRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/PortRouteConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PortRouteConfiguration {
+
+    @Value("${microservices.port.service.url}")
+    private String portUrl;
+
+
+    @Bean
+    public RouteLocator portRouteLocator(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r.path("/*/ports", "/*/ports/*").uri(portUrl))
+                .build();
+    }
+
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/PortRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/PortRouteConfiguration.java
@@ -34,7 +34,9 @@ public class PortRouteConfiguration {
     @Bean
     public RouteLocator portRouteLocator(RouteLocatorBuilder builder){
         return builder.routes()
-                .route(r -> r.path("/*/ports", "/*/ports/*").uri(portUrl))
+                .route(r -> r.path("/*/ports", "/*/ports/*",
+                        "/project/*/ports", "/project/*/ports/*")
+                        .uri(portUrl))
                 .build();
     }
 

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/SecurityGroupRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/SecurityGroupRouteConfiguration.java
@@ -25,17 +25,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class SubnetRouteConfiguration {
+public class SecurityGroupRouteConfiguration {
 
-    @Value("${microservices.subnet.service.url}")
-    private String subnetUrl;
+    @Value("${microservices.sg.service.url}")
+    private String sgUrl;
 
     @Bean
-    public RouteLocator subnetRouteLocator(RouteLocatorBuilder builder){
+    public RouteLocator securityGroupLocator(RouteLocatorBuilder builder){
         return builder.routes()
-                .route(r -> r.path("/*/subnets", "/*/subnets/*",
-                        "/project/*/subnets", "/project/*/subnets/*")
-                        .uri(subnetUrl))
+                .route(r -> r.path("/*/security-groups", "/*/security-groups/*",
+                        "/*/security-group-rules", "/*/security-group-rules/*",
+                        "/project/*/security-groups", "/project/*/security-groups/*",
+                        "/project/*/security-group-rules", "/project/*/security-group-rules/*")
+                .uri(sgUrl))
                 .build();
+
     }
 }

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/SubnetRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/SubnetRouteConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SubnetRouteConfiguration {
+
+    @Value("${microservices.subnet.service.url}")
+    private String subnetUrl;
+
+    @Bean
+    public RouteLocator subnetRouteLocator(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r.path("/*/subnets", "/*/subnets/*").uri(subnetUrl))
+                .build();
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
@@ -28,8 +28,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 
-import java.net.NetworkInterface;
-
 @Configuration
 public class VpcRouteConfiguration {
 
@@ -46,7 +44,8 @@ public class VpcRouteConfiguration {
                                 (exchange, vpcsWebJson) -> {
                                     NetworksWebJson networksWebJson = new NetworksWebJson(vpcsWebJson.getVpcs());
                                     return Mono.just(networksWebJson);
-                                })))
+                                }))
+                        .uri(vpcUrl))
                 .route(r -> r
                         .path("/*/networks", "/*/vpcs", "/*/networks/*", "/*/vpcs/*")
                         .uri(vpcUrl))

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
@@ -38,7 +38,7 @@ public class VpcRouteConfiguration {
     public RouteLocator vpcRouteLocator(RouteLocatorBuilder builder){
         return builder.routes()
                 .route(r -> r
-                        .path("/*networks", "/*/vpcs")
+                        .path("/*/networks", "/*/vpcs", "/project/*/vpcs")
                         .and().method(HttpMethod.GET)
                         .filters(f -> f.modifyResponseBody(VpcsWebJson.class, NetworksWebJson.class,
                                 (exchange, vpcsWebJson) -> {
@@ -47,7 +47,8 @@ public class VpcRouteConfiguration {
                                 }))
                         .uri(vpcUrl))
                 .route(r -> r
-                        .path("/*/networks", "/*/vpcs", "/*/networks/*", "/*/vpcs/*")
+                        .path("/*/networks", "/*/networks/*",
+                                "/project/*/vpcs",  "/project/*/vpcs/*")
                         .uri(vpcUrl))
                 .build();
     }

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/VpcRouteConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import com.futurewei.alcor.web.entity.vpc.NetworksWebJson;
+import com.futurewei.alcor.web.entity.vpc.VpcsWebJson;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import reactor.core.publisher.Mono;
+
+import java.net.NetworkInterface;
+
+@Configuration
+public class VpcRouteConfiguration {
+
+    @Value("${microservices.vpc.service.url}")
+    private String vpcUrl;
+
+    @Bean
+    public RouteLocator vpcRouteLocator(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r
+                        .path("/*networks", "/*/vpcs")
+                        .and().method(HttpMethod.GET)
+                        .filters(f -> f.modifyResponseBody(VpcsWebJson.class, NetworksWebJson.class,
+                                (exchange, vpcsWebJson) -> {
+                                    NetworksWebJson networksWebJson = new NetworksWebJson(vpcsWebJson.getVpcs());
+                                    return Mono.just(networksWebJson);
+                                })))
+                .route(r -> r
+                        .path("/*/networks", "/*/vpcs", "/*/networks/*", "/*/vpcs/*")
+                        .uri(vpcUrl))
+                .build();
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebConfiguration.java
@@ -28,8 +28,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
-@Configuration
-@EnableConfigurationProperties(SubnetWebDestinations.class)
+//@Configuration
+//@EnableConfigurationProperties(SubnetWebDestinations.class)
 public class SubnetWebConfiguration {
 
     @Bean

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebDestinations.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebDestinations.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import javax.validation.constraints.NotNull;
 
 @Data
-@ConfigurationProperties(prefix = "subnet.destinations")
+//@ConfigurationProperties(prefix = "subnet.destinations")
 public class SubnetWebDestinations {
 
     @Value("${microservices.subnet.service.url}")

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebConfiguration.java
@@ -28,8 +28,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
-@Configuration
-@EnableConfigurationProperties(VpcWebDestinations.class)
+//@Configuration
+//@EnableConfigurationProperties(VpcWebDestinations.class)
 public class VpcWebConfiguration {
 
     @Bean

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebDestinations.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebDestinations.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import javax.validation.constraints.NotNull;
 
 @Data
-@ConfigurationProperties(prefix = "vpc.destinations")
+//@ConfigurationProperties(prefix = "vpc.destinations")
 public class VpcWebDestinations {
 
     @Value("${microservices.vpc.service.url}")

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -23,6 +23,7 @@ ignite.trust-store-password=123456
 #URL
 microservices.vpc.service.url=http://192.168.1.17:30001/
 microservices.subnet.service.url=http://192.168.1.17:30006/
+microservices.port.service.url=http://192.168.1.17:30002/
 
 #keystone
 # if enable keystone auth filter

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -24,6 +24,7 @@ ignite.trust-store-password=123456
 microservices.vpc.service.url=http://192.168.1.17:30001/
 microservices.subnet.service.url=http://192.168.1.17:30006/
 microservices.port.service.url=http://192.168.1.17:30002/
+microservices.sg.service.url=http://192.168.1.17:30000/
 
 #keystone
 # if enable keystone auth filter

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/AlcorApiGatewayApplicationTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/AlcorApiGatewayApplicationTest.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.server.ServerWebExchange;
@@ -34,6 +35,7 @@ import org.springframework.web.server.WebFilterChain;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.mockito.Mockito.when;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthGwFilterTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthGwFilterTest.java
@@ -1,0 +1,132 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway;
+
+import com.futurewei.alcor.apigateway.client.KeystoneClient;
+import com.futurewei.alcor.apigateway.filter.KeystoneAuthGwFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeystoneAuthGwFilterTest {
+
+    private static final String AUTHORIZE_TOKEN = "X-Auth-Token";
+    private static final String TEST_TOKEN = "gaaaaaBex0xWssdfsadfDSSDFSDF";
+    private static final String TEST_PROJECT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private static final String TEST_ERROR_TOKEN = "testerrortoken";
+
+    private KeystoneAuthGwFilter filter;
+
+    @Mock
+    private KeystoneClient keystoneClient;
+
+    @Before
+    public void setUp(){
+        filter = new KeystoneAuthGwFilter();
+        ReflectionTestUtils.setField(filter, "keystoneClient", keystoneClient);
+        ReflectionTestUtils.setField(filter, "neutronUrlPrefix", "/v2.0");
+        when(keystoneClient.verifyToken(TEST_TOKEN)).thenReturn(TEST_PROJECT_ID);
+        when(keystoneClient.verifyToken(TEST_ERROR_TOKEN)).thenReturn("");
+    }
+
+    @Test
+    public void testNormal(){
+        URI url = URI.create("http://localhost:8080/v2.0/tests?a=b&c=d[]");
+        MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url)
+                .header(AUTHORIZE_TOKEN, TEST_TOKEN).build();
+        ServerWebExchange exchange = testFilter(request, "http://myhost");
+
+        URI uri = exchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
+
+        assertThat(uri).hasScheme("http")
+                .hasPath("/project/" +  TEST_PROJECT_ID + "/tests")
+                .hasParameter("a", "b")
+                .hasParameter("c", "d[]");
+
+    }
+
+    @Test
+    public void testErrorToken(){
+        URI url = URI.create("http://localhost:8080/v2.0/tests?a=b&c=d[]");
+        MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url)
+                .header(AUTHORIZE_TOKEN, TEST_ERROR_TOKEN).build();
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        testFilter(exchange, "http://myhost");
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void testNoToken(){
+        URI url = URI.create("http://localhost:8080/v2.0/tests?a=b&c=d[]");
+        MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url).build();
+
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        testFilter(exchange, "http://myhost");
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    private ServerWebExchange testFilter(MockServerHttpRequest request, String url){
+        Route route = Route.async().id("test").order(0).predicate(swe -> true)
+                .uri(url).build();
+
+        ServerWebExchange exchange = MockServerWebExchange.from(request);
+        exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, route);
+
+        GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
+
+        ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+        when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+
+        filter.filter(exchange, filterChain);
+        verify(filterChain).filter(captor.capture());
+        return captor.getValue();
+    }
+
+    private void testFilter(ServerWebExchange exchange, String url){
+        Route route = Route.async().id("test").order(0).predicate(swe -> true)
+                .uri(url).build();
+
+        exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, route);
+
+        GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
+        filter.filter(exchange, filterChain);
+    }
+}

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
@@ -16,27 +16,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.apigateway;
 
-import com.futurewei.alcor.apigateway.filter.KeystoneAuthWebFilter;
-import com.futurewei.alcor.apigateway.subnet.SubnetWebHandlers;
 import com.futurewei.alcor.apigateway.client.KeystoneClient;
+import com.futurewei.alcor.apigateway.filter.KeystoneAuthGwFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.server.ServerRequest;
-import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Mono;
 
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ComponentScan(value = "com.futurewei.alcor.common.test.config")
@@ -44,6 +38,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}",
                 "keystone.enable=true", "neutron.url_prefix=/v2.0"})
+@DirtiesContext
 @AutoConfigureWireMock(port = 0)
 public class KeystoneAuthWebFilterTest {
 
@@ -51,49 +46,38 @@ public class KeystoneAuthWebFilterTest {
     private static final String TEST_PROJECT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
     private static final String TEST_ERROR_TOKEN = "testerrortoken";
 
-
     @Autowired
     private WebTestClient webClient;
 
     @Autowired
-    private KeystoneAuthWebFilter keystoneAuthWebFilter;
+    private KeystoneAuthGwFilter keystoneAuthGwFilter;
 
     @MockBean
     private KeystoneClient keystoneClient;
 
-    @MockBean
-    private SubnetWebHandlers subnetWebHandlers;
-
     @Before
     public void setUp(){
-        ReflectionTestUtils.setField(keystoneAuthWebFilter, "keystoneClient", keystoneClient);
+        ReflectionTestUtils.setField(keystoneAuthGwFilter, "keystoneClient", keystoneClient);
         when(keystoneClient.verifyToken(TEST_TOKEN)).thenReturn(TEST_PROJECT_ID);
         when(keystoneClient.verifyToken(TEST_ERROR_TOKEN)).thenReturn("");
-
-        Mono<ServerResponse> response = ServerResponse.ok().body
-                (BodyInserters.fromObject("[{\"network_id\":\"bbaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"}]"));
-        when(subnetWebHandlers.getSubnets(ArgumentMatchers.any(ServerRequest.class))).thenReturn(response);
-        Mono<ServerResponse> responseError = ServerResponse.status(500).build();
-        when(subnetWebHandlers.createSubnet(ArgumentMatchers.any(ServerRequest.class))).thenReturn(responseError);
     }
 
     @Test
     public void testNormal(){
-
         webClient
-                .get().uri("/v2.0/subnets")
+                .get().uri("/v2.0/tests")
                 .header("X-Auth-Token", TEST_TOKEN)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
-                .jsonPath("$[0].network_id").isEqualTo("bbaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+                .equals("test ok");
 
     }
 
     @Test
     public void testNotFound(){
         webClient
-                .get().uri("/v2.0/test/not/found")
+                .get().uri("/v2.0/tests/not/found")
                 .header("X-Auth-Token", TEST_TOKEN)
                 .exchange()
                 .expectStatus().isNotFound();
@@ -102,7 +86,7 @@ public class KeystoneAuthWebFilterTest {
     @Test
     public void testNoToken(){
         webClient
-                .get().uri("/v2.0/subnets")
+                .get().uri("/v2.0/tests")
                 .exchange()
                 .expectStatus().isUnauthorized();
     }
@@ -110,7 +94,7 @@ public class KeystoneAuthWebFilterTest {
     @Test
     public void testErrorToken(){
         webClient
-                .get().uri("/v2.0/subnets")
+                .get().uri("/v2.0/tests")
                 .header("X-Auth-Token", TEST_ERROR_TOKEN)
                 .exchange()
                 .expectStatus().isUnauthorized();
@@ -119,11 +103,10 @@ public class KeystoneAuthWebFilterTest {
     @Test
     public void testServerError(){
         webClient
-                .post().uri("/v2.0/subnets")
+                .post().uri("/v2.0/test/error")
                 .header("X-Auth-Token", TEST_TOKEN)
-                .header("Content-Type", "application/json")
-                .body(BodyInserters.fromObject("{\"vpcId\": \"bbaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"}"))
                 .exchange()
                 .expectStatus().is5xxServerError();
     }
+
 }

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -38,6 +39,7 @@ import reactor.core.publisher.Mono;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}",

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneClientTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneClientTest.java
@@ -22,24 +22,21 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.entity.TokenEntity;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebFlux;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.*;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.text.ParseException;
@@ -47,11 +44,11 @@ import java.text.SimpleDateFormat;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties= {
         "keystone.enable=true",
@@ -63,6 +60,7 @@ import static org.mockito.Mockito.when;
         "keystone.auth_type=password",
         "keystone.auth_url=http://localhost/identity"
 })
+@AutoConfigureWebFlux
 public class KeystoneClientTest {
 
     private static final String TEST_LOCAL_TOKEN = "11aaaaaBex0xWssdfsadfDSSDFSDF";

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/RouteTestConfig.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/RouteTestConfig.java
@@ -1,0 +1,70 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway;
+
+import com.futurewei.alcor.apigateway.route.CustomerBodyOutputMessage;
+import org.springframework.cloud.gateway.filter.NettyWriteResponseFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.support.BodyInserterContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class RouteTestConfig {
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public RouteLocator testRoute(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r.path("/v2.0/tests")
+                        .filters(f -> f.filter((exchange, chain) -> {
+                            ServerHttpResponse response = exchange.getResponse();
+
+                            BodyInserter bodyInserter = BodyInserters.fromPublisher(Mono.just("{\"message\": \"test ok\"}"), String.class);
+                            CustomerBodyOutputMessage outputMessage = new CustomerBodyOutputMessage(exchange);
+                            return bodyInserter.insert(outputMessage, new BodyInserterContext())
+                                    .then(Mono.defer(() -> {
+                                        Flux<DataBuffer> messageBody = outputMessage.getBody();
+                                        return response.writeWith(messageBody);
+                                    }));
+                        }, NettyWriteResponseFilter.WRITE_RESPONSE_FILTER_ORDER - 1))
+                        .uri("localhost:8080"))
+                .route(r -> r.path("/v2.0/test/not/found")
+                        .filters(f -> f.filter((exchange, chain) -> {
+                            exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
+                            return exchange.getResponse().setComplete();
+                        }, NettyWriteResponseFilter.WRITE_RESPONSE_FILTER_ORDER - 1))
+                        .uri("localhost:8080"))
+                .route(r -> r.path("/v2.0/test/error")
+                        .filters(f -> f.filter((exchange, chain) -> {
+                            exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+                            return exchange.getResponse().setComplete();
+                        }, NettyWriteResponseFilter.WRITE_RESPONSE_FILTER_ORDER - 1))
+                        .uri("localhost:8080"))
+                .build();
+    }
+}

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacPoolRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacPoolRepository.java
@@ -79,6 +79,11 @@ public class MacPoolRepository implements ICacheRepository<MacPool> {
         return cache.getAll();
     }
 
+    @Override
+    public Map<String, MacPool> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
     /**
      * add a MAC address to MAC pool repository
      *

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeRepository.java
@@ -18,7 +18,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.web.entity.mac.MacRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +86,25 @@ public class MacRangeRepository implements ICacheRepository<MacRange> {
             throw e;
         }
         return hashMap;
+    }
+
+    /**
+     * get all MAC ranges by params filters
+     *
+     * @param queryParams url request params
+     * @return map of MAC ranges
+     * @throws CacheException Db or cache operation exception
+     */
+    @Override
+    public Map<String, MacRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        Map<String, MacRange> map = new HashMap<String, MacRange>();
+        try {
+            map = cache.getAll(queryParams);
+        } catch (CacheException e) {
+            logger.error("MacRangeRepository findAllItems() exception:", e);
+            throw e;
+        }
+        return map;
     }
 
     /**

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacStateRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacStateRepository.java
@@ -19,7 +19,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.web.entity.mac.MacState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +87,18 @@ public class MacStateRepository implements ICacheRepository<MacState> {
             throw e;
         }
         return hashMap;
+    }
+
+    @Override
+    public Map<String, MacState> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        Map map = new HashMap();
+        try {
+            map = cache.getAll(queryParams);
+        } catch (CacheException e) {
+            logger.error("MacStateRepository findAllItems() exception:", e);
+            throw e;
+        }
+        return map;
     }
 
     /**

--- a/services/mac_manager/src/main/resources/application.properties
+++ b/services/mac_manager/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 #server.port=9005
 #Machine configuration
 #Redis configuration
-spring.redis.host=localhost
-spring.redis.port=6380
+#spring.redis.host=localhost
+#spring.redis.port=6380
 #Ignite configuration
 ignite.host=localhost
 ignite.port=10800

--- a/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/AlcorMacManager/MacManagerApplicationTests.java
+++ b/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/AlcorMacManager/MacManagerApplicationTests.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 //@RunWith(SpringRunner.class)
 @AutoConfigureMockMvc

--- a/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/controller/MacControllerTest.java
+++ b/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/controller/MacControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -47,6 +48,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class MacControllerTest extends MockIgniteServer {

--- a/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/swagger/SwaggerJsonTest.java
+++ b/services/mac_manager/src/test/java/com/futurewei/alcor/macmanager/swagger/SwaggerJsonTest.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.macmanager.swagger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -43,6 +44,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/dao/NodeRepository.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/dao/NodeRepository.java
@@ -18,7 +18,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.web.entity.NodeInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +72,17 @@ public class NodeRepository implements ICacheRepository<NodeInfo> {
     @Override
     public Map findAllItems() throws CacheException {
         return cache.getAll();
+    }
+
+    /**
+     * find all nodes' information by filter
+     * @param queryParams url request params
+     * @return
+     * @throws CacheException
+     */
+    @Override
+    public Map<String, NodeInfo> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
     }
 
     /**

--- a/services/node_manager/src/main/resources/application.properties
+++ b/services/node_manager/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #server.port=9007
 #redis configuration
-spring.redis.host=localhost
-spring.redis.port=6380
+#spring.redis.host=localhost
+#spring.redis.port=6380
 #ignite configuration
 ignite.host=localhost
 ignite.port=10800

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/AlcorNodeManager/NodeManagerApplicationTests.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/AlcorNodeManager/NodeManagerApplicationTests.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @AutoConfigureMockMvc

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
@@ -19,14 +19,18 @@ import com.futurewei.alcor.common.db.ignite.MockIgniteServer;
 import com.futurewei.alcor.nodemanager.dao.NodeRepository;
 import com.futurewei.alcor.web.entity.NodeInfo;
 import com.futurewei.alcor.web.entity.NodeInfoJson;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -44,7 +48,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
+@RunWith(SpringRunner.class)
+@SpringBootTest()
 @AutoConfigureMockMvc
 public class NodeControllerTest extends MockIgniteServer {
     private static final ObjectMapper om = new ObjectMapper();

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/swagger/SwaggerJsonTest.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/swagger/SwaggerJsonTest.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.nodemanager.swagger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -41,6 +42,7 @@ import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/PortManagerApplication.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/PortManagerApplication.java
@@ -2,9 +2,11 @@ package com.futurewei.alcor.portmanager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
+@ComponentScan(value="com.futurewei.alcor.web.json")
+@ComponentScan(value="com.futurewei.alcor.portmanager")
 public class PortManagerApplication {
 
     public static void main(String[] args) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -26,8 +26,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.futurewei.alcor.portmanager.util.RestParameterValidator.checkPort;
 
@@ -162,10 +167,15 @@ public class PortController {
      */
     @FieldFilter(type=PortEntity.class)
     @GetMapping({"/project/{project_id}/ports", "v4/{project_id}/ports"})
-    public List<PortWebJson> listPort(@PathVariable("project_id") String projectId) throws Exception {
+    public PortWebBulkJson listPort(@PathVariable("project_id") String projectId) throws Exception {
         Map<String, Object[]> queryParams =
                 ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);
         queryParams.put("project_id", new String[]{projectId});
-        return portService.listPort(projectId, queryParams);
+        List<PortWebJson> portWebJsonList = portService.listPort(projectId, queryParams);
+        List<PortEntity> portsList = portWebJsonList.stream()
+                .map(PortWebJson::getPortEntity)
+                .collect(Collectors.toList());
+
+        return new PortWebBulkJson(portsList);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -15,21 +15,30 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.controller;
 
+import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.portmanager.exception.*;
 import com.futurewei.alcor.portmanager.service.PortService;
 import com.futurewei.alcor.web.entity.port.*;
+import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import io.netty.util.internal.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Map;
+
 import static com.futurewei.alcor.portmanager.util.RestParameterValidator.checkPort;
 
 @RestController
 public class PortController {
+
     @Autowired
     PortService portService;
 
+    @Autowired
+    private HttpServletRequest request;
     /**
      * Create a port, and call the interfaces of each micro-service according to the
      * configuration of the port to create various required resources for the port.
@@ -138,6 +147,7 @@ public class PortController {
      * @return PortWebJson
      * @throws Exception Db operation exception
      */
+    @FieldFilter(type=PortEntity.class)
     @GetMapping({"/project/{project_id}/ports/{port_id}", "v4/{project_id}/ports/{port_id}"})
     public PortWebJson getPort(@PathVariable("project_id") String projectId,
                                     @PathVariable("port_id") String portId) throws Exception {
@@ -150,8 +160,12 @@ public class PortController {
      * @return A list of port information
      * @throws Exception Db operation exception
      */
+    @FieldFilter(type=PortEntity.class)
     @GetMapping({"/project/{project_id}/ports", "v4/{project_id}/ports"})
     public List<PortWebJson> listPort(@PathVariable("project_id") String projectId) throws Exception {
-        return portService.listPort(projectId);
+        Map<String, Object[]> queryParams =
+                ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);
+        queryParams.put("project_id", new String[]{projectId});
+        return portService.listPort(projectId, queryParams);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -68,6 +68,10 @@ public class PortRepository {
         return portCache.getAll();
     }
 
+    public Map<String, PortEntity> findAllPortEntities(Map<String, Object[]> queryParams) throws CacheException {
+        return portCache.getAll(queryParams);
+    }
+
     public synchronized void createPortAndNeighbor(PortEntity portEntity, NeighborInfo neighborInfo) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Add portEntity to portCache

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public interface PortService {
@@ -39,4 +40,6 @@ public interface PortService {
     PortWebJson getPort(String projectId, String portId) throws Exception;
 
     List<PortWebJson> listPort(String projectId) throws Exception;
+
+    List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception;
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -744,4 +744,21 @@ public class PortServiceImpl implements PortService {
 
         return result;
     }
+
+    @Override
+    public List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception {
+        List<PortWebJson> result = new ArrayList<>();
+
+        Map<String, PortEntity> portEntityMap = portRepository.findAllPortEntities(queryParams);
+        if (portEntityMap == null) {
+            return result;
+        }
+
+        for (Map.Entry<String, PortEntity> entry: portEntityMap.entrySet()) {
+            PortWebJson portWebJson = new PortWebJson(entry.getValue());
+            result.add(portWebJson);
+        }
+
+        return result;
+    }
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/CreatePortTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/CreatePortTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class CreatePortTest extends MockRestClientAndRepository {

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/DeletePortTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/DeletePortTest.java
@@ -20,12 +20,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class DeletePortTest extends MockRestClientAndRepository {

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/GetPortTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/GetPortTest.java
@@ -55,7 +55,7 @@ public class GetPortTest extends MockRestClientAndRepository {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers
-                        .jsonPath("$[0].port.id")
+                        .jsonPath("$.ports[0].id")
                         .value(UnitTestConfig.portId1)
                 );
     }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/GetPortTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/GetPortTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class GetPortTest extends MockRestClientAndRepository {

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.futurewei.alcor.portmanager.util.ResourceBuilder.*;
+import static org.mockito.ArgumentMatchers.anyMap;
 
 public class MockRestClientAndRepository {
     @MockBean
@@ -109,7 +110,7 @@ public class MockRestClientAndRepository {
         Map<String, PortEntity> portStates = new HashMap<>();
         portStates.put(UnitTestConfig.portId1, buildPortWebJson(UnitTestConfig.portId1).getPortEntity());
 
-        Mockito.when(portRepository.findAllPortEntities())
+        Mockito.when(portRepository.findAllPortEntities(anyMap()))
                 .thenReturn(portStates);
 
         Mockito.when(portRepository.getPortNeighbors(UnitTestConfig.vpcId))

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/UpdatePortTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/UpdatePortTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class UpdatePortTest extends MockRestClientAndRepository {

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/swagger/SwaggerJsonTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/swagger/SwaggerJsonTest.java
@@ -15,6 +15,7 @@ package com.futurewei.alcor.portmanager.swagger;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -37,6 +38,7 @@ import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/IpAddrRangeRepo.java
+++ b/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/IpAddrRangeRepo.java
@@ -19,7 +19,7 @@ package com.futurewei.alcor.privateipmanager.repo;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.privateipmanager.entity.IpAddrAlloc;
 import com.futurewei.alcor.privateipmanager.entity.IpAddrRange;
 import com.futurewei.alcor.privateipmanager.entity.VpcIpRange;
@@ -36,7 +36,7 @@ import java.util.*;
 
 @ComponentScan(value="com.futurewei.alcor.common.db")
 @Repository
-public class  IpAddrRangeRepo implements ICacheRepository<IpAddrRange> {
+public class IpAddrRangeRepo implements ICacheRepository<IpAddrRange> {
     private static final Logger LOG = LoggerFactory.getLogger(IpAddrRangeRepo.class);
     private ICache<String, IpAddrRange> ipAddrRangeCache;
     private ICache<String, VpcIpRange> vpcIpRangeCache;
@@ -74,6 +74,18 @@ public class  IpAddrRangeRepo implements ICacheRepository<IpAddrRange> {
     public synchronized Map<String, IpAddrRange> findAllItems() {
         try {
             return ipAddrRangeCache.getAll();
+        } catch (CacheException e) {
+            e.printStackTrace();
+            LOG.error("IpRangeRepository findAllItems() exception:", e);
+        }
+
+        return new HashMap();
+    }
+
+    @Override
+    public Map<String, IpAddrRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        try {
+            return ipAddrRangeCache.getAll(queryParams);
         } catch (CacheException e) {
             e.printStackTrace();
             LOG.error("IpRangeRepository findAllItems() exception:", e);

--- a/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/IpAddrRepo.java
+++ b/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/IpAddrRepo.java
@@ -18,7 +18,7 @@ package com.futurewei.alcor.privateipmanager.repo;
 
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.privateipmanager.entity.IpAddrAlloc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +62,18 @@ public class IpAddrRepo implements ICacheRepository<IpAddrAlloc> {
     public synchronized Map findAllItems() {
         try {
             return cache.getAll();
+        } catch (CacheException e) {
+            e.printStackTrace();
+            LOG.error("IpAddrRepo findAllItems() exception:", e);
+        }
+
+        return new HashMap();
+    }
+
+    @Override
+    public Map<String, IpAddrAlloc> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        try {
+            return cache.getAll(queryParams);
         } catch (CacheException e) {
             e.printStackTrace();
             LOG.error("IpAddrRepo findAllItems() exception:", e);

--- a/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/VpcIpRangeRepo.java
+++ b/services/private_ip_manager/src/main/java/com/futurewei/alcor/privateipmanager/repo/VpcIpRangeRepo.java
@@ -18,8 +18,8 @@ package com.futurewei.alcor.privateipmanager.repo;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.exception.ResourceNotFoundException;
-import com.futurewei.alcor.common.repo.ICacheRepository;
 import com.futurewei.alcor.web.entity.ip.*;
 import com.futurewei.alcor.privateipmanager.entity.VpcIpRange;
 import org.slf4j.Logger;
@@ -44,13 +44,18 @@ public class VpcIpRangeRepo implements ICacheRepository<VpcIpRange> {
 
 
     @Override
-    public VpcIpRange findItem(String id) throws CacheException, ResourceNotFoundException {
+    public VpcIpRange findItem(String id) throws CacheException {
         return null;
     }
 
     @Override
     public Map<String, VpcIpRange> findAllItems() throws CacheException {
         return null;
+    }
+
+    @Override
+    public Map<String, VpcIpRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return vpcIpRangeCache.getAll(queryParams);
     }
 
     @Override

--- a/services/private_ip_manager/src/test/java/com/futurewei/alcor/privateipmanager/controller/IpAddrControllerTest.java
+++ b/services/private_ip_manager/src/test/java/com/futurewei/alcor/privateipmanager/controller/IpAddrControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -43,6 +44,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @AutoConfigureMockMvc

--- a/services/private_ip_manager/src/test/java/com/futurewei/alcor/privateipmanager/swagger/SwaggerJsonTest.java
+++ b/services/private_ip_manager/src/test/java/com/futurewei/alcor/privateipmanager/swagger/SwaggerJsonTest.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.privateipmanager.swagger;
 import com.futurewei.alcor.common.db.ignite.MockIgniteServer;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,7 +38,7 @@ import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteRepository.java
@@ -48,6 +48,11 @@ public class RouteRepository implements ICacheRepository<RouteEntity> {
     }
 
     @Override
+    public Map<String, RouteEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(RouteEntity routeEntity) throws CacheException {
         logger.log(Level.INFO, "Add route, route Id:" + routeEntity.getId());
         cache.put(routeEntity.getId(), routeEntity);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithSubnetMapperRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithSubnetMapperRepository.java
@@ -63,6 +63,11 @@ public class RouteWithSubnetMapperRepository implements ICacheRepository<SubnetT
     }
 
     @Override
+    public Map<String, SubnetToRouteMapper> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(SubnetToRouteMapper subnetToRouteMapper) throws CacheException {
         logger.log(Level.INFO, "Add routeWithSubnetMapper, mapper Id:" + subnetToRouteMapper.getSubnetId());
         cache.put(subnetToRouteMapper.getSubnetId(), subnetToRouteMapper);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithVpcMapperRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithVpcMapperRepository.java
@@ -62,6 +62,11 @@ public class RouteWithVpcMapperRepository implements ICacheRepository<VpcToRoute
     }
 
     @Override
+    public Map<String, VpcToRouteMapper> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(VpcToRouteMapper vpcToRouteMapper) throws CacheException {
         logger.log(Level.INFO, "Add RouteWithVpcMapper, mapper Id:" + vpcToRouteMapper.getVpcId());
         cache.put(vpcToRouteMapper.getVpcId(), vpcToRouteMapper);

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/RouteApplicationTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/RouteApplicationTests.java
@@ -1,9 +1,13 @@
 package com.futurewei.alcor.route;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
+@AutoConfigureMockMvc
 class RouteApplicationTests {
 
     @Test

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/RouteControllerTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/RouteControllerTests.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.io.IOException;
 
-
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/SecurityGroupManagerApplicationTests.java
+++ b/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/SecurityGroupManagerApplicationTests.java
@@ -1,9 +1,14 @@
 package com.futurewei.alcor.securitygroup;
 
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
+@AutoConfigureMockMvc
 class SecurityGroupManagerApplicationTests {
 
     @Test

--- a/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupTest.java
+++ b/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupTest.java
@@ -27,6 +27,7 @@ import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @SpringBootTest
 @RunWith(SpringRunner.class)
 @AutoConfigureMockMvc

--- a/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/swagger/SwaggerJsonTest.java
+++ b/services/security_group_manager/src/test/java/com/futurewei/alcor/securitygroup/swagger/SwaggerJsonTest.java
@@ -15,6 +15,7 @@ package com.futurewei.alcor.securitygroup.swagger;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,6 +37,7 @@ import io.github.swagger2markup.builder.Swagger2MarkupConfigBuilder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/SubnetApplication.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/SubnetApplication.java
@@ -2,10 +2,13 @@ package com.futurewei.alcor.subnet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @SpringBootApplication
+@ComponentScan(value="com.futurewei.alcor.web.json")
+@ComponentScan(value="com.futurewei.alcor.subnet")
 public class SubnetApplication {
 
     public static void main(String[] args) {

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
@@ -42,6 +42,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.thymeleaf.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
@@ -117,6 +118,11 @@ public class SubnetController {
         AtomicReference<MacStateJson> macResponseAtomic = new AtomicReference<>();
         AtomicReference<IpAddrRequest> ipResponseAtomic = new AtomicReference<>();
         String portId = UUID.randomUUID().toString();
+
+        if(StringUtils.isEmpty(resource.getSubnet().getId())){
+            String subnetId = UUID.randomUUID().toString();
+            resource.getSubnet().setId(subnetId);
+        }
 
         try {
             if (!SubnetManagementUtil.checkSubnetRequestResourceIsValid(resource)) {
@@ -279,7 +285,7 @@ public class SubnetController {
 //            if (!SubnetManagementUtil.checkSubnetRequestResourceIsValid(resource)) {
 //                throw new ResourceNotValidException("request resource is invalid");
 //            }
-
+            Preconditions.checkNotNull(resource, "resource can not be null");
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectId);
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(subnetId);
             SubnetWebRequestObject inSubnetWebResponseObject = resource.getSubnet();

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/dao/SubnetRepository.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/dao/SubnetRepository.java
@@ -67,6 +67,11 @@ public class SubnetRepository implements ICacheRepository<SubnetEntity> {
     }
 
     @Override
+    public Map<String, SubnetEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(SubnetEntity subnet) throws CacheException {
         logger.log(Level.INFO, "Add subnet, subnet Id:" + subnet.getId());
         cache.put(subnet.getId(), subnet);

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/SubnetDatabaseService.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/SubnetDatabaseService.java
@@ -11,8 +11,13 @@ import java.util.Map;
 public interface SubnetDatabaseService {
 
     public SubnetEntity getBySubnetId (String subnetId) throws ResourceNotFoundException, ResourcePersistenceException;
-    public Map getAllSubnets () throws CacheException;
+
+    public Map<String, SubnetEntity> getAllSubnets () throws CacheException;
+
+    public Map<String, SubnetEntity> getAllSubnets (Map<String, Object[]> queryParams) throws CacheException;
+
     public void addSubnet (SubnetEntity subnetEntity) throws DatabasePersistenceException;
+
     public void deleteSubnet (String id) throws CacheException;
 
 }

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetDatabaseServiceImpl.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetDatabaseServiceImpl.java
@@ -26,8 +26,13 @@ public class SubnetDatabaseServiceImpl implements SubnetDatabaseService {
     }
 
     @Override
-    public Map getAllSubnets() throws CacheException {
+    public Map<String, SubnetEntity> getAllSubnets() throws CacheException {
         return this.subnetRepository.findAllItems();
+    }
+
+    @Override
+    public Map<String, SubnetEntity> getAllSubnets(Map<String, Object[]> queryParams) throws CacheException {
+        return this.subnetRepository.findAllItems(queryParams);
     }
 
     @Override

--- a/services/subnet_manager/src/test/java/com/futurewei/alcor/subnet/SubnetApplicationTests.java
+++ b/services/subnet_manager/src/test/java/com/futurewei/alcor/subnet/SubnetApplicationTests.java
@@ -1,8 +1,12 @@
 package com.futurewei.alcor.subnet;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
+@AutoConfigureMockMvc
 @SpringBootTest
 class SubnetApplicationTests {
 

--- a/services/subnet_manager/src/test/java/com/futurewei/alcor/subnet/SubnetControllerTests.java
+++ b/services/subnet_manager/src/test/java/com/futurewei/alcor/subnet/SubnetControllerTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,7 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/VpcManagerApplication.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/VpcManagerApplication.java
@@ -18,8 +18,11 @@ package com.futurewei.alcor.vpcmanager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication()
+@ComponentScan(value="com.futurewei.alcor.web.json")
+@ComponentScan(value="com.futurewei.alcor.vpcmanager")
 public class VpcManagerApplication {
 
     public static void main(String[] args) {

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
@@ -263,7 +263,7 @@ public class VpcController {
     @RequestMapping(
             method = GET,
             value = "/project/{projectId}/vpcs")
-    public Map getVpcStatesByProjectId(@PathVariable String projectId) throws Exception {
+    public VpcsWebJson getVpcStatesByProjectId(@PathVariable String projectId) throws Exception {
         Map<String, VpcEntity> vpcStates = null;
 
         Map<String, Object[]> queryParams =
@@ -275,8 +275,6 @@ public class VpcController {
             RestPreconditionsUtil.verifyResourceFound(projectId);
 
             vpcStates = this.vpcDatabaseService.getAllVpcs(queryParams);
-            vpcStates = vpcStates.entrySet().stream()
-                    .collect(Collectors.toMap(state -> state.getKey(), state -> state.getValue()));
 
         } catch (ParameterNullOrEmptyException e) {
             throw new Exception(e);
@@ -284,7 +282,7 @@ public class VpcController {
             throw new Exception(e);
         }
 
-        return vpcStates;
+        return new VpcsWebJson(new ArrayList<>(vpcStates.values()));
     }
 
     /**

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRangeRepository.java
@@ -4,7 +4,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -68,6 +68,11 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
         }
 
         return new HashMap();
+    }
+
+    @Override
+    public Map<String, NetworkGRERange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
     }
 
     @Override

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRepository.java
@@ -48,6 +48,11 @@ public class GreRepository implements ICacheRepository<NetworkGREType> {
     }
 
     @Override
+    public Map<String, NetworkGREType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(NetworkGREType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Gre, Gre Id:" + newItem.getGreId());
         cache.put(newItem.getGreId(), newItem);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRangeRepository.java
@@ -48,6 +48,11 @@ public class SegmentRangeRepository implements ICacheRepository<NetworkSegmentRa
     }
 
     @Override
+    public Map<String, NetworkSegmentRangeEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(NetworkSegmentRangeEntity newItem) throws CacheException {
         logger.log(Level.INFO, "Add segment range, Segment Range Id:" + newItem.getId());
         cache.put(newItem.getId(), newItem);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRepository.java
@@ -48,6 +48,11 @@ public class SegmentRepository implements ICacheRepository<SegmentEntity> {
     }
 
     @Override
+    public Map<String, SegmentEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(SegmentEntity newItem) throws CacheException {
         logger.log(Level.INFO, "Add segment, Segment Id:" + newItem.getId());
         cache.put(newItem.getId(), newItem);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRangeRepository.java
@@ -4,7 +4,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -66,6 +66,11 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
         }
 
         return new HashMap();
+    }
+
+    @Override
+    public Map<String, NetworkVlanRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
     }
 
     @Override

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRepository.java
@@ -49,6 +49,11 @@ public class VlanRepository implements ICacheRepository<NetworkVlanType> {
     }
 
     @Override
+    public Map<String, NetworkVlanType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(NetworkVlanType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Vlan, Vlan Id:" + newItem.getVlanId());
         cache.put(newItem.getVlanId(), newItem);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VpcRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VpcRepository.java
@@ -63,6 +63,11 @@ public class VpcRepository implements ICacheRepository<VpcEntity> {
     }
 
     @Override
+    public Map<String, VpcEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(VpcEntity vpcState) throws CacheException {
         logger.log(Level.INFO, "Add vpc, Vpc Id:" + vpcState.getId());
         cache.put(vpcState.getId(), vpcState);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRangeRepository.java
@@ -4,7 +4,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
-import com.futurewei.alcor.common.repo.ICacheRepository;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -67,6 +67,11 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
         }
 
         return new HashMap();
+    }
+
+    @Override
+    public Map<String, NetworkVxlanRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
     }
 
     @Override

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRepository.java
@@ -48,6 +48,11 @@ public class VxlanRepository implements ICacheRepository<NetworkVxlanType> {
     }
 
     @Override
+    public Map<String, NetworkVxlanType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
+        return cache.getAll(queryParams);
+    }
+
+    @Override
     public void addItem(NetworkVxlanType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Vxlan, Vxlan Id:" + newItem.getVxlanId());
         cache.put(newItem.getVxlanId(), newItem);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/Impl/VpcDatabaseServiceImpl.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/Impl/VpcDatabaseServiceImpl.java
@@ -36,6 +36,11 @@ public class VpcDatabaseServiceImpl implements VpcDatabaseService {
     }
 
     @Override
+    public Map getAllVpcs(Map<String, Object[]> queryParams) throws CacheException {
+        return this.vpcRepository.findAllItems(queryParams);
+    }
+
+    @Override
     public void addVpc(VpcEntity vpcState) throws DatabasePersistenceException {
         try {
             this.vpcRepository.addItem(vpcState);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/VpcDatabaseService.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/VpcDatabaseService.java
@@ -13,6 +13,7 @@ public interface VpcDatabaseService {
 
     public VpcEntity getByVpcId (String vpcId) throws ResourceNotFoundException, ResourcePersistenceException;
     public Map getAllVpcs () throws CacheException;
+    public Map getAllVpcs (Map<String, Object[]> queryParams) throws CacheException;
     public void addVpc (VpcEntity vpcState) throws DatabasePersistenceException;
     public void deleteVpc (String id) throws CacheException;
     public ICache<String, VpcEntity> getCache ();

--- a/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/SegmentControllerTests.java
+++ b/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/SegmentControllerTests.java
@@ -14,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScans;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/SegmentRangeControllerTests.java
+++ b/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/SegmentRangeControllerTests.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/VpcControllerTests.java
+++ b/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/VpcControllerTests.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = {"httpbin=http://localhost:${wiremock.server.port}"})

--- a/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/VpcManagerApplicationTests.java
+++ b/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/VpcManagerApplicationTests.java
@@ -18,11 +18,15 @@ package com.futurewei.alcor.vpcmanager;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest()
+@AutoConfigureMockMvc
 public class VpcManagerApplicationTests {
 
     @Test

--- a/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/swagger/SwaggerJsonTest.java
+++ b/services/vpc_manager/src/test/java/com/futurewei/alcor/vpcmanager/swagger/SwaggerJsonTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -38,6 +39,7 @@ import java.nio.file.Paths;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/web/src/main/java/com/futurewei/alcor/web/entity/NetworkSegmentRangeEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/NetworkSegmentRangeEntity.java
@@ -30,9 +30,6 @@ public class NetworkSegmentRangeEntity extends CustomerResource {
     @JsonProperty("physical_network")
     private String physicalNetwork;
 
-    @JsonProperty("tenant_id")
-    private String tenantId;
-
     @JsonProperty("shared")
     private Boolean shared;
 
@@ -60,7 +57,7 @@ public class NetworkSegmentRangeEntity extends CustomerResource {
         this.networkType = networkType;
     }
 
-    public NetworkSegmentRangeEntity(String projectId, String id, String name, String description, boolean isDefault, Integer minimum, Integer maximum, String tags, String networkType, String physicalNetwork, String tenantId, Boolean shared, Integer revisionNumber, List<Integer> available, Map<Integer, String> used, String created_at, String updated_at) {
+    public NetworkSegmentRangeEntity(String projectId, String id, String name, String description, boolean isDefault, Integer minimum, Integer maximum, String tags, String networkType, String physicalNetwork, Boolean shared, Integer revisionNumber, List<Integer> available, Map<Integer, String> used, String created_at, String updated_at) {
         super(projectId, id, name, description);
         this.isDefault = isDefault;
         this.minimum = minimum;
@@ -68,7 +65,6 @@ public class NetworkSegmentRangeEntity extends CustomerResource {
         this.tags = tags;
         this.networkType = networkType;
         this.physicalNetwork = physicalNetwork;
-        this.tenantId = tenantId;
         this.shared = shared;
         this.revisionNumber = revisionNumber;
         this.available = available;

--- a/web/src/main/java/com/futurewei/alcor/web/entity/port/PortEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/port/PortEntity.java
@@ -27,9 +27,6 @@ public class PortEntity extends CustomerResource {
     @JsonProperty("network_id")
     private String vpcId;
 
-    @JsonProperty("tenant_id")
-    private String tenantId;
-
     @JsonProperty("admin_state_up")
     private boolean adminStateUp;
 
@@ -126,7 +123,7 @@ public class PortEntity extends CustomerResource {
     public PortEntity() {
     }
 
-    public PortEntity(String vpcId, String tenantId, boolean adminStateUp, String macAddress, String vethName,
+    public PortEntity(String vpcId, boolean adminStateUp, String macAddress, String vethName,
                       boolean fastPath, String deviceId, String deviceOwner, String status, List<FixedIp> fixedIps,
                       List<AllowAddressPair> allowedAddressPairs, List<ExtraDhcpOpt> extraDhcpOpts, List<String> securityGroups,
                       String bindingHostId, String bindingProfile, String bindingVifDetails, String bindingVifType,
@@ -135,7 +132,6 @@ public class PortEntity extends CustomerResource {
                       boolean portSecurityEnabled, String qosNetworkPolicyId, String qosPolicyId, int revisionNumber,
                       int resourceRequest, List<String> tags, boolean uplinkStatusPropagation, boolean macLearningEnabled) {
         this.vpcId = vpcId;
-        this.tenantId = tenantId;
         this.adminStateUp = adminStateUp;
         this.macAddress = macAddress;
         this.vethName = vethName;
@@ -169,10 +165,9 @@ public class PortEntity extends CustomerResource {
         this.macLearningEnabled = macLearningEnabled;
     }
 
-    public PortEntity(CustomerResource state, String vpcId, String tenantId, boolean adminStateUp, String macAddress, String vethName, boolean fastPath, String deviceId, String deviceOwner, String status, List<FixedIp> fixedIps, List<AllowAddressPair> allowedAddressPairs, List<ExtraDhcpOpt> extraDhcpOpts, List<String> securityGroups, String bindingHostId, String bindingProfile, String bindingVifDetails, String bindingVifType, String bindingVnicType, String networkNamespace, String dnsName, String dnsDomain, List<DnsRecord> dnsAssignment, String createAt, String updateAt, String ipAllocation, boolean portSecurityEnabled, String qosNetworkPolicyId, String qosPolicyId, int revisionNumber, int resourceRequest, List<String> tags, boolean uplinkStatusPropagation, boolean macLearningEnabled) {
+    public PortEntity(CustomerResource state, String vpcId, boolean adminStateUp, String macAddress, String vethName, boolean fastPath, String deviceId, String deviceOwner, String status, List<FixedIp> fixedIps, List<AllowAddressPair> allowedAddressPairs, List<ExtraDhcpOpt> extraDhcpOpts, List<String> securityGroups, String bindingHostId, String bindingProfile, String bindingVifDetails, String bindingVifType, String bindingVnicType, String networkNamespace, String dnsName, String dnsDomain, List<DnsRecord> dnsAssignment, String createAt, String updateAt, String ipAllocation, boolean portSecurityEnabled, String qosNetworkPolicyId, String qosPolicyId, int revisionNumber, int resourceRequest, List<String> tags, boolean uplinkStatusPropagation, boolean macLearningEnabled) {
         super(state);
         this.vpcId = vpcId;
-        this.tenantId = tenantId;
         this.adminStateUp = adminStateUp;
         this.macAddress = macAddress;
         this.vethName = vethName;
@@ -206,10 +201,9 @@ public class PortEntity extends CustomerResource {
         this.macLearningEnabled = macLearningEnabled;
     }
 
-    public PortEntity(String projectId, String id, String name, String description, String vpcId, String tenantId, boolean adminStateUp, String macAddress, String vethName, boolean fastPath, String deviceId, String deviceOwner, String status, List<FixedIp> fixedIps, List<AllowAddressPair> allowedAddressPairs, List<ExtraDhcpOpt> extraDhcpOpts, List<String> securityGroups, String bindingHostId, String bindingProfile, String bindingVifDetails, String bindingVifType, String bindingVnicType, String networkNamespace, String dnsName, String dnsDomain, List<DnsRecord> dnsAssignment, String createAt, String updateAt, String ipAllocation, boolean portSecurityEnabled, String qosNetworkPolicyId, String qosPolicyId, int revisionNumber, int resourceRequest, List<String> tags, boolean uplinkStatusPropagation, boolean macLearningEnabled) {
+    public PortEntity(String projectId, String id, String name, String description, String vpcId, boolean adminStateUp, String macAddress, String vethName, boolean fastPath, String deviceId, String deviceOwner, String status, List<FixedIp> fixedIps, List<AllowAddressPair> allowedAddressPairs, List<ExtraDhcpOpt> extraDhcpOpts, List<String> securityGroups, String bindingHostId, String bindingProfile, String bindingVifDetails, String bindingVifType, String bindingVnicType, String networkNamespace, String dnsName, String dnsDomain, List<DnsRecord> dnsAssignment, String createAt, String updateAt, String ipAllocation, boolean portSecurityEnabled, String qosNetworkPolicyId, String qosPolicyId, int revisionNumber, int resourceRequest, List<String> tags, boolean uplinkStatusPropagation, boolean macLearningEnabled) {
         super(projectId, id, name, description);
         this.vpcId = vpcId;
-        this.tenantId = tenantId;
         this.adminStateUp = adminStateUp;
         this.macAddress = macAddress;
         this.vethName = vethName;
@@ -244,7 +238,7 @@ public class PortEntity extends CustomerResource {
     }
 
     public PortEntity(PortEntity portEntity) {
-        this(portEntity.getProjectId(), portEntity.getId(), portEntity.getName(), portEntity.getDescription(), portEntity.getVpcId(), portEntity.getTenantId(),
+        this(portEntity.getProjectId(), portEntity.getId(), portEntity.getName(), portEntity.getDescription(), portEntity.getVpcId(),
                 portEntity.adminStateUp, portEntity.getMacAddress(), portEntity.getVethName(), portEntity.fastPath, portEntity.getDeviceId(),
                 portEntity.getDeviceOwner(), portEntity.getStatus(), portEntity.getFixedIps(), portEntity.getAllowedAddressPairs(),
                 portEntity.getExtraDhcpOpts(), portEntity.getSecurityGroups(), portEntity.getBindingHostId(), portEntity.getBindingProfile(),
@@ -458,14 +452,6 @@ public class PortEntity extends CustomerResource {
 
     public void setVpcId(String vpcId) {
         this.vpcId = vpcId;
-    }
-
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
     }
 
     public boolean isAdminStateUp() {

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.futurewei.alcor.common.entity.CustomerResource;
 
 public class SecurityGroupRule extends CustomerResource {
-    @JsonProperty("tenant_id")
-    private String tenantId;
 
     @JsonProperty("security_group_id")
     private String securityGroupId;
@@ -112,21 +110,8 @@ public class SecurityGroupRule extends CustomerResource {
         this.etherType = etherType;
     }
 
-    public SecurityGroupRule(String tenantId, String securityGroupId, String remoteGroupId, String direction, String remoteIpPrefix, String protocol, Integer portRangeMax, Integer portRangeMin, String etherType) {
-        this.tenantId = tenantId;
-        this.securityGroupId = securityGroupId;
-        this.remoteGroupId = remoteGroupId;
-        this.direction = direction;
-        this.remoteIpPrefix = remoteIpPrefix;
-        this.protocol = protocol;
-        this.portRangeMax = portRangeMax;
-        this.portRangeMin = portRangeMin;
-        this.etherType = etherType;
-    }
-
-    public SecurityGroupRule(CustomerResource state, String tenantId, String securityGroupId, String remoteGroupId, String direction, String remoteIpPrefix, String protocol, Integer portRangeMax, Integer portRangeMin, String etherType) {
+    public SecurityGroupRule(CustomerResource state, String securityGroupId, String remoteGroupId, String direction, String remoteIpPrefix, String protocol, Integer portRangeMax, Integer portRangeMin, String etherType) {
         super(state);
-        this.tenantId = tenantId;
         this.securityGroupId = securityGroupId;
         this.remoteGroupId = remoteGroupId;
         this.direction = direction;
@@ -137,9 +122,8 @@ public class SecurityGroupRule extends CustomerResource {
         this.etherType = etherType;
     }
 
-    public SecurityGroupRule(String projectId, String id, String name, String description, String tenantId, String securityGroupId, String remoteGroupId, String direction, String remoteIpPrefix, String protocol, Integer portRangeMax, Integer portRangeMin, String etherType) {
+    public SecurityGroupRule(String projectId, String id, String name, String description, String securityGroupId, String remoteGroupId, String direction, String remoteIpPrefix, String protocol, Integer portRangeMax, Integer portRangeMin, String etherType) {
         super(projectId, id, name, description);
-        this.tenantId = tenantId;
         this.securityGroupId = securityGroupId;
         this.remoteGroupId = remoteGroupId;
         this.direction = direction;
@@ -148,14 +132,6 @@ public class SecurityGroupRule extends CustomerResource {
         this.portRangeMax = portRangeMax;
         this.portRangeMin = portRangeMin;
         this.etherType = etherType;
-    }
-
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
     }
 
     public String getSecurityGroupId() {

--- a/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetEntity.java
@@ -39,7 +39,7 @@ public class SubnetEntity extends CustomerResource {
     @JsonProperty("gateway_ip")
     private String gatewayIp;
 
-    @JsonProperty("dhcp_enable")
+    @JsonProperty("enable_dhcp")
     private Boolean dhcpEnable;
 
     @JsonProperty("primary_dns")

--- a/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetEntity.java
@@ -87,9 +87,6 @@ public class SubnetEntity extends CustomerResource {
     @JsonProperty("sort_key")
     private String sortKey;
 
-    @JsonProperty("tenant_id")
-    private String tenantId;
-
     @JsonProperty("subnetpool_id")
     private String subnetpoolId;
 
@@ -158,7 +155,7 @@ public class SubnetEntity extends CustomerResource {
                         String secondaryDns, List<RouteEntity> routeEntities, String gatewayMacAddress, List<String> dnsList,
                         Integer ipVersion, String ipV4RangeId, String ipV6RangeId, String ipv6AddressMode, String ipv6RaMode,
                         Integer revisionNumber, String segmentId, Boolean shared, String sortDir, String sortKey,
-                        String tenantId, String subnetpoolId, boolean dnsPublishFixedIp, List<String> tags, String tagsAny,
+                        String subnetpoolId, boolean dnsPublishFixedIp, List<String> tags, String tagsAny,
                         String notTags, String notTagsAny, String fields, List<String> dnsNameservers, List<AllocationPool> allocationPools,
                         List<HostRoute> hostRoutes, Integer prefixlen, boolean useDefaultSubnetpool, List<String> serviceTypes, String created_at,
                         String updated_at) {
@@ -183,7 +180,6 @@ public class SubnetEntity extends CustomerResource {
         this.shared = shared;
         this.sortDir = sortDir;
         this.sortKey = sortKey;
-        this.tenantId = tenantId;
         this.subnetpoolId = subnetpoolId;
         this.dnsPublishFixedIp = dnsPublishFixedIp;
         this.tags = tags;
@@ -207,7 +203,7 @@ public class SubnetEntity extends CustomerResource {
                 subnetEntity.getSecondaryDns(), subnetEntity.getRouteEntities(), subnetEntity.getGatewayMacAddress(), subnetEntity.getDnsList(),
                 subnetEntity.getIpVersion(), subnetEntity.getIpV4RangeId(), subnetEntity.getIpV6RangeId(), subnetEntity.getIpv6AddressMode(), subnetEntity.getIpv6RaMode(),
                 subnetEntity.getRevisionNumber(), subnetEntity.getSegmentId(), subnetEntity.getShared(), subnetEntity.getSortDir(), subnetEntity.getSortKey(),
-                subnetEntity.getTenantId(), subnetEntity.getSubnetpoolId(), subnetEntity.dnsPublishFixedIp, subnetEntity.getTags(), subnetEntity.getTagsAny(),
+                subnetEntity.getSubnetpoolId(), subnetEntity.dnsPublishFixedIp, subnetEntity.getTags(), subnetEntity.getTagsAny(),
                 subnetEntity.getNotTags(), subnetEntity.getNotTagsAny(), subnetEntity.getFields(), subnetEntity.getDnsNameservers(), subnetEntity.getAllocationPools(),
                 subnetEntity.getHostRoutes(), subnetEntity.getPrefixlen(), subnetEntity.useDefaultSubnetpool, subnetEntity.getServiceTypes(), subnetEntity.getCreated_at(),
                 subnetEntity.getUpdated_at());

--- a/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetWebRequestObject.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/subnet/SubnetWebRequestObject.java
@@ -36,7 +36,7 @@ public class SubnetWebRequestObject extends CustomerResource {
     @JsonProperty("gateway_ip")
     private String gatewayIp;
 
-    @JsonProperty("dhcp_enable")
+    @JsonProperty("enable_dhcp")
     private Boolean dhcpEnable;
 
     @JsonProperty("routes")

--- a/web/src/main/java/com/futurewei/alcor/web/entity/vpc/NetworksWebJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/vpc/NetworksWebJson.java
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.entity.vpc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NetworksWebJson {
+
+    private ArrayList<VpcEntity> networks;
+
+    public NetworksWebJson() {
+    }
+
+    public NetworksWebJson(List<VpcEntity> networks) {
+        this.networks = new ArrayList<>(networks);
+    }
+
+    public ArrayList<VpcEntity> getNetworks() {
+        return networks;
+    }
+
+    public void setNetworks(ArrayList<VpcEntity> networks) {
+        this.networks = networks;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcEntity.java
@@ -50,9 +50,6 @@ public class VpcEntity extends CustomerResource {
     @JsonProperty("shared")
     private boolean shared;
 
-    @JsonProperty("tenant_id")
-    private String tenantId;
-
     @JsonProperty("vlan_transparent")
     private boolean vlanTransparent;
 
@@ -104,7 +101,7 @@ public class VpcEntity extends CustomerResource {
         this.routeEntities = routeEntities;
     }
 
-    public VpcEntity(String projectId, String id, String name, String description, List<RouteEntity> routeEntities, boolean adminStateUp, String dnsDomain, Integer mtu, boolean portSecurityEnabled, String networkType, String physicalNetwork, Integer segmentationId, boolean routerExternal, List<SegmentInfoInVpc> segments, boolean shared, String tenantId, boolean vlanTransparent, boolean isDefault, List availabilityZoneHints, List availabilityZones, List qosPolicyId, Integer revisionNumber, String status, List<String> tags, String created_at, String updated_at, String ipv4AddressScope, String ipv6AddressScope, String l2Adjacency, List<SubnetEntity> subnets, String cidr) {
+    public VpcEntity(String projectId, String id, String name, String description, List<RouteEntity> routeEntities, boolean adminStateUp, String dnsDomain, Integer mtu, boolean portSecurityEnabled, String networkType, String physicalNetwork, Integer segmentationId, boolean routerExternal, List<SegmentInfoInVpc> segments, boolean shared, boolean vlanTransparent, boolean isDefault, List availabilityZoneHints, List availabilityZones, List qosPolicyId, Integer revisionNumber, String status, List<String> tags, String created_at, String updated_at, String ipv4AddressScope, String ipv6AddressScope, String l2Adjacency, List<SubnetEntity> subnets, String cidr) {
         super(projectId, id, name, description);
         this.routeEntities = routeEntities;
         this.adminStateUp = adminStateUp;
@@ -117,7 +114,6 @@ public class VpcEntity extends CustomerResource {
         this.routerExternal = routerExternal;
         this.segments = segments;
         this.shared = shared;
-        this.tenantId = tenantId;
         this.vlanTransparent = vlanTransparent;
         this.isDefault = isDefault;
         this.availabilityZoneHints = availabilityZoneHints;

--- a/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcsWebJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcsWebJson.java
@@ -8,12 +8,12 @@ import java.util.List;
 @Data
 public class VpcsWebJson {
 
-    private ArrayList<VpcEntity> vpcs;
+    private ArrayList<VpcEntity> networks;
 
     public VpcsWebJson() {
     }
 
-    public VpcsWebJson(List<VpcEntity> vpcs) {
-        this.vpcs = new ArrayList<>(vpcs);
+    public VpcsWebJson(List<VpcEntity> networks) {
+        this.networks = new ArrayList<>(networks);
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcsWebJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/vpc/VpcsWebJson.java
@@ -8,12 +8,12 @@ import java.util.List;
 @Data
 public class VpcsWebJson {
 
-    private ArrayList<VpcEntity> networks;
+    private ArrayList<VpcEntity> vpcs;
 
     public VpcsWebJson() {
     }
 
     public VpcsWebJson(List<VpcEntity> networks) {
-        this.networks = new ArrayList<>(networks);
+        this.vpcs = new ArrayList<>(networks);
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/json/JsonHandlerConfiguration.java
+++ b/web/src/main/java/com/futurewei/alcor/web/json/JsonHandlerConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.json;
+
+import com.futurewei.alcor.web.json.handler.JsonReturnFieldFilterHandler;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link JsonReturnFieldFilterHandler} need a fixed position in a list handlers
+ * So need change the order of list hanlders.
+ * we set {@link JsonReturnFieldFilterHandler} before the {@link RequestResponseBodyMethodProcessor}
+ *
+ */
+@Configuration
+public class JsonHandlerConfiguration implements InitializingBean {
+
+    @Autowired
+    private RequestMappingHandlerAdapter adapter;
+
+    @Override
+    public void afterPropertiesSet(){
+        List<HandlerMethodReturnValueHandler> returnValueHandlers = adapter.getReturnValueHandlers();
+        List<HandlerMethodReturnValueHandler> newHandlers = new ArrayList<>();
+        if(null != returnValueHandlers) {
+            newHandlers.addAll(returnValueHandlers);
+            int pos = getHandlerPosition(returnValueHandlers);
+            if(pos != -1){
+                newHandlers.add(pos, new JsonReturnFieldFilterHandler());
+                adapter.setReturnValueHandlers(newHandlers);
+                return;
+            }
+        }
+        newHandlers.add(new JsonReturnFieldFilterHandler());
+        adapter.setReturnValueHandlers(newHandlers);
+    }
+
+    private int getHandlerPosition(List<HandlerMethodReturnValueHandler> returnValueHandlers){
+        for(int i=0;i<returnValueHandlers.size();i++){
+            if(returnValueHandlers.get(i).getClass().isAssignableFrom(RequestResponseBodyMethodProcessor.class)){
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/json/annotation/FieldFilter.java
+++ b/web/src/main/java/com/futurewei/alcor/web/json/annotation/FieldFilter.java
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.json.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * support web controller return a json str with required fields
+ *
+ * @param type the entity class type
+ *
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FieldFilter {
+    Class<?> type();
+}

--- a/web/src/main/java/com/futurewei/alcor/web/json/filter/JacksonJsonFilter.java
+++ b/web/src/main/java/com/futurewei/alcor/web/json/filter/JacksonJsonFilter.java
@@ -1,0 +1,71 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.json.filter;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * a filter class for filter fields from object to json str
+ *
+ */
+@JsonFilter("JacksonFilter")
+public class JacksonJsonFilter extends FilterProvider {
+
+    private List<String> fieldNames;
+
+
+    public JacksonJsonFilter(String[] fieldNames) {
+        this.fieldNames = Arrays.asList(fieldNames);
+    }
+
+    @Override
+    public PropertyFilter findPropertyFilter(Object filterId, Object valueToFilter) {
+        return new SimpleBeanPropertyFilter(){
+            @Override
+            public void serializeAsField(Object pojo, JsonGenerator jgen,
+                                         SerializerProvider provider, PropertyWriter writer) throws Exception {
+
+                if (apply(writer.getName())){
+                    writer.serializeAsField(pojo, jgen, provider);
+                }else if(!jgen.canOmitFields()){
+                    writer.serializeAsOmittedField(pojo, jgen, provider);
+                }
+            }
+        };
+    }
+
+    @Override
+    public BeanPropertyFilter findFilter(Object filterId) {
+        throw new UnsupportedOperationException("Access to deprecated filters not supported");
+    }
+
+    public boolean apply(String name){
+        return fieldNames.contains(name);
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/json/handler/JsonReturnFieldFilterHandler.java
+++ b/web/src/main/java/com/futurewei/alcor/web/json/handler/JsonReturnFieldFilterHandler.java
@@ -70,11 +70,9 @@ public class JsonReturnFieldFilterHandler implements HandlerMethodReturnValueHan
                                          Class<?> clasz) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         // if no fields param in request params, ignore it
-        if(fields != null && fields.length > 0) {
-            JacksonJsonFilter jacksonJsonFilter = new JacksonJsonFilter(fields);
-            mapper.setFilterProvider(jacksonJsonFilter);
-            mapper.addMixIn(clasz, JacksonJsonFilter.class);
-        }
+        JacksonJsonFilter jacksonJsonFilter = new JacksonJsonFilter(fields);
+        mapper.setFilterProvider(jacksonJsonFilter);
+        mapper.addMixIn(clasz, JacksonJsonFilter.class);
         return mapper.writeValueAsString(returnValue);
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/json/handler/JsonReturnFieldFilterHandler.java
+++ b/web/src/main/java/com/futurewei/alcor/web/json/handler/JsonReturnFieldFilterHandler.java
@@ -1,0 +1,80 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.json.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.futurewei.alcor.web.json.annotation.FieldFilter;
+import com.futurewei.alcor.web.json.filter.JacksonJsonFilter;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * in spring mvc, it use {@link HandlerMethodReturnValueHandler} to handler controller return value
+ * in this handler, we return a entity json str which has few required fields
+ *
+ */
+public class JsonReturnFieldFilterHandler implements HandlerMethodReturnValueHandler {
+
+    private static final String FIELD_PARAM_NAME = "fields";
+
+    @Override
+    public boolean supportsReturnType(MethodParameter returnType) {
+        return returnType.getMethodAnnotation(FieldFilter.class) != null;
+    }
+
+    @Override
+    public void handleReturnValue(Object returnValue, MethodParameter returnType,
+                                  ModelAndViewContainer mavContainer, NativeWebRequest webRequest) throws Exception {
+        // set finial handler process it
+        mavContainer.setRequestHandled(true);
+
+        HttpServletResponse response = webRequest.getNativeResponse(HttpServletResponse.class);
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        assert request != null;
+        String[] fields = request.getParameterValues(FIELD_PARAM_NAME);
+
+        assert response != null;
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        // get method annotation and get entity type from annotation
+        FieldFilter fieldFilter = returnType.getMethodAnnotation(FieldFilter.class);
+        assert fieldFilter != null;
+        String returnJsonValue = serializerReturnValue(returnValue, fields, fieldFilter.type());
+        response.getWriter().write(returnJsonValue);
+
+    }
+
+    private String serializerReturnValue(Object returnValue, String[] fields,
+                                         Class<?> clasz) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        // if no fields param in request params, ignore it
+        if(fields != null && fields.length > 0) {
+            JacksonJsonFilter jacksonJsonFilter = new JacksonJsonFilter(fields);
+            mapper.setFilterProvider(jacksonJsonFilter);
+            mapper.addMixIn(clasz, JacksonJsonFilter.class);
+        }
+        return mapper.writeValueAsString(returnValue);
+    }
+}


### PR DESCRIPTION
This PR proposes the following changes:

Features:
- change IgniteClient to Ignite node client
- add support multi params query 
- HTTP response can according to URL query param [field] filter need entity fields
- unit test can initialize the Ignite client bean on demand
- replace webflux with spring gateway route define
- support default value return for HTTP JSON response
- add a new API [/v2.0/extensions] in API GW
- add security group API in API GW
- support return both project_id and tenant_id

Bugs:
- fix VPC , Subnet, Port microservices return value not correct
- move generate UUID from API GW to microservice
- remove some no need check in VPC and Subnet microservices




