### PR TITLE
[Hotfix] Add missing configuration annotation to EIP RestClient

### DIFF
--- a/web/src/main/java/com/futurewei/alcor/web/restclient/ElasticIpManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/ElasticIpManagerRestClient.java
@@ -23,6 +23,7 @@ import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
 import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfoWrapper;
 import com.futurewei.alcor.web.entity.elasticip.ElasticIpsInfoWrapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.*;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
@@ -31,6 +32,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
+@Configuration
 public class ElasticIpManagerRestClient extends AbstractRestClient {
     @Value("${microservices.elasticip.service.url:#{\"\"}}")
     private String elasticIpManagerUrl;


### PR DESCRIPTION
This PR proposes a hotfix to a missing qualifying bean issue introduced by a recent change. 

__Client Logs__

The symptom is DELETE /ports/<port_id> call failed with the following exception
2020-07-22 11:29:19.604 13272 DEBUG neutronclient.v2_0.client [-] Error message: {"timestamp":"2020-07-22T17:49:52.661+0000","status":500,"error":"Internal Server Error","message":"No qualifying bean of type 'com.futurewei.alcor.web.restclient.ElasticIpManagerRestClient' available","path":"/project/f282163e-0698-40d0-8da9-07661a2ce609/ports/f6a00f29-d997-476e-aa1b-77e55bf8cfdc"} _handle_fault_response /usr/lib/python2.7/dist-packages/neutronclient/v2_0/client.py:259

__Server Logs__
2020-07-22 19:34:10.521  INFO 1 --- [nio-8080-exec-7] c.f.alcor.common.stats.StatisticsAspect  : com.futurewei.alcor.web.restclient.IpManagerRestClient.allocateIpAddress() startTime: 18652863559180410ns, endTime: 18652863569553127ns, duration: 10ms
2020-07-22 19:34:10.521 DEBUG 1 --- [nio-8080-exec-7] o.s.web.servlet.DispatcherServlet        : Failed to complete request: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.futurewei.alcor.web.restclient.ElasticIpManagerRestClient' available
2020-07-22 19:34:10.522 DEBUG 1 --- [nio-8080-exec-7] o.a.c.loader.WebappClassLoaderBase       :     findClass(jdk.internal.reflect.GeneratedMethodAccessor51)
2020-07-22 19:34:10.523 DEBUG 1 --- [nio-8080-exec-7] o.a.c.loader.WebappClassLoaderBase       :     --> Returning ClassNotFoundException
2020-07-22 19:34:10.523 ERROR 1 --- [nio-8080-exec-7] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.futurewei.alcor.web.restclient.ElasticIpManagerRestClient' available] with root cause

org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'com.futurewei.alcor.web.restclient.ElasticIpManagerRestClient' available
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:351) ~[spring-beans-5.2.5.RELEASE.jar!/:5.2.5.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:342) ~[spring-beans-5.2.5.RELEASE.jar!/:5.2.5.RELEASE]

__Fix__

Add missing configuration annotation to the new ElasticIpManagerRestClient in Port Mgr.