### PR TITLE
[Ignite] Set Ignite Thin Client as the Default Client

### DIFF
--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -24,7 +24,7 @@ neutron.url_prefix=/v2.0
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/elastic_ip_manager/src/main/resources/application.properties
+++ b/services/elastic_ip_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=9011
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/mac_manager/src/main/resources/application.properties
+++ b/services/mac_manager/src/main/resources/application.properties
@@ -8,7 +8,7 @@ macmanager.retrylimit = 10
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/node_manager/src/main/resources/application.properties
+++ b/services/node_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=9007
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -13,7 +13,7 @@ microservices.dataplane.service.url=http://localhost:9010/v4/port/
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/private_ip_manager/src/main/resources/application.properties
+++ b/services/private_ip_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=9004
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/route_manager/src/main/resources/application.properties
+++ b/services/route_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=9003
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/security_group_manager/src/main/resources/application.properties
+++ b/services/security_group_manager/src/main/resources/application.properties
@@ -3,7 +3,7 @@ server.port=9008
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/subnet_manager/src/main/resources/application.properties
+++ b/services/subnet_manager/src/main/resources/application.properties
@@ -9,7 +9,7 @@ microservices.ip.service.url=http://localhost:9004/ips/
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks

--- a/services/vpc_manager/src/main/resources/application.properties
+++ b/services/vpc_manager/src/main/resources/application.properties
@@ -6,7 +6,7 @@ microservices.route.service.url=http://localhost:9003/vpcs/
 #####Ignite configuration######
 ignite.host=localhost
 ignite.port=10800
-ignite.thin.client.enable=false
+ignite.thin.client.enable=true
 #ignite.key-store-path=keystore.jks
 #ignite.key-store-password=123456
 #ignite.trust-store-path=truststore.jks


### PR DESCRIPTION
This PR is mainly about enable all micro services to use ignite thin client mode