### PR TITLE
[Integration] Fix VPC/Subnet/Port/SG/EIP Misc, and Add SG Query

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/utils/ControllerUtil.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/utils/ControllerUtil.java
@@ -119,7 +119,7 @@ public class ControllerUtil {
         }
 
         // remove "&" in the tail
-        return filterStrBuilder.substring(0, -1);
+        return filterStrBuilder.substring(0, filterStrBuilder.length() - 1);
     }
 
     private static <T> Field[] getAllDeclaredFields(Class<T> tClass){

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
@@ -247,7 +247,7 @@ public class KeystoneClient {
                         te.setDomainName(domain.path(JSON_NAME_KEY).asText(""));
                     }
 
-                    projectId = transformProjectIdToUuid(projectId);
+                    //projectId = transformProjectIdToUuid(projectId);
                     te.setProjectId(projectId);
                     te.setProjectName(project.path(JSON_NAME_KEY).asText(""));
                     cache.put(token, te);

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthWebFilter.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthWebFilter.java
@@ -27,6 +27,7 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
+@Deprecated
 public class KeystoneAuthWebFilter implements WebFilter {
 
     private static final String AUTHORIZE_TOKEN = "X-Auth-Token";

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/SubnetManagerServiceProxy.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/SubnetManagerServiceProxy.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
+@Deprecated
 //@Service
 public class SubnetManagerServiceProxy {
 

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/VpcManagerServiceProxy.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/proxies/VpcManagerServiceProxy.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
+@Deprecated
 //@Service
 public class VpcManagerServiceProxy {
 

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebConfiguration.java
@@ -28,6 +28,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
+@Deprecated
 //@Configuration
 //@EnableConfigurationProperties(SubnetWebDestinations.class)
 public class SubnetWebConfiguration {

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebDestinations.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebDestinations.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.validation.constraints.NotNull;
 
+@Deprecated
 @Data
 //@ConfigurationProperties(prefix = "subnet.destinations")
 public class SubnetWebDestinations {

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebHandlers.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/subnet/SubnetWebHandlers.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.BodyInserters.fromObject;
 
+@Deprecated
 public class SubnetWebHandlers {
 
     private SubnetManagerServiceProxy serviceProxy;

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebConfiguration.java
@@ -1,18 +1,20 @@
 /*
-Copyright 2019 The Alcor Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-*/
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
 
 package com.futurewei.alcor.apigateway.vpc;
 
@@ -28,6 +30,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.server.RequestPredicates.*;
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
+@Deprecated
 //@Configuration
 //@EnableConfigurationProperties(VpcWebDestinations.class)
 public class VpcWebConfiguration {

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebDestinations.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebDestinations.java
@@ -1,18 +1,20 @@
 /*
-Copyright 2019 The Alcor Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-*/
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
 
 package com.futurewei.alcor.apigateway.vpc;
 
@@ -22,6 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.validation.constraints.NotNull;
 
+@Deprecated
 @Data
 //@ConfigurationProperties(prefix = "vpc.destinations")
 public class VpcWebDestinations {

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebHandlers.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/vpc/VpcWebHandlers.java
@@ -1,18 +1,20 @@
 /*
-Copyright 2019 The Alcor Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-        you may not use this file except in compliance with the License.
-        You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-        Unless required by applicable law or agreed to in writing, software
-        distributed under the License is distributed on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        See the License for the specific language governing permissions and
-        limitations under the License.
-*/
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
 
 package com.futurewei.alcor.apigateway.vpc;
 
@@ -30,6 +32,7 @@ import java.util.UUID;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.web.reactive.function.BodyInserters.fromObject;
 
+@Deprecated
 public class VpcWebHandlers {
 
     private VpcManagerServiceProxy serviceProxy;

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthGwFilterTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthGwFilterTest.java
@@ -48,7 +48,7 @@ public class KeystoneAuthGwFilterTest {
 
     private static final String AUTHORIZE_TOKEN = "X-Auth-Token";
     private static final String TEST_TOKEN = "gaaaaaBex0xWssdfsadfDSSDFSDF";
-    private static final String TEST_PROJECT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private static final String TEST_PROJECT_ID = "aaaaaaaabbbbccccddddeeeeeeeeeeee";
     private static final String TEST_ERROR_TOKEN = "testerrortoken";
 
     private KeystoneAuthGwFilter filter;

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneAuthWebFilterTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 public class KeystoneAuthWebFilterTest {
 
     private static final String TEST_TOKEN = "gaaaaaBex0xWssdfsadfDSSDFSDF";
-    private static final String TEST_PROJECT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private static final String TEST_PROJECT_ID = "aaaaaaaabbbbccccddddeeeeeeeeeeee";
     private static final String TEST_ERROR_TOKEN = "testerrortoken";
 
     @Autowired

--- a/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneClientTest.java
+++ b/services/api_gateway/src/test/java/com/futurewei/alcor/apigateway/KeystoneClientTest.java
@@ -74,7 +74,7 @@ public class KeystoneClientTest {
     private static final String TEST_INVALID_TOKEN = "eaaaaaBex0xWssdfsadfDSSDFSDF";
 
 
-    private static final String TEST_PROJECT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private static final String TEST_PROJECT_ID = "aaaaaaaabbbbccccddddeeeeeeeeeeee";
 
     private static final String TOKEN_URL = "/auth/tokens";
     private static final String BASE_URL = "http://localhost/identity";

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -23,6 +23,7 @@ import com.futurewei.alcor.web.entity.port.*;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import io.netty.util.internal.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,10 @@ public class PortController {
 
     @Autowired
     private HttpServletRequest request;
+
+    @Value("${alcor.vif_type}")
+    private String vifType;
+
     /**
      * Create a port, and call the interfaces of each micro-service according to the
      * configuration of the port to create various required resources for the port.
@@ -65,6 +70,10 @@ public class PortController {
         }
 
         checkPort(portEntity);
+
+        if(portEntity.getBindingVifType() == null){
+            portEntity.setBindingVifType(vifType);
+        }
 
         return portService.createPort(projectId, portWebJson);
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -176,7 +176,7 @@ public class PortController {
     public PortWebBulkJson listPort(@PathVariable("project_id") String projectId) throws Exception {
         Map<String, Object[]> queryParams =
                 ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);
-        queryParams.put("project_id", new String[]{projectId});
+        queryParams.put("projectId", new String[]{projectId});
         List<PortWebJson> portWebJsonList = portService.listPort(projectId, queryParams);
         List<PortEntity> portsList = portWebJsonList.stream()
                 .map(PortWebJson::getPortEntity)

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -29,3 +29,12 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=port-manager.log
 #logging.level.root=INFO
+
+####neutron port configuration####
+# TODO implement im future
+#The type of which mechanism is used for the port.
+# An API consumer like nova can use this to determine an appropriate way to attach a device (for example an interface of a virtual server) to the port.
+# Available values currently defined includes ovs, bridge, macvtap, hw_veb, hostdev_physical, vhostuser, distributed and other.
+# There are also special values: unbound and binding_failed. unbound means the port is not bound to a networking back-end.
+# binding_failed means an error that the port failed to be bound to a networking back-end.
+alcor.vif_type=ovs

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupController.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupController.java
@@ -15,16 +15,23 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.securitygroup.controller;
 
+import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.securitygroup.exception.*;
 import com.futurewei.alcor.securitygroup.service.SecurityGroupService;
+import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.PortSecurityGroupsJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupBulkJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupsJson;
+import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Map;
 
 import static com.futurewei.alcor.securitygroup.utils.RestParameterValidator.*;
 
@@ -33,6 +40,9 @@ public class SecurityGroupController {
 
     @Autowired
     private SecurityGroupService securityGroupService;
+
+    @Autowired
+    private HttpServletRequest request;
 
     @PostMapping({"/project/{project_id}/security-groups", "v4/{project_id}/security-groups"})
     @ResponseBody
@@ -90,6 +100,7 @@ public class SecurityGroupController {
         securityGroupService.deleteSecurityGroup(securityGroupId);
     }
 
+    @FieldFilter(type=SecurityGroup.class)
     @GetMapping({"/project/{project_id}/security-groups/{security_group_id}", "v4/{project_id}/security-groups/{security_group_id}"})
     public SecurityGroupJson getSecurityGroup(@PathVariable("project_id") String projectId,
                                               @PathVariable("security_group_id") String securityGroupId) throws Exception {
@@ -108,11 +119,16 @@ public class SecurityGroupController {
         return securityGroupService.getDefaultSecurityGroup(projectId, tenantId);
     }
 
+    @FieldFilter(type = SecurityGroup.class)
     @GetMapping({"/project/{project_id}/security-groups", "v4/{project_id}/security-groups"})
     public SecurityGroupsJson listSecurityGroup(@PathVariable("project_id") String projectId) throws Exception {
         checkProjectId(projectId);
 
-        return securityGroupService.listSecurityGroup();
+        Map<String, Object[]> queryParams =
+                ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);
+        queryParams.put("projectId", new String[]{projectId});
+
+        return securityGroupService.listSecurityGroup(queryParams);
     }
 
     private void checkPortSecurityGroups(String projectId, PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupRuleController.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/controller/SecurityGroupRuleController.java
@@ -15,20 +15,31 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.securitygroup.controller;
 
+import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.securitygroup.service.SecurityGroupRuleService;
+import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleBulkJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleJson;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRulesJson;
+import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Map;
+
 import static com.futurewei.alcor.securitygroup.utils.RestParameterValidator.*;
 
 @RestController
 public class SecurityGroupRuleController {
     @Autowired
     private SecurityGroupRuleService securityGroupRuleService;
+
+    @Autowired
+    private HttpServletRequest request;
 
     @PostMapping({"/project/{project_id}/security-group-rules", "v4/{project_id}/security-group-rules"})
     @ResponseBody
@@ -83,6 +94,7 @@ public class SecurityGroupRuleController {
         securityGroupRuleService.deleteSecurityGroupRule(securityGroupRuleId);
     }
 
+    @FieldFilter(type = SecurityGroupRule.class)
     @GetMapping({"/project/{project_id}/security-group-rules/{security_group_rule_id}", "v4/{project_id}/security-group-rules/{security_group_rule_id}"})
     public SecurityGroupRuleJson getSecurityGroupRule(@PathVariable("project_id") String projectId,
                                               @PathVariable("security_group_rule_id") String securityGroupRuleId) throws Exception {
@@ -92,10 +104,15 @@ public class SecurityGroupRuleController {
         return securityGroupRuleService.getSecurityGroupRule(securityGroupRuleId);
     }
 
+    @FieldFilter(type = SecurityGroupRule.class)
     @GetMapping({"/project/{project_id}/security-group-rules", "v4/{project_id}/security-group-rules"})
-    public List<SecurityGroupRuleJson> listSecurityGroupRule(@PathVariable("project_id") String projectId) throws Exception {
+    public SecurityGroupRulesJson listSecurityGroupRule(@PathVariable("project_id") String projectId) throws Exception {
         checkProjectId(projectId);
 
-        return securityGroupRuleService.listSecurityGroupRule();
+        Map<String, Object[]> queryParams =
+                ControllerUtil.transformUrlPathParams(request.getParameterMap(), PortEntity.class);
+        queryParams.put("projectId", new String[]{projectId});
+
+        return securityGroupRuleService.listSecurityGroupRule(queryParams);
     }
 }

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
@@ -118,6 +118,10 @@ public class SecurityGroupRepository {
         return securityGroupCache.getAll();
     }
 
+    public Map<String, SecurityGroup> getAllSecurityGroups(Map<String, Object[]> queryParams) throws CacheException {
+        return securityGroupCache.getAll(queryParams);
+    }
+
     /**
      * In order to find the default security group quickly bt tenant id,
      * when creating a default security group for each tenant, create an
@@ -222,5 +226,9 @@ public class SecurityGroupRepository {
 
     public Map<String, SecurityGroupRule> getAllSecurityGroupRules() throws CacheException {
         return securityGroupRuleCache.getAll();
+    }
+
+    public Map<String, SecurityGroupRule> getAllSecurityGroupRules(Map<String, Object[]> queryParams) throws CacheException {
+        return securityGroupRuleCache.getAll(queryParams);
     }
 }

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupRuleService.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupRuleService.java
@@ -15,11 +15,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.securitygroup.service;
 
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleBulkJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleJson;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRulesJson;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public interface SecurityGroupRuleService {
@@ -33,5 +36,7 @@ public interface SecurityGroupRuleService {
 
     SecurityGroupRuleJson getSecurityGroupRule(String securityGroupRuleId) throws Exception;
 
-    List<SecurityGroupRuleJson> listSecurityGroupRule() throws Exception;
+    SecurityGroupRulesJson listSecurityGroupRule() throws Exception;
+
+    SecurityGroupRulesJson listSecurityGroupRule(Map<String, Object[]> queryParams) throws Exception;
 }

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupService.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/SecurityGroupService.java
@@ -21,6 +21,8 @@ import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupsJson;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @Service
 public interface SecurityGroupService {
     SecurityGroupJson createSecurityGroup(SecurityGroupJson securityGroupJson) throws Exception;
@@ -36,6 +38,8 @@ public interface SecurityGroupService {
     SecurityGroupJson getDefaultSecurityGroup(String projectId, String tenantId) throws Exception;
 
     SecurityGroupsJson listSecurityGroup() throws Exception;
+
+    SecurityGroupsJson listSecurityGroup(Map<String, Object[]> queryParams) throws Exception;
 
     PortSecurityGroupsJson bindSecurityGroups(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception;
 

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupRuleServiceImpl.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupRuleServiceImpl.java
@@ -21,10 +21,7 @@ import com.futurewei.alcor.securitygroup.exception.SecurityGroupRequired;
 import com.futurewei.alcor.securitygroup.exception.SecurityGroupRuleNotFound;
 import com.futurewei.alcor.securitygroup.repo.SecurityGroupRepository;
 import com.futurewei.alcor.securitygroup.service.SecurityGroupRuleService;
-import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
-import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
-import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleBulkJson;
-import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRuleJson;
+import com.futurewei.alcor.web.entity.securitygroup.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,21 +121,38 @@ public class SecurityGroupRuleServiceImpl implements SecurityGroupRuleService {
     }
 
     @Override
-    public List<SecurityGroupRuleJson> listSecurityGroupRule() throws Exception {
-        List<SecurityGroupRuleJson> securityGroupRules = new ArrayList<>();
+    public SecurityGroupRulesJson listSecurityGroupRule() throws Exception {
+        List<SecurityGroupRule> securityGroupRules = new ArrayList<>();
 
         Map<String, SecurityGroupRule> securityGroupRuleMap = securityGroupRepository.getAllSecurityGroupRules();
         if (securityGroupRuleMap == null) {
-            return securityGroupRules;
+            return new SecurityGroupRulesJson(securityGroupRules);
         }
 
         for (Map.Entry<String, SecurityGroupRule> entry: securityGroupRuleMap.entrySet()) {
-            SecurityGroupRuleJson securityGroupRule = new SecurityGroupRuleJson(entry.getValue());
-            securityGroupRules.add(securityGroupRule);
+            securityGroupRules.add(entry.getValue());
         }
 
         LOG.info("List security group rule success");
 
-        return securityGroupRules;
+        return new SecurityGroupRulesJson(securityGroupRules);
+    }
+
+    @Override
+    public SecurityGroupRulesJson listSecurityGroupRule(Map<String, Object[]> queryParams) throws Exception {
+        List<SecurityGroupRule> securityGroupRules = new ArrayList<>();
+
+        Map<String, SecurityGroupRule> securityGroupRuleMap = securityGroupRepository.getAllSecurityGroupRules(queryParams);
+        if (securityGroupRuleMap == null) {
+            return new SecurityGroupRulesJson(securityGroupRules);
+        }
+
+        for (Map.Entry<String, SecurityGroupRule> entry: securityGroupRuleMap.entrySet()) {
+            securityGroupRules.add(entry.getValue());
+        }
+
+        LOG.info("List security group rule success");
+
+        return new SecurityGroupRulesJson(securityGroupRules);
     }
 }

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
@@ -287,6 +287,28 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
     }
 
     @Override
+    public SecurityGroupsJson listSecurityGroup(Map<String, Object[]> queryParams) throws Exception {
+        List<SecurityGroup> securityGroups = new ArrayList<>();
+        Map<String, SecurityGroup> securityGroupMap = securityGroupRepository.getAllSecurityGroups(queryParams);
+
+        if (securityGroupMap == null) {
+            return new SecurityGroupsJson();
+        }
+
+        for (Map.Entry<String, SecurityGroup> entry : securityGroupMap.entrySet()) {
+            //Skip the internal default security group
+            if (entry.getKey().equals(entry.getValue().getTenantId())) {
+                continue;
+            }
+
+            securityGroups.add(entry.getValue());
+        }
+
+        LOG.info("List security group success");
+        return new SecurityGroupsJson(securityGroups);
+    }
+
+    @Override
     public PortSecurityGroupsJson bindSecurityGroups(PortSecurityGroupsJson portSecurityGroupsJson) throws Exception {
         securityGroupBindingsRepository.addSecurityGroupBinding(portSecurityGroupsJson);
 

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
@@ -397,7 +397,7 @@ public class SubnetController {
 
         Map<String, Object[]> queryParams =
                 ControllerUtil.transformUrlPathParams(request.getParameterMap(), SubnetEntity.class);
-        queryParams.put("project_id", new String[]{projectId});
+        queryParams.put("projectId", new String[]{projectId});
 
         Map<String, SubnetEntity> subnetStates = null;
 

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
@@ -283,7 +283,7 @@ public class VpcController {
 
         Map<String, Object[]> queryParams =
                 ControllerUtil.transformUrlPathParams(request.getParameterMap(), SubnetEntity.class);
-        queryParams.put("project_id", new String[]{projectId});
+        queryParams.put("projectId", new String[]{projectId});
 
         try {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectId);

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRule.java
@@ -41,7 +41,7 @@ public class SecurityGroupRule extends CustomerResource {
     @JsonProperty("port_range_min")
     private Integer portRangeMin;
 
-    @JsonProperty("ether_type")
+    @JsonProperty("ethertype")
     private String etherType;
 
     public static enum EtherType {

--- a/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRulesJson.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/securitygroup/SecurityGroupRulesJson.java
@@ -1,0 +1,38 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.web.entity.securitygroup;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SecurityGroupRulesJson {
+
+    @JsonProperty("security_group_rules")
+    private ArrayList<SecurityGroupRule> securityGroupRules;
+
+    public SecurityGroupRulesJson() {
+
+    }
+
+    public SecurityGroupRulesJson(List<SecurityGroupRule> securityGroupRules) {
+        this.securityGroupRules = new ArrayList<>(securityGroupRules);
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/ElasticIpManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/ElasticIpManagerRestClient.java
@@ -63,7 +63,7 @@ public class ElasticIpManagerRestClient extends AbstractRestClient {
 
     @DurationStatistics
     public ElasticIpsInfoWrapper getElasticIps(String projectId, Map<String, Object[]> filters) throws Exception {
-        String url = elasticIpManagerUrl + "/project/" + projectId + "/ports" +
+        String url = elasticIpManagerUrl + "/project/" + projectId + "/elasticips" +
                 ControllerUtil.transformParamsToUrl(filters);
         ElasticIpsInfoWrapper elasticIpsInfoWrapper = null;
 


### PR DESCRIPTION
 This PR proposes the following changes:

-  remove '-' in projectId to adaptor neutron formater
-  add security group multi params filters
-  rename ether_type to ethertype in SecurityGroupRule
-  fix a ElasticIP client bug
-  add default binding:vif_type=ovs config in port manager 
-  fix openstack dashboard get all project vpcs