### PR TITLE
[Schema] Add Pending Operation Status for Port Operation

### DIFF
--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -49,6 +49,7 @@ enum OperationStatus {
     SUCCESS = 0;
     FAILURE = 1;
     INVALID_ARG = 2;
+    PENDING = 3;
 }
 
 enum EtherType {


### PR DESCRIPTION
This PR updates the GS schema by adding one operation status - pending - so that host agent could acknowledge the reception of GS from DPM,