### PR TITLE
[Data-Plane Mgr] Add Time Cost Estimation and Fixed Issue #344

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/ClientOfDPMFailureException.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/ClientOfDPMFailureException.java
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR, reason = "Client of DPM sending invalid payload")
+public class ClientOfDPMFailureException extends RuntimeException {
+    public ClientOfDPMFailureException(String message) {
+        super(message);
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.dataplane.utils;
 
+import com.futurewei.alcor.dataplane.exception.ClientOfDPMFailureException;
 import com.futurewei.alcor.dataplane.exception.DPMFailureException;
 import com.futurewei.alcor.dataplane.service.GoalStateService;
 import com.futurewei.alcor.schema.*;
@@ -257,6 +258,10 @@ public class GoalStateManager {
                         // lookup subnet entity
                         for (InternalSubnetEntity subnetEntity1 :
                             portStateWithEverythingFilledNB.getSubnetEntities()) {
+                            if(subnetEntity1.getTunnelId()==null)
+                            {
+                                throw new ClientOfDPMFailureException("empty tunnelId in the subnet payload!");
+                            }
                           Subnet.SubnetConfiguration subnetConfiguration =
                               Subnet.SubnetConfiguration.newBuilder()
                                   .setId(subnetEntity1.getId())

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
@@ -119,4 +119,9 @@ public class NetworkConfiguration {
   public void setSecurityGroups(List<SecurityGroup> securityGroups) {
     this.securityGroups = securityGroups;
   }
+
+  @Override
+  public String toString() {
+    return "NetworkConfiguration{" + "rsType=" + rsType + ", opType=" + opType + ", portEntities=" + portEntities + ", vpcs=" + vpcs + ", subnets=" + subnets + ", securityGroups=" + securityGroups + '}';
+  }
 }


### PR DESCRIPTION
This PR enhances DPM logging by adding time cost estimation. It also fixes a NPE issue tracked by Issue #344 in which Port Mgr passes a network configuration with NULL tunnel id causing DPM throw NPE. 