### PR TITLE
RCA of Issue #264 with Fix of Port-SG Concurrent binding

### DIFF
--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupBindingsRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupBindingsRepository.java
@@ -55,7 +55,7 @@ public class SecurityGroupBindingsRepository {
     }
 
 
-    public void addSecurityGroupBinding(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
+    public synchronized void addSecurityGroupBinding(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         try (Transaction tx = bindingCache.getTransaction().start()) {
             String portId = portSecurityGroupsJson.getPortId();
 
@@ -83,7 +83,7 @@ public class SecurityGroupBindingsRepository {
         }
     }
 
-    public void deleteSecurityGroupBinding(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
+    public synchronized void deleteSecurityGroupBinding(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         try (Transaction tx = bindingCache.getTransaction().start()) {
             String portId = portSecurityGroupsJson.getPortId();
 

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
@@ -55,7 +55,7 @@ public class SecurityGroupRepository {
         LOG.info("SecurityGroupRepository init done");
     }
 
-    public void addSecurityGroup(SecurityGroup securityGroup) throws Exception {
+    public synchronized void addSecurityGroup(SecurityGroup securityGroup) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //Add all security group rules
@@ -71,7 +71,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void addSecurityGroupBulk(List<SecurityGroup> securityGroups) throws Exception {
+    public synchronized void addSecurityGroupBulk(List<SecurityGroup> securityGroups) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
             //Add all security group rules
             Map<String, SecurityGroupRule> securityGroupRules = new HashMap<>();
@@ -92,7 +92,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void deleteSecurityGroup(String id) throws Exception {
+    public synchronized void deleteSecurityGroup(String id) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //If securityGroup is null, an exception will be thrown
@@ -125,7 +125,7 @@ public class SecurityGroupRepository {
      * @param defaultSecurityGroup
      * @throws Exception
      */
-    public void createDefaultSecurityGroup(SecurityGroup defaultSecurityGroup) throws Exception {
+    public synchronized void createDefaultSecurityGroup(SecurityGroup defaultSecurityGroup) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //Add all security group rules
@@ -141,7 +141,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void deleteDefaultSecurityGroup(String id) throws Exception {
+    public synchronized void deleteDefaultSecurityGroup(String id) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //If securityGroup is null, an exception will be thrown
@@ -160,7 +160,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void addSecurityGroupRule(SecurityGroup securityGroup, SecurityGroupRule securityGroupRule) throws Exception {
+    public synchronized void addSecurityGroupRule(SecurityGroup securityGroup, SecurityGroupRule securityGroupRule) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //Add security group rule to security group
@@ -174,7 +174,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void addSecurityGroupRuleBulk(List<SecurityGroupRule> securityGroupRules) throws Exception {
+    public synchronized void addSecurityGroupRuleBulk(List<SecurityGroupRule> securityGroupRules) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
             //Add security group rule to security group
             for (SecurityGroupRule securityGroupRule: securityGroupRules) {
@@ -198,7 +198,7 @@ public class SecurityGroupRepository {
         }
     }
 
-    public void deleteSecurityGroupRule(SecurityGroupRule securityGroupRule) throws Exception {
+    public synchronized void deleteSecurityGroupRule(SecurityGroupRule securityGroupRule) throws Exception {
         try (Transaction tx = securityGroupCache.getTransaction().start()) {
 
             //Delete the security group rule from security group


### PR DESCRIPTION
__Context__

Root Cause Analysis to Issue #264:
IgniteClient and ignite server have only one connection, and the transaction is at the connection level, so when a client opens multiple transactions at the same time, only one transaction will be returned. After the first transaction is committed, errors such as "Transaction not found" will not be reported when the subsequent transaction commits.

__Fix__

This PR proposes a fix to the bug by adding _synchronized_ key word to the repo method. 