### PR TITLE
[Port Manager] Bug Fixes for Delete Ports, Duplicated Port-SG Binding

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/entity/PortNeighbors.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/entity/PortNeighbors.java
@@ -22,6 +22,7 @@ import java.util.Map;
 public class PortNeighbors {
     private String vpcId;
     private Map<String, NeighborInfo> neighbors;
+
     public PortNeighbors() {
 
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/SecurityGroupManagerProxy.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/SecurityGroupManagerProxy.java
@@ -33,7 +33,7 @@ public class SecurityGroupManagerProxy {
     }
 
     public SecurityGroup getSecurityGroup(Object args) throws Exception {
-        String securityGroupId = (String)args;
+        String securityGroupId = (String) args;
         SecurityGroupJson securityGroupJson = securityGroupManagerRestClient.getSecurityGroup(projectId, securityGroupId);
         if (securityGroupJson == null || securityGroupJson.getSecurityGroup() == null) {
             throw new GetSecurityGroupException();
@@ -43,7 +43,7 @@ public class SecurityGroupManagerProxy {
     }
 
     public SecurityGroup getDefaultSecurityGroupEntity(Object args) throws Exception {
-        String tenantId = (String)args;
+        String tenantId = (String) args;
         SecurityGroupJson securityGroupJson = securityGroupManagerRestClient.getDefaultSecurityGroup(projectId, tenantId);
         if (securityGroupJson == null || securityGroupJson.getSecurityGroup() == null) {
             throw new GetSecurityGroupException();
@@ -53,7 +53,7 @@ public class SecurityGroupManagerProxy {
     }
 
     public PortSecurityGroupsJson bindSecurityGroup(Object args) throws Exception {
-        PortEntity portEntity = (PortEntity)args;
+        PortEntity portEntity = (PortEntity) args;
 
         PortSecurityGroupsJson portSecurityGroupsJson = new PortSecurityGroupsJson();
         portSecurityGroupsJson.setPortId(portEntity.getId());
@@ -63,7 +63,7 @@ public class SecurityGroupManagerProxy {
     }
 
     public PortSecurityGroupsJson unbindSecurityGroup(Object args) throws Exception {
-        PortEntity portEntity = (PortEntity)args;
+        PortEntity portEntity = (PortEntity) args;
 
         PortSecurityGroupsJson portSecurityGroupsJson = new PortSecurityGroupsJson();
         portSecurityGroupsJson.setPortId(portEntity.getId());

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -116,10 +116,11 @@ public class PortRepository {
             //Add neighborInfos to neighborCache
             if (neighbors != null) {
                 for (Map.Entry<String, List<NeighborInfo>> entry: neighbors.entrySet()) {
-                    PortNeighbors portNeighbors = neighborCache.get(entry.getKey());
+                    String vpcId = entry.getKey();
+                    PortNeighbors portNeighbors = neighborCache.get(vpcId);
                     if (portNeighbors == null) {
                         portNeighbors = new PortNeighbors();
-                        portNeighbors.setVpcId(entry.getKey());
+                        portNeighbors.setVpcId(vpcId);
                         portNeighbors.setNeighbors(new HashMap<>());
                     }
 
@@ -127,7 +128,7 @@ public class PortRepository {
                         portNeighbors.getNeighbors().put(neighborInfo.getPortId(), neighborInfo);
                     }
 
-                    neighborCache.put(entry.getKey(), portNeighbors);
+                    neighborCache.put(vpcId, portNeighbors);
                 }
             }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -188,13 +188,14 @@ public class PortRepository {
 
     }
 
-    public void deletePortAndNeighbor(String portId) throws Exception {
+    public void deletePortAndNeighbor(PortEntity portEntity) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Delete portEntity from portCache
+            String portId = portEntity.getId();
             portCache.remove(portId);
 
             //Delete neighborInfo from neighborCache
-            PortNeighbors portNeighbors = neighborCache.get(portId);
+            PortNeighbors portNeighbors = neighborCache.get(portEntity.getVpcId());
             if (portNeighbors != null && portNeighbors.getNeighbors().containsKey(portId)) {
                 portNeighbors.getNeighbors().remove(portId);
                 neighborCache.put(portNeighbors.getVpcId(), portNeighbors);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -47,6 +47,7 @@ public class PortRepository {
     @Autowired
     public PortRepository(CacheFactory cacheFactory) {
         portCache = cacheFactory.getCache(PortEntity.class);
+        neighborCache= cacheFactory.getCache(PortNeighbors.class);
     }
 
     @PostConstruct

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Repository;
+
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@ComponentScan(value="com.futurewei.alcor.common.db")
+@ComponentScan(value = "com.futurewei.alcor.common.db")
 @Repository
 public class PortRepository {
     private static final Logger LOG = LoggerFactory.getLogger(PortRepository.class);
@@ -115,7 +116,7 @@ public class PortRepository {
 
             //Add neighborInfos to neighborCache
             if (neighbors != null) {
-                for (Map.Entry<String, List<NeighborInfo>> entry: neighbors.entrySet()) {
+                for (Map.Entry<String, List<NeighborInfo>> entry : neighbors.entrySet()) {
                     String vpcId = entry.getKey();
                     PortNeighbors portNeighbors = neighborCache.get(vpcId);
                     if (portNeighbors == null) {
@@ -124,7 +125,7 @@ public class PortRepository {
                         portNeighbors.setNeighbors(new HashMap<>());
                     }
 
-                    for (NeighborInfo neighborInfo: entry.getValue()) {
+                    for (NeighborInfo neighborInfo : entry.getValue()) {
                         portNeighbors.getNeighbors().put(neighborInfo.getPortId(), neighborInfo);
                     }
 
@@ -145,7 +146,7 @@ public class PortRepository {
             portCache.putAll(portEntityMap);
 
             Map<String, List<PortEntity>> vpcPorts = new HashMap<>();
-            for (PortEntity portEntity: portEntities) {
+            for (PortEntity portEntity : portEntities) {
                 if (!vpcPorts.containsKey(portEntity.getVpcId())) {
                     List<PortEntity> ports = new ArrayList<>();
                     vpcPorts.put(portEntity.getVpcId(), ports);
@@ -155,10 +156,10 @@ public class PortRepository {
             }
 
             //Delete old neighborInfos from neighborCache
-            for (Map.Entry<String, List<PortEntity>> entry: vpcPorts.entrySet()) {
+            for (Map.Entry<String, List<PortEntity>> entry : vpcPorts.entrySet()) {
                 PortNeighbors portNeighbors = neighborCache.get(entry.getKey());
                 if (portNeighbors != null) {
-                    for (PortEntity portEntity: entry.getValue()) {
+                    for (PortEntity portEntity : entry.getValue()) {
                         portNeighbors.getNeighbors().remove(portEntity.getId());
                     }
                 }
@@ -168,7 +169,7 @@ public class PortRepository {
 
             //Add neighborInfos to neighborCache
             if (neighbors != null) {
-                for (Map.Entry<String, List<NeighborInfo>> entry: neighbors.entrySet()) {
+                for (Map.Entry<String, List<NeighborInfo>> entry : neighbors.entrySet()) {
                     PortNeighbors portNeighbors = neighborCache.get(entry.getKey());
                     if (portNeighbors == null) {
                         portNeighbors = new PortNeighbors();
@@ -176,7 +177,7 @@ public class PortRepository {
                         portNeighbors.setNeighbors(new HashMap<>());
                     }
 
-                    for (NeighborInfo neighborInfo: entry.getValue()) {
+                    for (NeighborInfo neighborInfo : entry.getValue()) {
                         portNeighbors.getNeighbors().put(neighborInfo.getPortId(), neighborInfo);
                     }
 
@@ -207,10 +208,10 @@ public class PortRepository {
     }
 
     public PortNeighbors getPortNeighbors(Object arg) throws CacheException {
-        String vpcId = (String)arg;
+        String vpcId = (String) arg;
         PortNeighbors portNeighbors = neighborCache.get(vpcId);
         if (portNeighbors == null) {
-            portNeighbors =  new PortNeighbors(vpcId, null);
+            portNeighbors = new PortNeighbors(vpcId, null);
         }
 
         return portNeighbors;

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -689,7 +689,7 @@ public class PortServiceImpl implements PortService {
             DataPlaneManagerProxy dataPlaneManagerProxy = new DataPlaneManagerProxy(rollbacks);
             dataPlaneManagerProxy.deleteNetworkConfig(networkConfiguration);
 
-            portRepository.deletePortAndNeighbor(portId);
+            portRepository.deletePortAndNeighbor(portEntity);
         } catch (Exception e) {
             exceptionHandle(executor, rollbacks, e);
         }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -158,7 +158,7 @@ public class PortServiceImpl implements PortService {
                 portEntity.getMacAddress());
     }
 
-    private Map<String, List<NeighborInfo>> buildNeighborInfos(List<PortEntity> portEntities, Map<String, NodeInfo> nodeInfoMap) {
+    private Map<String, List<NeighborInfo>> buildNeighborInfosForNewHosts(List<PortEntity> portEntities, Map<String, NodeInfo> nodeInfoMap) {
         Map<String, List<NeighborInfo>> portNeighbors = new HashMap<>();
         for (PortEntity portEntity : portEntities) {
             NodeInfo nodeInfo = nodeInfoMap.get(portEntity.getId());
@@ -267,8 +267,8 @@ public class PortServiceImpl implements PortService {
             }
 
             //Build neighborInfos
-            Map<String, List<NeighborInfo>> neighborInfos =
-                    this.buildNeighborInfos(portEntities, this.getNodeInfos(entities));
+            Map<String, List<NeighborInfo>> neighborInfoMapForNewHosts =
+                    this.buildNeighborInfosForNewHosts(portEntities, this.getNodeInfos(entities));
 
             //Build GoalState and Send it to DPM
             NetworkConfiguration networkConfiguration = NetworkConfigurationUtil.buildNetworkConfiguration(entities);
@@ -278,7 +278,7 @@ public class PortServiceImpl implements PortService {
             }
 
             //Persist portEntities and neighborInfos
-            portRepository.createPortAndNeighborBulk(portEntities, neighborInfos);
+            portRepository.createPortAndNeighborBulk(portEntities, neighborInfoMapForNewHosts);
         } catch (Exception e) {
             exceptionHandle(executor, rollbacks, e);
         }
@@ -633,11 +633,11 @@ public class PortServiceImpl implements PortService {
             }
 
             //Build neighborInfos
-            Map<String, List<NeighborInfo>> portNeighbors =
-                    this.buildNeighborInfos(portEntities, this.getNodeInfos(entities));
+            Map<String, List<NeighborInfo>> neighborInfoMapForUpdatedHosts =
+                    this.buildNeighborInfosForNewHosts(portEntities, this.getNodeInfos(entities));
 
             //Persist portEntities and neighborInfos
-            portRepository.updatePortAndNeighborBulk(portEntities, portNeighbors);
+            portRepository.updatePortAndNeighborBulk(portEntities, neighborInfoMapForUpdatedHosts);
             portWebBulkJson.setPortEntities(portEntities);
         } catch (Exception e) {
             exceptionHandle(executor, rollbacks, e);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -32,12 +32,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Service;
+
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 @Service
-@ComponentScan(value="com.futurewei.alcor.common.utils")
-@ComponentScan(value="com.futurewei.alcor.web.restclient")
+@ComponentScan(value = "com.futurewei.alcor.common.utils")
+@ComponentScan(value = "com.futurewei.alcor.web.restclient")
 public class PortServiceImpl implements PortService {
     private static final Logger LOG = LoggerFactory.getLogger(PortServiceImpl.class);
 
@@ -66,7 +67,7 @@ public class PortServiceImpl implements PortService {
         SubnetManagerProxy subnetManagerProxy = new SubnetManagerProxy(portEntity.getProjectId());
         RouteManagerProxy routeManagerProxy = new RouteManagerProxy(rollbacks);
         if (portEntity.getFixedIps() != null) {
-            for (PortEntity.FixedIp fixedIp: portEntity.getFixedIps()) {
+            for (PortEntity.FixedIp fixedIp : portEntity.getFixedIps()) {
                 executor.runAsyncThenAccept(subnetManagerProxy::getSubnetEntity,
                         ipManagerProxy::allocateFixedIpAddress, fixedIp, fixedIp);
                 executor.runAsync(routeManagerProxy::getRouteBySubnetId, portEntity.getId(), fixedIp.getSubnetId());
@@ -95,7 +96,7 @@ public class PortServiceImpl implements PortService {
         //Verify and bind security group
         SecurityGroupManagerProxy securityGroupManagerProxy = new SecurityGroupManagerProxy(portEntity.getProjectId());
         if (portEntity.getSecurityGroups() != null) {
-            for (String securityGroupId: portEntity.getSecurityGroups()) {
+            for (String securityGroupId : portEntity.getSecurityGroups()) {
                 executor.runAsync(securityGroupManagerProxy::getSecurityGroup, securityGroupId);
             }
             executor.runAsync(securityGroupManagerProxy::bindSecurityGroup, portEntity);
@@ -131,7 +132,7 @@ public class PortServiceImpl implements PortService {
     private Map<String, NodeInfo> getNodeInfos(List<Object> entities) {
         Map<String, NodeInfo> nodeInfoMap = new HashMap<>();
 
-        for (Object entity: entities) {
+        for (Object entity : entities) {
             if (entity instanceof PortBindingHost) {
                 PortBindingHost portBindingHost = (PortBindingHost) entity;
                 nodeInfoMap.put(portBindingHost.getPortId(), portBindingHost.getNodeInfo());
@@ -159,7 +160,7 @@ public class PortServiceImpl implements PortService {
 
     private Map<String, List<NeighborInfo>> buildNeighborInfos(List<PortEntity> portEntities, Map<String, NodeInfo> nodeInfoMap) {
         Map<String, List<NeighborInfo>> portNeighbors = new HashMap<>();
-        for (PortEntity portEntity: portEntities) {
+        for (PortEntity portEntity : portEntities) {
             NodeInfo nodeInfo = nodeInfoMap.get(portEntity.getId());
             if (nodeInfo == null) {
                 continue;
@@ -186,7 +187,8 @@ public class PortServiceImpl implements PortService {
      * configuration of the port to create various required resources for the port.
      * If any exception occurs in the added process, we need to roll back
      * the resource allocated from each micro-service.
-     * @param projectId Project the port belongs to
+     *
+     * @param projectId   Project the port belongs to
      * @param portWebJson Port configuration
      * @return PortWebJson
      * @throws Exception Various exceptions that may occur during the create process
@@ -235,7 +237,8 @@ public class PortServiceImpl implements PortService {
      * configuration of the port to create various required resources for all ports.
      * If an exception occurs during the creation of multiple ports, we need to roll back
      * the resource allocated from each micro-service.
-     * @param projectId Project the port belongs to
+     *
+     * @param projectId       Project the port belongs to
      * @param portWebBulkJson Multiple ports configuration
      * @return PortWebBulkJson
      * @throws Exception Various exceptions that may occur during the create process
@@ -248,7 +251,7 @@ public class PortServiceImpl implements PortService {
         Map<String, Boolean> getNeighborStatus = new HashMap<>();
 
         try {
-            for (PortEntity portEntity: portEntities) {
+            for (PortEntity portEntity : portEntities) {
                 portEntity.setProjectId(projectId);
                 boolean needPortNeighbors = !getNeighborStatus.containsKey(portEntity.getVpcId());
                 createPortAsync(portEntity, executor, rollbacks, needPortNeighbors);
@@ -257,7 +260,7 @@ public class PortServiceImpl implements PortService {
 
             //Wait for all async functions to finish
             List<Object> entities = executor.joinAll();
-            for (PortEntity portEntity: portEntities) {
+            for (PortEntity portEntity : portEntities) {
                 if (portEntity.getBindingHostId() != null) {
                     entities.add(portEntity);
                 }
@@ -286,7 +289,7 @@ public class PortServiceImpl implements PortService {
     private Map<String, Set<String>> fixedIpsToMap(List<PortEntity.FixedIp> fixedIps) {
         Map<String, Set<String>> subnetIpsMap = new HashMap<>();
 
-        for (PortEntity.FixedIp fixedIp: fixedIps) {
+        for (PortEntity.FixedIp fixedIp : fixedIps) {
             if (subnetIpsMap.containsKey(fixedIp.getSubnetId())) {
                 subnetIpsMap.get(fixedIp.getSubnetId()).add(fixedIp.getIpAddress());
             } else {
@@ -303,7 +306,7 @@ public class PortServiceImpl implements PortService {
         List<PortEntity.FixedIp> addFixedIps = new ArrayList<>();
         Map<String, Set<String>> subnetIpsMap = fixedIpsToMap(fixedIps2);
 
-        for (PortEntity.FixedIp fixedIp: fixedIps1) {
+        for (PortEntity.FixedIp fixedIp : fixedIps1) {
             String subnetId = fixedIp.getSubnetId();
             String ipAddress = fixedIp.getIpAddress();
             if (subnetIpsMap.containsKey(subnetId)) {
@@ -319,7 +322,7 @@ public class PortServiceImpl implements PortService {
     }
 
     private boolean updatePortAsync(PortEntity newPortEntity, PortEntity oldPortEntity, AsyncExecutor executor,
-                                 Stack<Rollback> rollbacks) throws Exception {
+                                    Stack<Rollback> rollbacks) throws Exception {
         boolean needNotifyDpm = false;
 
         //Update name
@@ -457,7 +460,7 @@ public class PortServiceImpl implements PortService {
         //Update qos_policy_id
         String newQosPolicyId = newPortEntity.getQosPolicyId();
         String oldQosPolicyId = oldPortEntity.getQosPolicyId();
-        if (newQosPolicyId!= null && !newQosPolicyId.equals(oldQosPolicyId)) {
+        if (newQosPolicyId != null && !newQosPolicyId.equals(oldQosPolicyId)) {
             oldPortEntity.setQosPolicyId(newQosPolicyId);
             needNotifyDpm = true;
         }
@@ -493,7 +496,7 @@ public class PortServiceImpl implements PortService {
         //Get SubnetEntity and subnet route
         SubnetManagerProxy subnetManagerProxy = new SubnetManagerProxy(portEntity.getProjectId());
         RouteManagerProxy routeManagerProxy = new RouteManagerProxy(null);
-        for (PortEntity.FixedIp fixedIp: portEntity.getFixedIps()) {
+        for (PortEntity.FixedIp fixedIp : portEntity.getFixedIps()) {
             executor.runAsync(subnetManagerProxy::getSubnetEntity, fixedIp);
             executor.runAsync(routeManagerProxy::getRouteBySubnetId, portEntity.getId(), fixedIp.getSubnetId());
         }
@@ -501,7 +504,7 @@ public class PortServiceImpl implements PortService {
         //Get SecurityGroupEntity
         SecurityGroupManagerProxy securityGroupManagerProxy = new SecurityGroupManagerProxy(portEntity.getProjectId());
         if (portEntity.getSecurityGroups() != null) {
-            for (String securityGroupId: portEntity.getSecurityGroups()) {
+            for (String securityGroupId : portEntity.getSecurityGroups()) {
                 executor.runAsync(securityGroupManagerProxy::getSecurityGroup, securityGroupId);
             }
         } else {
@@ -525,8 +528,9 @@ public class PortServiceImpl implements PortService {
      * micro-services may need to be updated according to the new configuration of port.
      * If any exception occurs in the updated process, we need to roll back
      * the resource added or deleted operation of each micro-service.
-     * @param projectId Project the port belongs to
-     * @param portId Id of port
+     *
+     * @param projectId   Project the port belongs to
+     * @param portId      Id of port
      * @param portWebJson The new configuration of port
      * @return The new configuration of port
      * @throws Exception Various exceptions that may occur during the update process
@@ -587,7 +591,8 @@ public class PortServiceImpl implements PortService {
      * micro-services may need to be updated according to the new configuration of ports.
      * If an exception occurs during the update, we need to roll back
      * the resource added or deleted operation of each micro-service.
-     * @param projectId Project the port belongs to
+     *
+     * @param projectId       Project the port belongs to
      * @param portWebBulkJson The new configuration of ports
      * @return The new configuration of ports
      * @throws Exception Various exceptions that may occur during the update process
@@ -600,7 +605,7 @@ public class PortServiceImpl implements PortService {
         Map<String, Boolean> getNeighborStatus = new HashMap<>();
 
         try {
-            for (PortEntity portEntity: portWebBulkJson.getPortEntities()) {
+            for (PortEntity portEntity : portWebBulkJson.getPortEntities()) {
                 portEntity.setProjectId(projectId);
                 PortEntity oldPortEntity = portRepository.findPortEntity(portEntity.getId());
                 if (oldPortEntity == null) {
@@ -646,8 +651,9 @@ public class PortServiceImpl implements PortService {
      * the resources requested by the port from each micro-service.
      * If any exception occurs in the deleted process, we need to roll back
      * the resource deletion operation of each micro-service.
+     *
      * @param projectId Project the port belongs to
-     * @param portId Id of port
+     * @param portId    Id of port
      * @throws Exception Various exceptions that may occur during the delete process
      */
     @Override
@@ -699,8 +705,9 @@ public class PortServiceImpl implements PortService {
 
     /**
      * Get the configuration of the port by port id
+     *
      * @param projectId Project the port belongs to
-     * @param portId Id of port
+     * @param portId    Id of port
      * @return PortWebJson
      * @throws Exception Db operation exception
      */
@@ -716,6 +723,7 @@ public class PortServiceImpl implements PortService {
 
     /**
      * Get all port information
+     *
      * @param projectId Project the port belongs to
      * @return A list of port information
      * @throws Exception Db operation exception
@@ -729,7 +737,7 @@ public class PortServiceImpl implements PortService {
             return result;
         }
 
-        for (Map.Entry<String, PortEntity> entry: portEntityMap.entrySet()) {
+        for (Map.Entry<String, PortEntity> entry : portEntityMap.entrySet()) {
             PortWebJson portWebJson = new PortWebJson(entry.getValue());
             result.add(portWebJson);
         }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -95,10 +95,7 @@ public class PortServiceImpl implements PortService {
         //Verify and bind security group
         SecurityGroupManagerProxy securityGroupManagerProxy = new SecurityGroupManagerProxy(portEntity.getProjectId());
         if (portEntity.getSecurityGroups() != null) {
-            for (String securityGroupId: portEntity.getSecurityGroups()) {
-                executor.runAsync(securityGroupManagerProxy::getSecurityGroup, securityGroupId);
-                executor.runAsync(securityGroupManagerProxy::bindSecurityGroup, portEntity);
-            }
+             executor.runAsync(securityGroupManagerProxy::bindSecurityGroup, portEntity);
         } else {
             //Do we need to bind default security group? No, we don't
             executor.runAsync(securityGroupManagerProxy::getDefaultSecurityGroupEntity, portEntity.getTenantId());

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -95,7 +95,10 @@ public class PortServiceImpl implements PortService {
         //Verify and bind security group
         SecurityGroupManagerProxy securityGroupManagerProxy = new SecurityGroupManagerProxy(portEntity.getProjectId());
         if (portEntity.getSecurityGroups() != null) {
-             executor.runAsync(securityGroupManagerProxy::bindSecurityGroup, portEntity);
+            for (String securityGroupId: portEntity.getSecurityGroups()) {
+                executor.runAsync(securityGroupManagerProxy::getSecurityGroup, securityGroupId);
+            }
+            executor.runAsync(securityGroupManagerProxy::bindSecurityGroup, portEntity);
         } else {
             //Do we need to bind default security group? No, we don't
             executor.runAsync(securityGroupManagerProxy::getDefaultSecurityGroupEntity, portEntity.getTenantId());

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -31,6 +31,7 @@ import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class NetworkConfigurationUtil {
 
@@ -45,15 +46,18 @@ public class NetworkConfigurationUtil {
             return null;
         }
 
-        List<NeighborInfo> neighborInfos = null;
+        List<NeighborInfo> neighborInfoList, filteredNeighborInfoList = null;
         if (portNeighborsMap.get(portEntity.getVpcId()).getNeighbors() != null) {
-            neighborInfos = new ArrayList<>(portNeighborsMap.get(
-                    portEntity.getVpcId()).getNeighbors().values());
+            neighborInfoList = new ArrayList<>(portNeighborsMap.get(portEntity.getVpcId()).getNeighbors().values());
+            filteredNeighborInfoList = neighborInfoList.stream()
+                    .filter(n -> !portEntity.getBindingHostId().equals(n.getHostId()))
+                    .collect(Collectors.toList());
         }
 
-        String bindingHostIp = nodeInfoMap.get(portEntity.getId()).getLocalIp();
         List<RouteEntity> routeEntities = portRouteEntityMap.get(portEntity.getId());
-        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, neighborInfos, bindingHostIp);
+        String bindingHostIp = nodeInfoMap.get(portEntity.getId()).getLocalIp();
+
+        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, filteredNeighborInfoList, bindingHostIp);
 
         return internalPortEntity;
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -29,6 +29,7 @@ import com.futurewei.alcor.web.entity.route.RouteEntity;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
+
 import java.util.*;
 
 public class NetworkConfigurationUtil {
@@ -59,6 +60,7 @@ public class NetworkConfigurationUtil {
 
     /**
      * Util method to generate a network configuration message for Data-Plane Manager.
+     *
      * @param entities A list of network entities
      * @return NetworkConfiguration
      * @throws Exception Various exceptions that may occur during the create process
@@ -88,13 +90,13 @@ public class NetworkConfigurationUtil {
             } else if (entity instanceof PortEntity) {
                 portEntities.add((PortEntity) entity);
             } else if (entity instanceof PortBindingRoute) {
-                PortBindingRoute portBindingRoute = (PortBindingRoute)entity;
+                PortBindingRoute portBindingRoute = (PortBindingRoute) entity;
                 if (!portRouteEntityMap.containsKey(portBindingRoute.getPortId())) {
                     portRouteEntityMap.put(portBindingRoute.getPortId(), new ArrayList<>());
                 }
                 portRouteEntityMap.get(portBindingRoute.getPortId()).add(portBindingRoute.getRouteEntity());
             } else if (entity instanceof PortNeighbors) {
-                PortNeighbors portNeighbors = (PortNeighbors)entity;
+                PortNeighbors portNeighbors = (PortNeighbors) entity;
                 portNeighborsMap.put(portNeighbors.getVpcId(), portNeighbors);
             }
         }
@@ -137,7 +139,7 @@ public class NetworkConfigurationUtil {
                 }
 
                 if (!subnetUniqueIds.contains(subnetId)) {
-                    Long tunnelId = subnetEntity.getTenantId() !=null ? Long.valueOf(subnetEntity.getTenantId()): null;
+                    Long tunnelId = subnetEntity.getTenantId() != null ? Long.valueOf(subnetEntity.getTenantId()) : null;
                     InternalSubnetEntity internalSubnetEntity = new InternalSubnetEntity(subnetEntity, tunnelId);
                     networkConfigMessage.addSubnetEntity(internalSubnetEntity);
                     subnetUniqueIds.add(subnetId);
@@ -159,7 +161,7 @@ public class NetworkConfigurationUtil {
                 }
             } else {
                 SecurityGroup securityGroup = null;
-                for (Map.Entry<String, SecurityGroup> entry: securityGroupMap.entrySet()) {
+                for (Map.Entry<String, SecurityGroup> entry : securityGroupMap.entrySet()) {
                     if ("default".equals(entry.getValue().getName())) {
                         securityGroup = entry.getValue();
                         break;


### PR DESCRIPTION
This PR proposes fix to a few Port Manager bugs:
* Delete Port API doesn't correctly update neighborCache resulting in legacy ports in neighborCache. The root cause is that update NeighborCache doesn't use the correct key for query
* Remove duplicated binding between port and security groups for bulk creation
* Remove redundant neighbor_info for ports on the same host