### PR TITLE
Add performance statistics for port manager

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -35,6 +35,12 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-aop -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>

--- a/lib/src/main/java/com/futurewei/alcor/common/stats/DurationStatistics.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/stats/DurationStatistics.java
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.common.stats;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DurationStatistics {
+}

--- a/lib/src/main/java/com/futurewei/alcor/common/stats/StatisticsAspect.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/stats/StatisticsAspect.java
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.common.stats;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class StatisticsAspect {
+    private static final Logger LOG = LoggerFactory.getLogger(StatisticsAspect.class);
+
+    @Pointcut("@annotation(com.futurewei.alcor.common.stats.DurationStatistics)")
+    public void annotationPointCut() {
+
+    }
+
+    @Around("annotationPointCut()")
+    public Object durationStatistics(ProceedingJoinPoint pjp) throws Throwable {
+        long startTime = 0;
+        long endTime = 0;
+        long duration = 0;
+
+        LOG.info("Calculating duration of {}.{}()...",
+                pjp.getSignature().getDeclaringTypeName(), pjp.getSignature().getName());
+
+        startTime = System.nanoTime();
+
+        Object object = pjp.proceed();
+
+        endTime = System.nanoTime();
+        duration = endTime- startTime;
+
+        LOG.info("{}.{}() startTime: {}ns, endTime: {}ns, duration: {}ms",
+                pjp.getSignature().getDeclaringTypeName(),
+                pjp.getSignature().getName(), startTime, endTime, duration/1000000);
+
+        return object;
+    }
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.controller;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.portmanager.exception.*;
 import com.futurewei.alcor.portmanager.service.PortService;
@@ -22,21 +23,19 @@ import com.futurewei.alcor.web.entity.port.*;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import io.netty.util.internal.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.futurewei.alcor.portmanager.util.RestParameterValidator.checkPort;
 
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class PortController {
 
     @Autowired
@@ -57,6 +56,7 @@ public class PortController {
     @PostMapping({"/project/{project_id}/ports", "v4/{project_id}/ports"})
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public PortWebJson createPort(@PathVariable("project_id") String projectId,
                                          @RequestBody PortWebJson portWebJson) throws Exception {
         PortEntity portEntity = portWebJson.getPortEntity();
@@ -82,6 +82,7 @@ public class PortController {
     @PostMapping({"/project/{project_id}/ports/bulk", "v4/{project_id}/ports/bulk"})
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public PortWebBulkJson createPortBulk(@PathVariable("project_id") String projectId,
                                              @RequestBody PortWebBulkJson portWebBulkJson) throws Exception {
         for (PortEntity portEntity: portWebBulkJson.getPortEntities()) {
@@ -103,6 +104,7 @@ public class PortController {
      * @throws Exception Various exceptions that may occur during the update process
      */
     @PutMapping({"/project/{project_id}/ports/{port_id}", "v4/{project_id}/ports/{port_id}"})
+    @DurationStatistics
     public PortWebJson updatePort(@PathVariable("project_id") String projectId,
                                            @PathVariable("port_id") String portId,
                                            @RequestBody PortWebJson portWebJson) throws Exception {
@@ -121,6 +123,7 @@ public class PortController {
      * @throws Exception Various exceptions that may occur during the update process
      */
     @PutMapping({"/project/{project_id}/ports/bulk", "v4/{project_id}/ports/bulk"})
+    @DurationStatistics
     public PortWebBulkJson updatePortBulk(@PathVariable("project_id") String projectId,
                                          @RequestBody PortWebBulkJson portWebBulkJson) throws Exception {
         for (PortEntity portEntity: portWebBulkJson.getPortEntities()) {
@@ -140,6 +143,7 @@ public class PortController {
      * @throws Exception Various exceptions that may occur during the delete process
      */
     @DeleteMapping({"/project/{project_id}/ports/{port_id}", "v4/{project_id}/ports/{port_id}"})
+    @DurationStatistics
     public void deletePort(@PathVariable("project_id") String projectId,
                                 @PathVariable("port_id") String portId) throws Exception {
         portService.deletePort(projectId, portId);
@@ -154,6 +158,7 @@ public class PortController {
      */
     @FieldFilter(type=PortEntity.class)
     @GetMapping({"/project/{project_id}/ports/{port_id}", "v4/{project_id}/ports/{port_id}"})
+    @DurationStatistics
     public PortWebJson getPort(@PathVariable("project_id") String projectId,
                                     @PathVariable("port_id") String portId) throws Exception {
         return portService.getPort(projectId, portId);
@@ -167,6 +172,7 @@ public class PortController {
      */
     @FieldFilter(type=PortEntity.class)
     @GetMapping({"/project/{project_id}/ports", "v4/{project_id}/ports"})
+    @DurationStatistics
     public PortWebBulkJson listPort(@PathVariable("project_id") String projectId) throws Exception {
         Map<String, Object[]> queryParams =
                 ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.portmanager.entity.PortNeighbors;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
@@ -60,18 +61,22 @@ public class PortRepository {
         LOG.info("PortRepository init done");
     }
 
+    @DurationStatistics
     public PortEntity findPortEntity(String portId) throws CacheException {
         return portCache.get(portId);
     }
 
+    @DurationStatistics
     public Map<String, PortEntity> findAllPortEntities() throws CacheException {
         return portCache.getAll();
     }
 
+    @DurationStatistics
     public Map<String, PortEntity> findAllPortEntities(Map<String, Object[]> queryParams) throws CacheException {
         return portCache.getAll(queryParams);
     }
 
+    @DurationStatistics
     public synchronized void createPortAndNeighbor(PortEntity portEntity, NeighborInfo neighborInfo) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Add portEntity to portCache
@@ -94,6 +99,7 @@ public class PortRepository {
         }
     }
 
+    @DurationStatistics
     public synchronized void updatePortAndNeighbor(PortEntity portEntity, NeighborInfo neighborInfo) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Update portEntity to portCache
@@ -124,6 +130,7 @@ public class PortRepository {
         }
     }
 
+    @DurationStatistics
     public synchronized void createPortAndNeighborBulk(List<PortEntity> portEntities, Map<String, List<NeighborInfo>> neighbors) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Add portEntities to portCache
@@ -155,6 +162,7 @@ public class PortRepository {
         }
     }
 
+    @DurationStatistics
     public synchronized void updatePortAndNeighborBulk(List<PortEntity> portEntities, Map<String, List<NeighborInfo>> neighbors) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Update portEntities to portCache
@@ -208,6 +216,7 @@ public class PortRepository {
 
     }
 
+    @DurationStatistics
     public synchronized void deletePortAndNeighbor(PortEntity portEntity) throws Exception {
         try (Transaction tx = portCache.getTransaction().start()) {
             //Delete portEntity from portCache
@@ -225,6 +234,7 @@ public class PortRepository {
         }
     }
 
+    @DurationStatistics
     public PortNeighbors getPortNeighbors(Object arg) throws CacheException {
         String vpcId = (String) arg;
         PortNeighbors portNeighbors = neighborCache.get(vpcId);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.portmanager.service.implement;
 
 import com.futurewei.alcor.common.executor.AsyncExecutor;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.portmanager.entity.PortBindingHost;
 import com.futurewei.alcor.portmanager.exception.*;
 import com.futurewei.alcor.portmanager.proxy.*;
@@ -194,6 +195,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @Override
+    @DurationStatistics
     public PortWebJson createPort(String projectId, PortWebJson portWebJson) throws Exception {
         LOG.debug("Create port, projectId: {}, PortWebJson: {}", projectId, portWebJson);
 
@@ -244,6 +246,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @Override
+    @DurationStatistics
     public PortWebBulkJson createPortBulk(String projectId, PortWebBulkJson portWebBulkJson) throws Exception {
         Stack<Rollback> rollbacks = new Stack<>();
         AsyncExecutor executor = new AsyncExecutor();
@@ -536,6 +539,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Various exceptions that may occur during the update process
      */
     @Override
+    @DurationStatistics
     public PortWebJson updatePort(String projectId, String portId, PortWebJson portWebJson) throws Exception {
         LOG.debug("Update port, projectId: {}, portId: {}, PortWebJson: {}",
                 projectId, portId, portWebJson);
@@ -598,6 +602,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Various exceptions that may occur during the update process
      */
     @Override
+    @DurationStatistics
     public PortWebBulkJson updatePortBulk(String projectId, PortWebBulkJson portWebBulkJson) throws Exception {
         Stack<Rollback> rollbacks = new Stack<>();
         AsyncExecutor executor = new AsyncExecutor();
@@ -657,6 +662,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Various exceptions that may occur during the delete process
      */
     @Override
+    @DurationStatistics
     public void deletePort(String projectId, String portId) throws Exception {
         LOG.debug("Delete port, projectId: {}, portId: {}", projectId, portId);
 
@@ -712,6 +718,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Db operation exception
      */
     @Override
+    @DurationStatistics
     public PortWebJson getPort(String projectId, String portId) throws Exception {
         PortEntity portEntity = portRepository.findPortEntity(portId);
         if (portEntity == null) {
@@ -729,6 +736,7 @@ public class PortServiceImpl implements PortService {
      * @throws Exception Db operation exception
      */
     @Override
+    @DurationStatistics
     public List<PortWebJson> listPort(String projectId) throws Exception {
         List<PortWebJson> result = new ArrayList<>();
 
@@ -746,6 +754,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception {
         List<PortWebJson> result = new ArrayList<>();
 

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/DataPlaneManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/DataPlaneManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
 
 import org.slf4j.Logger;
@@ -31,17 +32,20 @@ public class DataPlaneManagerRestClient extends AbstractRestClient {
     @Value("${microservices.dataplane.service.url:#{\"\"}}")
     private String dataPlaneManagerUrl;
 
+    @DurationStatistics
     public void createNetworkConfig(NetworkConfiguration message) throws Exception {
         HttpEntity<NetworkConfiguration> request = new HttpEntity<>(message);
         //logger.info(new ObjectMapper().writeValueAsString(request));
         restTemplate.postForObject(dataPlaneManagerUrl, request, Object.class);
     }
 
+    @DurationStatistics
     public void deleteNetworkConfig(NetworkConfiguration message) throws Exception {
         HttpEntity<NetworkConfiguration> request = new HttpEntity<>(message);
         restTemplate.put(dataPlaneManagerUrl, request);
     }
 
+    @DurationStatistics
     public void updateNetworkConfig(NetworkConfiguration message) throws Exception {
         HttpEntity<NetworkConfiguration> request = new HttpEntity<>(message);
         restTemplate.put(dataPlaneManagerUrl, request, String[].class);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/IpManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/IpManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.ip.IpAddrRequest;
 import com.futurewei.alcor.web.entity.ip.IpAddrRequestBulk;
 import com.futurewei.alcor.web.entity.ip.IpAddrState;
@@ -38,6 +39,7 @@ public class IpManagerRestClient extends AbstractRestClient {
         }
     }
 
+    @DurationStatistics
     public void getIpAddress(String rangeId, String ip) throws Exception {
         String url = ipManagerUrl + "/" + rangeId + "/" + ip;
 
@@ -47,6 +49,7 @@ public class IpManagerRestClient extends AbstractRestClient {
         }
     }
 
+    @DurationStatistics
     public IpAddrRequest allocateIpAddress(IpVersion ipVersion, String vpcId, String rangeId, String ipAddr) throws Exception {
         IpAddrRequest ipAddrRequest = new IpAddrRequest();
         if (ipVersion != null) {
@@ -73,6 +76,7 @@ public class IpManagerRestClient extends AbstractRestClient {
         return result;
     }
 
+    @DurationStatistics
     public IpAddrRequestBulk allocateIpAddressBulk(List<IpAddrRequest> ipAddrRequests) throws Exception {
         IpAddrRequestBulk ipAddrRequestBulk = new IpAddrRequestBulk();
         ipAddrRequestBulk.setIpRequests(ipAddrRequests);
@@ -88,13 +92,14 @@ public class IpManagerRestClient extends AbstractRestClient {
         return result;
     }
 
-
+    @DurationStatistics
     public void releaseIpAddress(String rangeId,String ip) throws Exception {
         String url = ipManagerUrl + "/" + rangeId + "/" + ip;
 
         restTemplate.delete(url);
     }
 
+    @DurationStatistics
     public void releaseIpAddressBulk(List<IpAddrRequest> ipAddrRequests) throws Exception {
         IpAddrRequestBulk ipAddrRequestBulk = new IpAddrRequestBulk();
         ipAddrRequestBulk.setIpRequests(ipAddrRequests);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/MacManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/MacManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.mac.MacState;
 import com.futurewei.alcor.web.entity.mac.MacStateJson;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,12 +40,14 @@ public class MacManagerRestClient extends AbstractRestClient {
         return new MacStateJson(macState);
     }
 
+    @DurationStatistics
     public void releaseMacAddress(String macAddress) throws Exception {
         String url = macManagerUrl + "/" + macAddress;
 
         restTemplate.delete(url);
     }
 
+    @DurationStatistics
     public MacStateJson allocateMacAddress(String projectId, String vpcId, String portId, String macAddress) throws Exception {
         MacStateJson macStateJson = newMacStateJson(projectId, vpcId, portId, macAddress);
         HttpEntity<MacStateJson> request = new HttpEntity<>(macStateJson);
@@ -56,6 +59,7 @@ public class MacManagerRestClient extends AbstractRestClient {
         return result;
     }
 
+    @DurationStatistics
     public MacStateJson updateMacAddress(String projectId, String vpcId, String portId, String macAddress) throws Exception {
         MacStateJson macStateJson = newMacStateJson(projectId, vpcId, portId, macAddress);
         HttpEntity<MacStateJson> request = new HttpEntity<>(macStateJson);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/NodeManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/NodeManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.NodeInfoJson;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ public class NodeManagerRestClient extends AbstractRestClient {
     @Value("${microservices.node.service.url:#{\"\"}}")
     private String nodeManagerUrl;
 
+    @DurationStatistics
     public NodeInfoJson getNodeInfo(String nodeId) throws Exception {
         String url = nodeManagerUrl + "/" + nodeId;
         return getRequest(url, NodeInfoJson.class);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/RouteManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/RouteManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.route.RouteWebJson;
 import com.futurewei.alcor.web.entity.route.RoutesWebJson;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +26,7 @@ public class RouteManagerRestClient extends AbstractRestClient {
     @Value("${microservices.route.service.url:#{\"\"}}")
     private String routeManagerUrl;
 
+    @DurationStatistics
     public RoutesWebJson getRouteBySubnetId(String subnetId) throws Exception {
         String url = routeManagerUrl + "/subnets/" + subnetId + "/get";
         RoutesWebJson routesWebJson = restTemplate.getForObject(url, RoutesWebJson.class);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/SecurityGroupManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/SecurityGroupManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.port.PortSecurityGroupsJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +27,7 @@ public class SecurityGroupManagerRestClient extends  AbstractRestClient {
     @Value("${microservices.sg.service.url:#{\"\"}}")
     private String securityGroupManagerUrl;
 
+    @DurationStatistics
     public SecurityGroupJson getSecurityGroup(String projectId, String securityGroupId) throws Exception {
         String url = securityGroupManagerUrl + "/project/" + projectId + "/security-groups/" + securityGroupId;
         SecurityGroupJson securityGroupWebJson = restTemplate.getForObject(url, SecurityGroupJson.class);
@@ -36,6 +38,7 @@ public class SecurityGroupManagerRestClient extends  AbstractRestClient {
         return securityGroupWebJson;
     }
 
+    @DurationStatistics
     public SecurityGroupJson getDefaultSecurityGroup(String projectId, String tenantId) throws Exception {
         String url = securityGroupManagerUrl + "/project/" + projectId + "/security-groups/default/" + tenantId;
         SecurityGroupJson securityGroupWebJson = restTemplate.getForObject(url, SecurityGroupJson.class);
@@ -46,6 +49,7 @@ public class SecurityGroupManagerRestClient extends  AbstractRestClient {
         return securityGroupWebJson;
     }
 
+    @DurationStatistics
     public PortSecurityGroupsJson bindSecurityGroups(String projectId, PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         String url = securityGroupManagerUrl + "/project/" + projectId + "/bind-security-groups";
         HttpEntity<PortSecurityGroupsJson> request = new HttpEntity<>(portSecurityGroupsJson);
@@ -57,6 +61,7 @@ public class SecurityGroupManagerRestClient extends  AbstractRestClient {
         return result;
     }
 
+    @DurationStatistics
     public PortSecurityGroupsJson unbindSecurityGroups(String projectId, PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         String url = securityGroupManagerUrl + "/project/" + projectId + "/unbind-security-groups";
         HttpEntity<PortSecurityGroupsJson> request = new HttpEntity<>(portSecurityGroupsJson);

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/SubnetManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/SubnetManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.subnet.SubnetWebJson;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ public class SubnetManagerRestClient extends AbstractRestClient {
     @Value("${microservices.subnet.service.url:#{\"\"}}")
     private String subnetManagerUrl;
 
+    @DurationStatistics
     public SubnetWebJson getSubnet(String projectId, String subnetId) throws Exception {
         String url = subnetManagerUrl + "/project/" + projectId + "/subnets/" + subnetId;
 

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/VpcManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/VpcManagerRestClient.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.web.restclient;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.vpc.VpcWebJson;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ public class VpcManagerRestClient extends AbstractRestClient {
     @Value("${microservices.vpc.service.url:#{\"\"}}")
     private String vpcManagerUrl;
 
+    @DurationStatistics
     public VpcWebJson getVpc(String projectId, String vpcId) throws Exception {
         String url = vpcManagerUrl + "/project/" + projectId + "/vpcs/" + vpcId;
         VpcWebJson vpcWebJson = restTemplate.getForObject(url, VpcWebJson.class);


### PR DESCRIPTION
This PR proposes the following changes:
- Introduce a new annotation to keep track of method elapse time
- Record Web/Service/Repo layers of port creation
- Record elapse time of downstream microservices 
- Identify a potential bottleneck in one of downstream microservices