### PR TITLE
[Common Lib] Fix Distribution Lock Name Bug

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/db/IDistributedLock.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/IDistributedLock.java
@@ -30,4 +30,19 @@ public interface IDistributedLock {
      */
     Boolean tryLock(String lockKey);
 
+    /**
+     * a prefix for each lock
+     * @return
+     */
+    String getLockPrefix();
+
+    /**
+     * return a combine real key for distribution lock
+     * @param key
+     * @return
+     */
+    default String getRealKey(String key) {
+        return getLockPrefix() + " lock:" + key;
+    }
+
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDistributedLock.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDistributedLock.java
@@ -59,7 +59,7 @@ public class IgniteClientDistributedLock implements IDistributedLock {
     @Override
     public void lock(String lockKey) throws DistributedLockException {
         boolean locked = false;
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             while (!locked) {
@@ -76,7 +76,7 @@ public class IgniteClientDistributedLock implements IDistributedLock {
 
     @Override
     public Boolean tryLock(String lockKey){
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
         try {
             return cache.putIfAbsent(lockKeyWithPrefix, "lock");
         }catch (Exception e) {
@@ -87,7 +87,7 @@ public class IgniteClientDistributedLock implements IDistributedLock {
 
     @Override
     public void unlock(String lockKey) throws DistributedLockException {
-        String lockKeyWithPrefix = this.name + "lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             cache.remove(lockKeyWithPrefix);
@@ -97,4 +97,8 @@ public class IgniteClientDistributedLock implements IDistributedLock {
         }
     }
 
+    @Override
+    public String getLockPrefix() {
+        return this.name;
+    }
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDistributedLock.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDistributedLock.java
@@ -58,7 +58,7 @@ public class IgniteDistributedLock implements IDistributedLock {
     @Override
     public void lock(String lockKey) throws DistributedLockException {
         boolean locked = false;
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             while (!locked) {
@@ -75,7 +75,7 @@ public class IgniteDistributedLock implements IDistributedLock {
 
     @Override
     public Boolean tryLock(String lockKey){
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
         try {
             return cache.putIfAbsent(lockKeyWithPrefix, "lock");
         } catch (Exception e) {
@@ -85,8 +85,13 @@ public class IgniteDistributedLock implements IDistributedLock {
     }
 
     @Override
+    public String getLockPrefix() {
+        return this.name;
+    }
+
+    @Override
     public void unlock(String lockKey) throws DistributedLockException {
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             cache.remove(lockKeyWithPrefix);
@@ -94,5 +99,7 @@ public class IgniteDistributedLock implements IDistributedLock {
             logger.log(Level.WARNING, "Ignite unlock error:" + e.getMessage());
             throw new DistributedLockException(e.getMessage());
         }
+
+
     }
 }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisDistributedLock.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/redis/RedisDistributedLock.java
@@ -44,7 +44,7 @@ public class RedisDistributedLock implements IDistributedLock {
     @Override
     public void lock(String lockKey) throws DistributedLockException {
         Boolean locked = false;
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             while (!locked) {
@@ -63,7 +63,7 @@ public class RedisDistributedLock implements IDistributedLock {
 
     @Override
     public void unlock(String lockKey) throws DistributedLockException {
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
 
         try {
             redisTemplate.delete(lockKeyWithPrefix);
@@ -75,7 +75,7 @@ public class RedisDistributedLock implements IDistributedLock {
 
     @Override
     public Boolean tryLock(String lockKey){
-        String lockKeyWithPrefix = this.name + " lock:" + lockKey;
+        String lockKeyWithPrefix = getRealKey(lockKey);
         try {
             return redisTemplate.opsForValue().setIfAbsent(lockKeyWithPrefix, "lock",
                     this.expireTime, TimeUnit.SECONDS);
@@ -83,5 +83,10 @@ public class RedisDistributedLock implements IDistributedLock {
             logger.log(Level.WARNING, "Redis lock error:" + e.getMessage());
             return false;
         }
+    }
+
+    @Override
+    public String getLockPrefix() {
+        return this.name;
     }
 }


### PR DESCRIPTION
This PR fix a bug in distribution lock common lib:

-   Now each distribution lock methods combine a db lock key, it may cause different names and can't remove this lock. 
-   So add a common method to combine a lock key name.