### PR TITLE
[Spring Config] Remove Redis Health Check to Avoid Start Service Error

### DIFF
--- a/services/elastic_ip_manager/src/main/resources/application.properties
+++ b/services/elastic_ip_manager/src/main/resources/application.properties
@@ -21,3 +21,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=elastic-ip-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/mac_manager/src/main/resources/application.properties
+++ b/services/mac_manager/src/main/resources/application.properties
@@ -22,3 +22,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=mac-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/node_manager/src/main/resources/application.properties
+++ b/services/node_manager/src/main/resources/application.properties
@@ -29,3 +29,5 @@ spring.servlet.multipart.max-file-size=200MB
 # Max Request Size
 spring.servlet.multipart.max-request-size=215MB
 
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -38,3 +38,6 @@ ignite.thin.client.enable=true
 # There are also special values: unbound and binding_failed. unbound means the port is not bound to a networking back-end.
 # binding_failed means an error that the port failed to be bound to a networking back-end.
 alcor.vif_type=ovs
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/private_ip_manager/src/main/resources/application.properties
+++ b/services/private_ip_manager/src/main/resources/application.properties
@@ -18,3 +18,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=ip-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/route_manager/src/main/resources/application.properties
+++ b/services/route_manager/src/main/resources/application.properties
@@ -18,3 +18,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=route-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/security_group_manager/src/main/resources/application.properties
+++ b/services/security_group_manager/src/main/resources/application.properties
@@ -18,3 +18,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=security-group-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/subnet_manager/src/main/resources/application.properties
+++ b/services/subnet_manager/src/main/resources/application.properties
@@ -24,3 +24,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=subnet-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false

--- a/services/vpc_manager/src/main/resources/application.properties
+++ b/services/vpc_manager/src/main/resources/application.properties
@@ -21,3 +21,6 @@ ignite.thin.client.enable=true
 #logging.file.path=./
 #logging.file.name=vpc-manager.log
 #logging.level.root=INFO
+
+#####Spring health#####
+management.health.redis.enabled=false


### PR DESCRIPTION
 This PR proposes the following fix:

- When a microservice is launched,  an error is thrown that Redis can't connect. It was caused by unnecessary actuator Redis check. This PR by default disables this Redis check.