### PR TITLE
[Nova Integration]Add Quota Web Controller and Update List SG API

### DIFF
--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
 package com.futurewei.alcor.apigateway.route;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
@@ -1,0 +1,21 @@
+package com.futurewei.alcor.apigateway.route;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+
+public class QuotaRouteConfiguration {
+
+    @Value("${microservices.quota.service.url}")
+    private String quotaUrl;
+
+    @Bean
+    public RouteLocator quotaGroupLocator(RouteLocatorBuilder builder) {
+        return builder.routes()
+                .route(r -> r.path("/*/quotas", "/*/quotas/*",
+                        "/project/*/quotas", "/project/*/quotas/*")
+                        .uri(quotaUrl))
+                .build();
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/QuotaRouteConfiguration.java
@@ -4,7 +4,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class QuotaRouteConfiguration {
 
     @Value("${microservices.quota.service.url}")

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -6,6 +6,8 @@ microservices.vpc.service.url=http://192.168.1.17:30001/
 microservices.subnet.service.url=http://192.168.1.17:30006/
 microservices.port.service.url=http://192.168.1.17:30002/
 microservices.sg.service.url=http://192.168.1.17:30000/
+#TODO:Quota API temporarily points to VPC Mgr before Quota Mgr is deployed
+microservices.quota.service.url = http://192.168.1.17:30001/
 
 #####keystone configuration######
 # if enable keystone auth filter

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -2,12 +2,12 @@ server.port=9009
 spring.application.name=alcor-api-gateway
 
 #URL
-microservices.vpc.service.url=http://192.168.1.17:30001/
-microservices.subnet.service.url=http://192.168.1.17:30006/
-microservices.port.service.url=http://192.168.1.17:30002/
-microservices.sg.service.url=http://192.168.1.17:30000/
+microservices.vpc.service.url=http://localhost:9001/
+microservices.subnet.service.url=http://localhost:9002/
+microservices.port.service.url=http://localhost:9006/
+microservices.sg.service.url=http://localhost:9008/
 #TODO:Quota API temporarily points to VPC Mgr before Quota Mgr is deployed
-microservices.quota.service.url = http://192.168.1.17:30001/
+microservices.quota.service.url = http://localhost:9001/
 
 #####keystone configuration######
 # if enable keystone auth filter

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupController.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupController.java
@@ -21,10 +21,11 @@ import com.futurewei.alcor.web.entity.port.PortSecurityGroupsJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupBulkJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupsJson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
+
 import static com.futurewei.alcor.securitygroup.utils.RestParameterValidator.*;
 
 @RestController
@@ -37,7 +38,7 @@ public class SecurityGroupController {
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
     public SecurityGroupJson createSecurityGroup(@PathVariable("project_id") String projectId,
-                                             @RequestBody SecurityGroupJson securityGroupJson) throws Exception {
+                                                 @RequestBody SecurityGroupJson securityGroupJson) throws Exception {
         checkProjectId(projectId);
         checkSecurityGroup(securityGroupJson);
         checkTenantId(securityGroupJson.getSecurityGroup().getTenantId());
@@ -55,7 +56,7 @@ public class SecurityGroupController {
         checkSecurityGroups(securityGroupBulkJson);
 
         String tenantId = null;
-        for (SecurityGroup securityGroup: securityGroupBulkJson.getSecurityGroups()) {
+        for (SecurityGroup securityGroup : securityGroupBulkJson.getSecurityGroups()) {
             checkTenantId(securityGroup.getTenantId());
             if (tenantId == null) {
                 tenantId = securityGroup.getTenantId();
@@ -71,8 +72,8 @@ public class SecurityGroupController {
 
     @PutMapping({"/project/{project_id}/security-groups/{security_group_id}", "v4/{project_id}/security-groups/{security_group_id}"})
     public SecurityGroupJson updateSecurityGroup(@PathVariable("project_id") String projectId,
-                                         @PathVariable("security_group_id") String securityGroupId,
-                                         @RequestBody SecurityGroupJson securityGroupJson) throws Exception {
+                                                 @PathVariable("security_group_id") String securityGroupId,
+                                                 @RequestBody SecurityGroupJson securityGroupJson) throws Exception {
         checkProjectId(projectId);
         checkSecurityGroup(securityGroupJson);
         checkSecurityGroupId(securityGroupId);
@@ -82,7 +83,7 @@ public class SecurityGroupController {
 
     @DeleteMapping({"/project/{project_id}/security-groups/{security_group_id}", "v4/{project_id}/security-groups/{security_group_id}"})
     public void deleteSecurityGroup(@PathVariable("project_id") String projectId,
-                                @PathVariable("security_group_id") String securityGroupId) throws Exception {
+                                    @PathVariable("security_group_id") String securityGroupId) throws Exception {
         checkProjectId(projectId);
         checkSecurityGroupId(securityGroupId);
 
@@ -91,7 +92,7 @@ public class SecurityGroupController {
 
     @GetMapping({"/project/{project_id}/security-groups/{security_group_id}", "v4/{project_id}/security-groups/{security_group_id}"})
     public SecurityGroupJson getSecurityGroup(@PathVariable("project_id") String projectId,
-                                      @PathVariable("security_group_id") String securityGroupId) throws Exception {
+                                              @PathVariable("security_group_id") String securityGroupId) throws Exception {
         checkProjectId(projectId);
         checkSecurityGroupId(securityGroupId);
 
@@ -108,7 +109,7 @@ public class SecurityGroupController {
     }
 
     @GetMapping({"/project/{project_id}/security-groups", "v4/{project_id}/security-groups"})
-    public List<SecurityGroupJson> listSecurityGroup(@PathVariable("project_id") String projectId) throws Exception {
+    public SecurityGroupsJson listSecurityGroup(@PathVariable("project_id") String projectId) throws Exception {
         checkProjectId(projectId);
 
         return securityGroupService.listSecurityGroup();
@@ -118,7 +119,7 @@ public class SecurityGroupController {
         checkProjectId(projectId);
         checkPortId(portSecurityGroupsJson.getPortId());
 
-        for (String securityGroupId: portSecurityGroupsJson.getSecurityGroups()) {
+        for (String securityGroupId : portSecurityGroupsJson.getSecurityGroups()) {
             checkSecurityGroupId(securityGroupId);
         }
     }
@@ -127,7 +128,7 @@ public class SecurityGroupController {
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
     public PortSecurityGroupsJson bindSecurityGroups(@PathVariable("project_id") String projectId,
-                                                              @RequestBody PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
+                                                     @RequestBody PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         checkPortSecurityGroups(projectId, portSecurityGroupsJson);
 
         return securityGroupService.bindSecurityGroups(portSecurityGroupsJson);
@@ -137,7 +138,7 @@ public class SecurityGroupController {
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
     public PortSecurityGroupsJson unbindSecurityGroups(@PathVariable("project_id") String projectId,
-                                                              @RequestBody PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
+                                                       @RequestBody PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         checkPortSecurityGroups(projectId, portSecurityGroupsJson);
 
         return securityGroupService.unbindSecurityGroups(portSecurityGroupsJson);

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupService.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupService.java
@@ -18,9 +18,8 @@ package com.futurewei.alcor.securitygroup.service;
 import com.futurewei.alcor.web.entity.port.PortSecurityGroupsJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupBulkJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupsJson;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 public interface SecurityGroupService {
@@ -36,7 +35,7 @@ public interface SecurityGroupService {
 
     SecurityGroupJson getDefaultSecurityGroup(String projectId, String tenantId) throws Exception;
 
-    List<SecurityGroupJson> listSecurityGroup() throws Exception;
+    SecurityGroupsJson listSecurityGroup() throws Exception;
 
     PortSecurityGroupsJson bindSecurityGroups(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception;
 

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
@@ -47,7 +47,7 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
         List<SecurityGroupRule> securityGroupRules = new ArrayList<>();
         List<SecurityGroupRule.EtherType> etherTypes = Arrays.asList(SecurityGroupRule.EtherType.IPV4, SecurityGroupRule.EtherType.IPV6);
 
-        for (SecurityGroupRule.EtherType etherType: etherTypes) {
+        for (SecurityGroupRule.EtherType etherType : etherTypes) {
             SecurityGroupRule securityGroupRule = new SecurityGroupRule();
 
             securityGroupRule.setId(UUID.randomUUID().toString());
@@ -131,7 +131,7 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
         String currentTime = TimeUtil.getCurrentTime();
         SecurityGroup defaultSecurityGroup = null;
 
-        for (SecurityGroup securityGroup: securityGroups) {
+        for (SecurityGroup securityGroup : securityGroups) {
             if (isDefaultSecurityGroup(securityGroup)) {
                 if (defaultSecurityGroup != null) {
                     throw new DefaultSecurityGroupNotUnique();
@@ -161,8 +161,8 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
 
             String description = defaultSecurityGroup.getDescription();
             createDefaultSecurityGroup(tenantId, projectId, description);
-        } else if (oldDefaultSecurityGroup == null){
-            createDefaultSecurityGroup(tenantId, projectId,null);
+        } else if (oldDefaultSecurityGroup == null) {
+            createDefaultSecurityGroup(tenantId, projectId, null);
         }
 
         securityGroupRepository.addSecurityGroupBulk(securityGroups);
@@ -264,27 +264,26 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
     }
 
     @Override
-    public List<SecurityGroupJson> listSecurityGroup() throws Exception {
-        List<SecurityGroupJson> securityGroups = new ArrayList<>();
+    public SecurityGroupsJson listSecurityGroup() throws Exception {
+        List<SecurityGroup> securityGroups = new ArrayList<>();
 
         Map<String, SecurityGroup> securityGroupMap = securityGroupRepository.getAllSecurityGroups();
         if (securityGroupMap == null) {
-            return securityGroups;
+            return new SecurityGroupsJson();
         }
 
-        for (Map.Entry<String, SecurityGroup> entry: securityGroupMap.entrySet()) {
+        for (Map.Entry<String, SecurityGroup> entry : securityGroupMap.entrySet()) {
             //Skip the internal default security group
             if (entry.getKey().equals(entry.getValue().getTenantId())) {
                 continue;
             }
 
-            SecurityGroupJson securityGroup = new SecurityGroupJson(entry.getValue());
-            securityGroups.add(securityGroup);
+            securityGroups.add(entry.getValue());
         }
 
         LOG.info("List security group success");
 
-        return securityGroups;
+        return new SecurityGroupsJson(securityGroups);
     }
 
     @Override

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.vpcmanager.controller;
+
+import com.futurewei.alcor.web.entity.quota.QuotaEntity;
+import com.futurewei.alcor.web.entity.quota.QuotaWebJson;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+////////////////////////////////////////////////////////////////////
+//NOTE: QuotaController is hosted temporarily in VPC Mgr
+//      before Quote Mgr is deployed
+////////////////////////////////////////////////////////////////////
+@RestController
+public class QuotaController {
+
+    /**
+     * Lists quota to which the project has access
+     *
+     * @param projectId
+     * @return QuotaWebJson
+     * @throws Exception
+     */
+    @RequestMapping(
+            method = GET,
+            value = "/project/{projectId}/quotas/{projectId}")
+    public QuotaWebJson getQuotaByProjectId(@PathVariable String projectId) throws Exception {
+
+        QuotaEntity defaultQuota = this.createDefaultQuotaEntity();
+
+        return new QuotaWebJson(defaultQuota);
+    }
+
+    private QuotaEntity createDefaultQuotaEntity() {
+        return new QuotaEntity(50, 10, 50, -1, 10,
+                10, 100, 10, -1);
+    }
+}

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
@@ -48,7 +48,7 @@ public class QuotaController {
     }
 
     private QuotaEntity createDefaultQuotaEntity() {
-        return new QuotaEntity(50, 10, 50, -1, 10,
+        return new QuotaEntity(50, 10, 1000, -1, 10,
                 10, 100, 10, -1);
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/quota/QuotaEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/quota/QuotaEntity.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.web.entity.quota;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class QuotaEntity {
+
+    @JsonProperty("floatingip")
+    private int floatingIp;
+
+    @JsonProperty("network")
+    private int network;
+
+    @JsonProperty("port")
+    private int port;
+
+    @JsonProperty("rbac_policy")
+    private int rbacPolicy;
+
+    @JsonProperty("router")
+    private int router;
+
+    @JsonProperty("security_group")
+    private int securityGroup;
+
+    @JsonProperty("security_group_rule")
+    private int securityGroupRule;
+
+    @JsonProperty("subnet")
+    private long subnet;
+
+    @JsonProperty("subnetpool")
+    private long subnetPool;
+
+    public QuotaEntity() {
+    }
+
+    public QuotaEntity(int floatingIp, int network, int port, int rbacPolicy, int router, int securityGroup,
+                       int securityGroupRule, int subnet, int subnetPool) {
+        this.floatingIp = floatingIp;
+        this.network = network;
+        this.port = port;
+        this.rbacPolicy = rbacPolicy;
+        this.router = router;
+        this.securityGroup = securityGroup;
+        this.securityGroupRule = securityGroupRule;
+        this.subnet = subnet;
+        this.subnetPool = subnetPool;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/quota/QuotaWebJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/quota/QuotaWebJson.java
@@ -13,25 +13,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
         See the License for the specific language governing permissions and
         limitations under the License.
 */
-package com.futurewei.alcor.web.entity.securitygroup;
+package com.futurewei.alcor.web.entity.quota;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Data
-public class SecurityGroupsJson {
+public class QuotaWebJson {
 
-    @JsonProperty("security_groups")
-    private ArrayList<SecurityGroup> securityGroups;
+    private QuotaEntity quota;
 
-    public SecurityGroupsJson() {
-
+    public QuotaWebJson() {
     }
 
-    public SecurityGroupsJson(List<SecurityGroup> securityGroups) {
-        this.securityGroups = new ArrayList<>(securityGroups);
+    public QuotaWebJson(QuotaEntity quotaEntity) {
+        this.quota = quotaEntity;
     }
+
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroup.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroup.java
@@ -91,13 +91,13 @@ public class SecurityGroup extends CustomerResource {
         this.updateAt = updateAt;
     }
 
-    @Override
-    public String toString() {
-        return "SecurityGroup{" +
-                "tenantId='" + tenantId + '\'' +
-                ", securityGroupRules=" + securityGroupRules +
-                ", createAt='" + createAt + '\'' +
-                ", updateAt='" + updateAt + '\'' +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "SecurityGroup{" +
+//                "tenantId='" + tenantId + '\'' +
+//                ", securityGroupRules=" + securityGroupRules +
+//                ", createAt='" + createAt + '\'' +
+//                ", updateAt='" + updateAt + '\'' +
+//                '}';
+//    }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupJson.java
@@ -36,10 +36,10 @@ public class SecurityGroupJson {
         this.securityGroup = securityGroup;
     }
 
-    @Override
-    public String toString() {
-        return "SecurityGroupJson{" +
-                "securityGroup=" + securityGroup +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "SecurityGroupJson{" +
+//                "securityGroup=" + securityGroup +
+//                '}';
+//    }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
@@ -198,17 +198,17 @@ public class SecurityGroupRule extends CustomerResource {
         this.etherType = etherType;
     }
 
-    @Override
-    public String toString() {
-        return "SecurityGroupRuleJson{" +
-                "securityGroupId='" + securityGroupId + '\'' +
-                ", remoteGroupId='" + remoteGroupId + '\'' +
-                ", direction='" + direction + '\'' +
-                ", remoteIpPrefix='" + remoteIpPrefix + '\'' +
-                ", protocol='" + protocol + '\'' +
-                ", portRangeMax=" + portRangeMax +
-                ", portRangeMin=" + portRangeMin +
-                ", etherType='" + etherType + '\'' +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "SecurityGroupRuleJson{" +
+//                "securityGroupId='" + securityGroupId + '\'' +
+//                ", remoteGroupId='" + remoteGroupId + '\'' +
+//                ", direction='" + direction + '\'' +
+//                ", remoteIpPrefix='" + remoteIpPrefix + '\'' +
+//                ", protocol='" + protocol + '\'' +
+//                ", portRangeMax=" + portRangeMax +
+//                ", portRangeMin=" + portRangeMin +
+//                ", etherType='" + etherType + '\'' +
+//                '}';
+//    }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRuleJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRuleJson.java
@@ -36,10 +36,10 @@ public class SecurityGroupRuleJson {
         this.securityGroupRule = securityGroupRule;
     }
 
-    @Override
-    public String toString() {
-        return "SecurityGroupRuleJson{" +
-                "securityGroupRule=" + securityGroupRule +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "SecurityGroupRuleJson{" +
+//                "securityGroupRule=" + securityGroupRule +
+//                '}';
+//    }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupsJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupsJson.java
@@ -1,0 +1,22 @@
+package com.futurewei.alcor.web.entity.securitygroup;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class SecurityGroupsJson {
+
+    @JsonProperty("security_groups")
+    private ArrayList<SecurityGroup> securityGroups;
+
+    public SecurityGroupsJson() {
+
+    }
+
+    public SecurityGroupsJson(List<SecurityGroup> securityGroups) {
+        this.securityGroups = new ArrayList<>(securityGroups);
+    }
+}


### PR DESCRIPTION
This PR proposes the following changes to bridge the gap for Nova Integration:
- Add quota entity classes, quota routes in API GW, and quota web controller to return default quota for any given project. Note that it is temporarily hosted in VPC Mgr and will be moved to a new Quota Mgr.
- Add a new web class SecurityGroupsJson to show an array of SGs in the List SG API
- Remove toString in SG web classes (which caused integration failure)
- Fix API GW application properties