### PR TITLE
Upgrade Alcor Project to Use OpenJDK 11 LTS

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build with Maven
         run: scripts/test-prep.sh

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>
@@ -120,9 +120,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <description>Alcor Controller Project</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <snippets>${project.basedir}/target/generated-snippets/</snippets>
     </properties>
@@ -69,8 +69,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -78,6 +78,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <packaging>pom</packaging>
 
     <dependencies>
-        <!-- Compile -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -19,7 +19,7 @@
     </parent>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>
@@ -82,8 +82,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
 

--- a/services/api_gateway/pom.xml
+++ b/services/api_gateway/pom.xml
@@ -11,9 +11,9 @@
     <description>Alcor API Gateway</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <snippets>${project.basedir}/target/generated-snippets/</snippets>
     </properties>

--- a/services/mac_manager/pom.xml
+++ b/services/mac_manager/pom.xml
@@ -15,7 +15,7 @@
     <description>Virtual MAC Address Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>
     </properties>

--- a/services/node_manager/pom.xml
+++ b/services/node_manager/pom.xml
@@ -15,7 +15,7 @@
     <description>Physical Node Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <ignite.version>2.8.1</ignite.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>

--- a/services/port_manager/pom.xml
+++ b/services/port_manager/pom.xml
@@ -15,7 +15,7 @@
     <description>Alcor Port Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>
     </properties>

--- a/services/private_ip_manager/pom.xml
+++ b/services/private_ip_manager/pom.xml
@@ -15,7 +15,7 @@
     <description>Alcor Private Ip Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>
     </properties>

--- a/services/route_manager/pom.xml
+++ b/services/route_manager/pom.xml
@@ -15,9 +15,9 @@
     <description>Alcor Route Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <snippets>${project.basedir}/target/generated-snippets/</snippets>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
@@ -123,8 +123,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/services/security_group_manager/pom.xml
+++ b/services/security_group_manager/pom.xml
@@ -15,7 +15,7 @@
     <description>Security Group Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>
     </properties>

--- a/services/subnet_manager/pom.xml
+++ b/services/subnet_manager/pom.xml
@@ -15,9 +15,9 @@
     <description>Alcor Subnet Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
 
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
@@ -130,8 +130,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/services/vpc_manager/pom.xml
+++ b/services/vpc_manager/pom.xml
@@ -10,9 +10,9 @@
     <description>VPC Manager Module</description>
 
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <asciidoctor-plugin.version>1.5.6</asciidoctor-plugin.version>
         <swagger2markup.version>1.2.0</swagger2markup.version>
         <snippets>${project.basedir}/target/generated-snippets/</snippets>
@@ -132,8 +132,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
     </properties>
 
     <dependencies>
@@ -75,8 +75,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
__Context__

The Alcor project uses JDK8 (LTS), which was released back on March 2014 and will be ceased for public updates by December 2020. 

The latest LTS version is JDK11 (18.9), which comes with many new features including new improvement on startup, performance, memory usage, diagnostics and productivity. Notably, new features includes
- Modules
- New profiling and diagnostics features including Java Flight Recorder, Java Mission Control, Unified loggging, low-overhead heap profiling, and StackWalker. Java Flight Recorder and Java Mission Control are two commercial features which were only available in Oracle JDK before JDK11.
- New GC mechanisms, for example, ZGC was only available in the commercial version of Oracle JDK but now available in OpenSDK 11.
- Most important to Alcor project is better integration with containers. JDK11 could honor the memory and CPU constraint set by container control groups (cgroups), which was not fully supported in older versions before JDK10 (although backported to Java 8 as of jdk8u191).

__What this PR does__

This PR upgrade Java version from 8 to 11 throughout the Alcor project (except legacy module).

__References__
- https://blogs.oracle.com/java-platform-group/oracle-jdk-releases-for-java-11-and-later
- https://docs.microsoft.com/en-us/azure/developer/java/fundamentals/reasons-to-move-to-java-11