### PR TITLE
[Integration] ElasticIP APIs Compatible with OpenStack 

### DIFF
--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthGwFilter.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/filter/KeystoneAuthGwFilter.java
@@ -45,6 +45,8 @@ public class KeystoneAuthGwFilter implements GlobalFilter, Ordered {
     private static final String AUTHORIZE_TOKEN = "X-Auth-Token";
     private static final String VPC_NAME = "vpcs";
     private static final String VPC_REPLACE_NAME = "networks";
+    private static final String ELASTICIP_NAME = "elasticips";
+    private static final String ELASTICIP_REPLACE_NAME = "floatingips";
     private static final int KEYSTONE_FILTER_ORDERED = -100;
 
     @Autowired
@@ -76,8 +78,9 @@ public class KeystoneAuthGwFilter implements GlobalFilter, Ordered {
         ServerHttpRequest req = exchange.getRequest();
         ServerWebExchangeUtils.addOriginalRequestUrl(exchange, req.getURI());
         String path = req.getURI().getRawPath();
-        path = path.replaceAll(neutronUrlPrefix, "/project/" + projectId);
-        path = path.replaceAll(VPC_REPLACE_NAME, VPC_NAME);
+        path = path.replaceAll(neutronUrlPrefix, "/project/" + projectId)
+                .replaceAll(VPC_REPLACE_NAME, VPC_NAME)
+                .replaceAll(ELASTICIP_REPLACE_NAME, ELASTICIP_NAME);
 
         ServerHttpRequest request = req.mutate().path(path).header(TOKEN_INFO_HEADER, tokenEntity.toJson()).build();
         exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR, request.getURI());

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/ElasticIPRouteConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/route/ElasticIPRouteConfiguration.java
@@ -1,0 +1,135 @@
+/*
+ *
+ * Copyright 2019 The Alcor Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *         Unless required by applicable law or agreed to in writing, software
+ *         distributed under the License is distributed on an "AS IS" BASIS,
+ *         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *         See the License for the specific language governing permissions and
+ *         limitations under the License.
+ * /
+ */
+
+package com.futurewei.alcor.apigateway.route;
+
+import com.futurewei.alcor.apigateway.filter.KeystoneAuthGwFilter;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfoWrapper;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpsInfoWrapper;
+import com.futurewei.alcor.web.entity.elasticip.openstack.*;
+import com.futurewei.alcor.web.entity.vpc.NetworksWebJson;
+import com.futurewei.alcor.web.entity.vpc.VpcsWebJson;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.GatewayFilterSpec;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.route.builder.UriSpec;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+@Configuration
+public class ElasticIPRouteConfiguration {
+
+    @Value("${microservices.elasticip.service.url}")
+    private String elasticipUrl;
+
+    private static class FloatingIpGetsFilter implements Function<GatewayFilterSpec, UriSpec> {
+         public UriSpec apply(GatewayFilterSpec t) {
+            return t.modifyResponseBody(ElasticIpsInfoWrapper.class, FloatingIpsWrapper.class,
+                    (exchange, elasticIpsInfoWrapper) -> {
+                        List<ElasticIpInfo> elasticIpInfoList = elasticIpsInfoWrapper.getElasticips();
+                        List<FloatingIpResponse> floatingIpList = new LinkedList<>();
+                        if (elasticIpInfoList != null) {
+                            for (ElasticIpInfo item: elasticIpInfoList) {
+                                floatingIpList.add(new FloatingIpResponse(item));
+                            }
+                        }
+                        FloatingIpsWrapper floatingIpsWrapper = new FloatingIpsWrapper(floatingIpList);
+                        return Mono.just(floatingIpsWrapper);
+                    });
+        }
+    }
+
+    private static class FloatingIpGetFilter implements Function<GatewayFilterSpec, UriSpec> {
+        public UriSpec apply(GatewayFilterSpec t) {
+            return t.modifyResponseBody(ElasticIpInfoWrapper.class, FloatingIpResponseWrapper.class,
+                    (exchange, elasticIpInfoWrapper) -> {
+                        FloatingIpResponse floatingIpResponse = null;
+                        if (elasticIpInfoWrapper.getElasticip() != null) {
+                            floatingIpResponse = new FloatingIpResponse(elasticIpInfoWrapper.getElasticip());
+                        }
+                        return Mono.just(new FloatingIpResponseWrapper(floatingIpResponse));
+                    });
+        }
+    }
+
+    private static class FloatingIpUpdateFilter implements Function<GatewayFilterSpec, UriSpec> {
+        public UriSpec apply(GatewayFilterSpec t) {
+            return t.modifyRequestBody(FloatingIpRequestWrapper.class, ElasticIpInfoWrapper.class,
+                    (exchange, floatingIpRequestWrapper) -> {
+                        ElasticIpInfo elasticIpInfo = null;
+                        FloatingIpRequest floatingIpRequest = floatingIpRequestWrapper.getFloatingIpRequest();
+                        if (floatingIpRequest != null) {
+                            elasticIpInfo = floatingIpRequest.getElasticIpInfo();
+                        }
+
+                        return Mono.just(new ElasticIpInfoWrapper(elasticIpInfo));
+                    }).modifyResponseBody(ElasticIpInfoWrapper.class, FloatingIpResponseWrapper.class,
+                    (exchange, elasticIpInfoWrapper) -> {
+                        FloatingIpResponse floatingIpResponse = null;
+                        if (elasticIpInfoWrapper.getElasticip() != null) {
+                            floatingIpResponse = new FloatingIpResponse(elasticIpInfoWrapper.getElasticip());
+                        }
+                        return Mono.just(new FloatingIpResponseWrapper(floatingIpResponse));
+                    });
+        }
+    }
+
+    @Bean
+    public RouteLocator elasticIpRouteLocator(RouteLocatorBuilder builder){
+        return builder.routes()
+                .route(r -> r
+                        .path("/project/*/elasticips", "/project/*/elasticips/*",
+                                "/elasticip-ranges",  "/elasticip-ranges/*")
+                        .uri(elasticipUrl))
+                .route(r -> r
+                        .path("/*/floatingips")
+                        .and().method(HttpMethod.GET)
+                        .filters(new FloatingIpGetsFilter())
+                        .uri(elasticipUrl))
+                .route(r -> r
+                        .path("/*/floatingips/*")
+                        .and().method(HttpMethod.GET)
+                        .filters(new FloatingIpGetFilter())
+                        .uri(elasticipUrl))
+                .route(r -> r
+                        .path("/*/floatingips")
+                        .and().method(HttpMethod.POST)
+                        .filters(new FloatingIpUpdateFilter())
+                        .uri(elasticipUrl))
+                .route(r -> r
+                        .path("/*/floatingips/*")
+                        .and().method(HttpMethod.PUT)
+                        .filters(new FloatingIpUpdateFilter())
+                        .uri(elasticipUrl))
+                .route(r -> r
+                        .path("/*/floatingips/*")
+                        .and().method(HttpMethod.DELETE)
+                        .uri(elasticipUrl))
+                .build();
+    }
+}

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -8,6 +8,7 @@ microservices.port.service.url=http://localhost:9006/
 microservices.sg.service.url=http://localhost:9008/
 #TODO:Quota API temporarily points to VPC Mgr before Quota Mgr is deployed
 microservices.quota.service.url = http://localhost:9001/
+microservices.elasticip.service.url=http://localhost:9011/
 
 #####keystone configuration######
 # if enable keystone auth filter

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/dao/ElasticIpAllocator.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/dao/ElasticIpAllocator.java
@@ -95,7 +95,7 @@ public class ElasticIpAllocator {
             if (glance == null) {
                 // initial the available buckets set
                 BitSet initialBitset = new BitSet(IPv4_BUCKETS_COUNT);
-                initialBitset.set(0, IPv4_BUCKETS_COUNT, true);
+                initialBitset.set(0, IPv4_BUCKETS_COUNT, false);
                 glance = new ElasticIpAvailableBucketsSet(rangeId, initialBitset);
 
                 availableBucketsCache.put(availableBucketsKey, glance);

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpServiceImpl.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpServiceImpl.java
@@ -96,13 +96,14 @@ public class ElasticIpServiceImpl implements ElasticIpService {
         String ipAddress = elasticIpAllocator.allocateIpAddress(range, request.getElasticIp());
         eip.setElasticIp(ipAddress);
 
+        PortEntity port = null;
         try{
             String portId = eip.getPortId();
             if (!StringUtils.isEmpty(portId)) {
-                String associatedIp = this.getAssociatedPortIp(request.getProjectId(), portId,
-                        request.getPrivateIpVersion(), request.getPrivateIp());
+                PortManagerProxy portManagerProxy = new PortManagerProxy(request.getProjectId());
+                port = portManagerProxy.getPortById(portId);
+                String associatedIp = this.getAssociatedPortIp(port, request.getPrivateIp());
                 eip.setPrivateIp(associatedIp);
-                eip.setPrivateIpVersion(ElasticIpControllerUtils.getVersionByIpString(associatedIp));
             }
 
             elasticIpRepo.addItem(eip);
@@ -117,7 +118,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
 
         LOG.debug("Create an elastic ip success, request: {}", request);
 
-        return new ElasticIpInfo(eip);
+        return new ElasticIpInfo(eip, port);
     }
 
     /**
@@ -165,7 +166,13 @@ public class ElasticIpServiceImpl implements ElasticIpService {
         if (eip == null || !projectId.equals(eip.getProjectId())) {
             throw new ElasticIpNotFoundException();
         }
-        ElasticIpInfo result = new ElasticIpInfo(eip);
+
+        PortEntity port = null;
+        if (!StringUtils.isEmpty(eip.getPortId())) {
+            PortManagerProxy portManagerProxy = new PortManagerProxy(projectId);
+            port = portManagerProxy.getPortById(eip.getPortId());
+        }
+        ElasticIpInfo result = new ElasticIpInfo(eip, port);
 
         LOG.debug("Get an elastic ip success, request: {}", elasticIpId);
 
@@ -191,7 +198,12 @@ public class ElasticIpServiceImpl implements ElasticIpService {
         List<ElasticIpInfo> results = new ArrayList<>();
         Map<String, ElasticIp> eips = elasticIpRepo.findAllItems(queryParams);
         for (ElasticIp eipItem: eips.values()) {
-            results.add(new ElasticIpInfo(eipItem));
+            PortEntity port = null;
+            if (!StringUtils.isEmpty(eipItem.getPortId())) {
+                PortManagerProxy portManagerProxy = new PortManagerProxy(projectId);
+                port = portManagerProxy.getPortById(eipItem.getPortId());
+            }
+            results.add(new ElasticIpInfo(eipItem, port));
         }
 
         LOG.debug("Get an elastic ip success");
@@ -231,27 +243,22 @@ public class ElasticIpServiceImpl implements ElasticIpService {
             throw new ElasticIpModifyParameterException();
         }
 
-        if (request.getPrivateIpVersion() != null && eip.getPrivateIpVersion() != null &&
-                !request.getPrivateIpVersion().equals(eip.getPrivateIpVersion())) {
-            throw new ElasticIpModifyParameterException();
-        }
-
         if (request.getPrivateIp() != null && eip.getPrivateIp() != null &&
                 !request.getPrivateIp().equals(eip.getPrivateIp())) {
             throw new ElasticIpModifyParameterException();
         }
 
         String newPortId = request.getPortId();
+        PortEntity port = null;
         if (newPortId != null) {
             eip.setPortId(newPortId);
             if (newPortId.isEmpty()) {
-                eip.setPrivateIpVersion(null);
                 eip.setPrivateIp(null);
             } else {
-                String associatedIp = this.getAssociatedPortIp(request.getProjectId(), newPortId,
-                        request.getPrivateIpVersion(), request.getPrivateIp());
+                PortManagerProxy portManagerProxy = new PortManagerProxy(request.getProjectId());
+                port = portManagerProxy.getPortById(newPortId);
+                String associatedIp = this.getAssociatedPortIp(port, request.getPrivateIp());
                 eip.setPrivateIp(associatedIp);
-                eip.setPrivateIpVersion(ElasticIpControllerUtils.getVersionByIpString(associatedIp));
             }
         }
 
@@ -277,7 +284,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
 
         LOG.debug("Update an elastic ip success, request: {}", request);
 
-        return new ElasticIpInfo(eip);
+        return new ElasticIpInfo(eip, port);
     }
 
     private Map<String, ElasticIp> getElasticIpsByPortId(String projectId, String portId) {
@@ -289,10 +296,8 @@ public class ElasticIpServiceImpl implements ElasticIpService {
         return elasticIpRepo.findAllItems(filter);
     }
 
-    private String getAssociatedPortIp(String projectId, String portId, Integer ipVersion, String ipAddress)
+    private String getAssociatedPortIp(PortEntity port, String ipAddress)
             throws Exception {
-        PortManagerProxy portManagerProxy = new PortManagerProxy(projectId);
-        PortEntity port = portManagerProxy.getPortById(portId);
 
         List<PortEntity.FixedIp> fixedIps = port.getFixedIps();
         List<String> fixedIpList = new ArrayList<>();
@@ -304,7 +309,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
             throw new ElasticIpPipNotFound();
         }
 
-        Map<String, ElasticIp> associatedEips = this.getElasticIpsByPortId(projectId, portId);
+        Map<String, ElasticIp> associatedEips = this.getElasticIpsByPortId(port.getProjectId(), port.getId());
         String associatedIp;
         if (ipAddress != null) {
             if (fixedIpList.contains(ipAddress)) {

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/utils/ElasticIpControllerUtils.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/utils/ElasticIpControllerUtils.java
@@ -22,11 +22,9 @@ import java.util.*;
 public class ElasticIpControllerUtils {
 
 
-    public static boolean isIpAddressInvalid(String ipAddress, Integer ipVersion) {
-        boolean isInvalid = true;
-        if (ipVersion.equals(IpVersion.IPV4.getVersion())) {
-            isInvalid = !Ipv4AddrUtil.formatCheck(ipAddress);
-        } else if (ipVersion.equals(IpVersion.IPV6.getVersion())) {
+    public static boolean isIpAddressInvalid(String ipAddress) {
+        boolean isInvalid = !Ipv4AddrUtil.formatCheck(ipAddress);
+        if (isInvalid) {
             isInvalid = !Ipv6AddrUtil.formatCheck(ipAddress);
         }
 
@@ -90,7 +88,7 @@ public class ElasticIpControllerUtils {
         }
 
         if (elasticIpInfo.getElasticIp() != null) {
-            if (isIpAddressInvalid(elasticIpInfo.getElasticIp(), elasticIpInfo.getElasticIpVersion())) {
+            if (isIpAddressInvalid(elasticIpInfo.getElasticIp())) {
                 throw new ElasticIpEipAddressException();
             }
         }
@@ -99,21 +97,12 @@ public class ElasticIpControllerUtils {
             elasticIpInfo.setPortId("");
         }
         if (elasticIpInfo.getPortId().isEmpty()) {
-            if (elasticIpInfo.getPrivateIp()!= null || elasticIpInfo.getPrivateIpVersion() != null) {
+            if (elasticIpInfo.getPrivateIp()!= null) {
                 throw new ElasticIpNoPortIdException();
             }
         } else {
-            if (elasticIpInfo.getPrivateIpVersion() != null) {
-                if (isIpVersionInvalid(elasticIpInfo.getPrivateIpVersion())) {
-                    throw new ElasticIpPipVersionException();
-                }
-            }
-
             if (elasticIpInfo.getPrivateIp() != null) {
-                if (elasticIpInfo.getPrivateIpVersion() == null) {
-                    elasticIpInfo.setPrivateIpVersion(IpVersion.IPV4.getVersion());
-                }
-                if (isIpAddressInvalid(elasticIpInfo.getPrivateIp(), elasticIpInfo.getPrivateIpVersion())) {
+                if (isIpAddressInvalid(elasticIpInfo.getPrivateIp())) {
                     throw new ElasticIpPipAddressException();
                 }
             }
@@ -168,26 +157,18 @@ public class ElasticIpControllerUtils {
             if (elasticIpInfo.getElasticIpVersion() == null) {
                 elasticIpInfo.setElasticIpVersion(IpVersion.IPV4.getVersion());
             }
-            if (isIpAddressInvalid(elasticIpInfo.getElasticIp(), elasticIpInfo.getElasticIpVersion())) {
+            if (isIpAddressInvalid(elasticIpInfo.getElasticIp())) {
                 throw new ElasticIpEipAddressException();
             }
         }
 
         if (StringUtils.isEmpty(elasticIpInfo.getPortId())) {
-            if (elasticIpInfo.getPrivateIp() != null || elasticIpInfo.getPrivateIpVersion() != null) {
+            if (elasticIpInfo.getPrivateIp() != null) {
                 throw new ElasticIpNoPortIdException();
             }
         } else {
-            if (elasticIpInfo.getPrivateIpVersion() != null) {
-                if (isIpVersionInvalid(elasticIpInfo.getPrivateIpVersion())) {
-                    throw new ElasticIpPipVersionException();
-                }
-            }
             if (elasticIpInfo.getPrivateIp() != null) {
-                if (elasticIpInfo.getPrivateIp() == null) {
-                    elasticIpInfo.setPrivateIpVersion(IpVersion.IPV4.getVersion());
-                }
-                if (isIpAddressInvalid(elasticIpInfo.getPrivateIp(), elasticIpInfo.getPrivateIpVersion())) {
+                if (isIpAddressInvalid(elasticIpInfo.getPrivateIp())) {
                     throw new ElasticIpPipAddressException();
                 }
             }

--- a/services/elastic_ip_manager/src/test/java/com/futurewei/alcor/elasticipmanager/ElasticIpControllerTests.java
+++ b/services/elastic_ip_manager/src/test/java/com/futurewei/alcor/elasticipmanager/ElasticIpControllerTests.java
@@ -1041,6 +1041,7 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         List<PortEntity.FixedIp> fixedIps = new ArrayList<>();
         fixedIps.add(fixedIp);
         port.setFixedIps(fixedIps);
+        port.setName(UnitTestConfig.elasticIpPortName1);
         Mockito.when(portManagerRestClient.getPort(UnitTestConfig.projectId1, UnitTestConfig.elasticIpPort1))
                 .thenReturn(new PortWebJson(port));
 
@@ -1062,8 +1063,8 @@ public class ElasticIpControllerTests extends MockIgniteServer {
                         .value(UnitTestConfig.elasticIpPort1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip")
                         .value(UnitTestConfig.elasticIpPrivateIp1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip_version")
-                        .value(UnitTestConfig.elasticIpPrivateIpVersion1.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.port_details.name")
+                        .value(UnitTestConfig.elasticIpPortName1))
                 .andReturn().getResponse().getContentAsString();
 
         ElasticIpInfoWrapper response = mapper.readValue(responseStr, ElasticIpInfoWrapper.class);
@@ -1092,7 +1093,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         putRequest.setProjectId(UnitTestConfig.projectId1);
         putRequest.setId(elasticIpId);
         putRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        putRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion1);
         putRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp1);
 
         requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(putRequest));
@@ -1108,8 +1108,8 @@ public class ElasticIpControllerTests extends MockIgniteServer {
                         .value(UnitTestConfig.elasticIpPort1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip")
                         .value(UnitTestConfig.elasticIpPrivateIp1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip_version")
-                        .value(UnitTestConfig.elasticIpPrivateIpVersion1.toString()));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.port_details.name")
+                        .value(UnitTestConfig.elasticIpPortName1));
 
         // disassociate elastic ip with the port
         putRequest = new ElasticIp();
@@ -1180,8 +1180,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
                         .value(UnitTestConfig.elasticIpPort1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip")
                         .isNotEmpty())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip_version")
-                        .isNotEmpty())
                 .andReturn().getResponse().getContentAsString();
 
         ElasticIpInfoWrapper response = mapper.readValue(responseStr, ElasticIpInfoWrapper.class);
@@ -1210,7 +1208,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         putRequest.setProjectId(UnitTestConfig.projectId1);
         putRequest.setId(elasticIpId);
         putRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        putRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion2);
         putRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp3);
 
         requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(putRequest));
@@ -1246,7 +1243,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         putRequest.setProjectId(UnitTestConfig.projectId1);
         putRequest.setId(elasticIpId);
         putRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        putRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion1);
         putRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp2);
 
         requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(putRequest));
@@ -1261,9 +1257,7 @@ public class ElasticIpControllerTests extends MockIgniteServer {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.port_id")
                         .value(UnitTestConfig.elasticIpPort1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip")
-                        .value(UnitTestConfig.elasticIpPrivateIp2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.elasticip.private_ip_version")
-                        .value(UnitTestConfig.elasticIpPrivateIpVersion1.toString()));
+                        .value(UnitTestConfig.elasticIpPrivateIp2));
 
         // disassociate elastic ip with the port
         putRequest = new ElasticIp();
@@ -1320,7 +1314,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         ElasticIp postRequest = new ElasticIp();
         postRequest.setProjectId(UnitTestConfig.projectId1);
         postRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        postRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion1);
         postRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp1);
 
         ElasticIpInfoWrapper requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(postRequest));
@@ -1347,7 +1340,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         postRequest = new ElasticIp();
         postRequest.setProjectId(UnitTestConfig.projectId1);
         postRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        postRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion1);
         postRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp1);
 
         requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(postRequest));
@@ -1364,7 +1356,6 @@ public class ElasticIpControllerTests extends MockIgniteServer {
         postRequest = new ElasticIp();
         postRequest.setProjectId(UnitTestConfig.projectId1);
         postRequest.setPortId(UnitTestConfig.elasticIpPort1);
-        postRequest.setPrivateIpVersion(UnitTestConfig.elasticIpPrivateIpVersion1);
         postRequest.setPrivateIp(UnitTestConfig.elasticIpPrivateIp2);
 
         requestWraper = new ElasticIpInfoWrapper(new ElasticIpInfo(postRequest));

--- a/services/elastic_ip_manager/src/test/java/com/futurewei/alcor/elasticipmanager/config/UnitTestConfig.java
+++ b/services/elastic_ip_manager/src/test/java/com/futurewei/alcor/elasticipmanager/config/UnitTestConfig.java
@@ -63,4 +63,6 @@ public class UnitTestConfig {
     public static String elasticIpRangeEnd4 = "2002:200::FFFF:FFFF:FFFF:FFFE";
     public static String getElasticIpPrivateIpSubnetId1 = "11223344-1122-1122-1122-112233440009";
     public static String getElasticIpPrivateIpSubnetId2 = "11223344-1122-1122-1122-112233440010";
+    public static String elasticIpPortName1 = "port1";
+    public static String elasticIpPortName2 = "port2";
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIp.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIp.java
@@ -36,10 +36,6 @@ public class ElasticIp extends CustomerResource {
     @JsonProperty("port_id")
     private String portId;
 
-    @JsonProperty("private_ip_version")
-    @JsonInclude(value = JsonInclude.Include.NON_NULL)
-    private Integer privateIpVersion;
-
     @JsonProperty("private_ip")
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private String privateIp;
@@ -59,7 +55,6 @@ public class ElasticIp extends CustomerResource {
         this.elasticIpVersion = eip.getElasticIpVersion();
         this.elasticIp = eip.getElasticIp();
         this.portId = eip.getPortId();
-        this.privateIpVersion = eip.getPrivateIpVersion();
         this.privateIp = eip.getPrivateIp();
         this.dnsName = eip.getDnsName();
         this.dnsDomain = eip.getDnsDomain();
@@ -67,13 +62,12 @@ public class ElasticIp extends CustomerResource {
 
     public ElasticIp(String projectId, String id, String name, String description,
                      String rangeId, Integer elasticIpVersion, String elasticIp, String portId,
-                     Integer privateIpVersion, String privateIp, String dnsName, String dnsDomain) {
+                     String privateIp, String dnsName, String dnsDomain) {
         super(projectId, id, name, description);
         this.rangeId = rangeId;
         this.elasticIpVersion = elasticIpVersion;
         this.elasticIp = elasticIp;
         this.portId = portId;
-        this.privateIpVersion = privateIpVersion;
         this.privateIp = privateIp;
         this.dnsName = dnsName;
         this.dnsDomain = dnsDomain;
@@ -111,14 +105,6 @@ public class ElasticIp extends CustomerResource {
         this.portId = portId;
     }
 
-    public Integer getPrivateIpVersion() {
-        return privateIpVersion;
-    }
-
-    public void setPrivateIpVersion(Integer privateIpVersion) {
-        this.privateIpVersion = privateIpVersion;
-    }
-
     public String getPrivateIp() {
         return privateIp;
     }
@@ -150,7 +136,6 @@ public class ElasticIp extends CustomerResource {
                 ", elasticIpVersion=" + elasticIpVersion +
                 ", elasticIp='" + elasticIp + '\'' +
                 ", portId='" + portId + '\'' +
-                ", privateIpVersion=" + privateIpVersion +
                 ", privateIp='" + privateIp + '\'' +
                 ", dnsName='" + dnsName + '\'' +
                 ", dnsDomain='" + dnsDomain + '\'' +

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIpInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIpInfo.java
@@ -19,12 +19,16 @@ package com.futurewei.alcor.web.entity.elasticip;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.futurewei.alcor.web.entity.port.PortEntity;
 
 
 public class ElasticIpInfo extends ElasticIp {
 
     @JsonProperty("state")
     private String state;
+
+    @JsonProperty("port_details")
+    private ElasticIpPortDetails portDetails;
 
     public ElasticIpInfo() {
     }
@@ -38,12 +42,35 @@ public class ElasticIpInfo extends ElasticIp {
         }
     }
 
+    public ElasticIpInfo(ElasticIp eip, PortEntity port) {
+        this(eip);
+        if (port != null) {
+            ElasticIpPortDetails portDetails = new ElasticIpPortDetails();
+            portDetails.setAdminStateUp(port.isAdminStateUp());
+            portDetails.setDeviceId(port.getDeviceId());
+            portDetails.setDeviceOwner(port.getDeviceOwner());
+            portDetails.setMacAddress(port.getMacAddress());
+            portDetails.setName(port.getName());
+            portDetails.setNetworkId(port.getVpcId());
+            portDetails.setStatus(port.getStatus());
+            this.portDetails = portDetails;
+        }
+    }
+
     public String getState() {
         return state;
     }
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public ElasticIpPortDetails getPortDetails() {
+        return portDetails;
+    }
+
+    public void setPortDetails(ElasticIpPortDetails portDetails) {
+        this.portDetails = portDetails;
     }
 
     @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIpPortDetails.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/ElasticIpPortDetails.java
@@ -1,0 +1,85 @@
+package com.futurewei.alcor.web.entity.elasticip;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ElasticIpPortDetails {
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("network_id")
+    private String networkId;
+
+    @JsonProperty("mac_address")
+    private String macAddress;
+
+    @JsonProperty("admin_state_up")
+    private Boolean adminStateUp;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("device_id")
+    private String deviceId;
+
+    @JsonProperty("device_owner")
+    private String deviceOwner;
+
+    public ElasticIpPortDetails() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNetworkId() {
+        return networkId;
+    }
+
+    public void setNetworkId(String networkId) {
+        this.networkId = networkId;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public Boolean getAdminStateUp() {
+        return adminStateUp;
+    }
+
+    public void setAdminStateUp(Boolean adminStateUp) {
+        this.adminStateUp = adminStateUp;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getDeviceOwner() {
+        return deviceOwner;
+    }
+
+    public void setDeviceOwner(String deviceOwner) {
+        this.deviceOwner = deviceOwner;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequest.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequest.java
@@ -17,18 +17,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.web.entity.elasticip.openstack;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.futurewei.alcor.common.utils.Ipv4AddrUtil;
+import com.futurewei.alcor.common.entity.CustomerResource;
 import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
-import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfoWrapper;
-import com.futurewei.alcor.web.entity.ip.IpVersion;
 
-public class FloatingIpRequest {
 
-    @JsonProperty("project_id")
-    private String projectId;
-
-    @JsonProperty("tenant_id")
-    private String tenantId;
+public class FloatingIpRequest extends CustomerResource {
 
     @JsonProperty("floating_network_id")
     private String floatingNetworkId;
@@ -45,9 +38,6 @@ public class FloatingIpRequest {
     @JsonProperty("subnet_id")
     private String subnetId;
 
-    @JsonProperty("description")
-    private String description;
-
     @JsonProperty("dns_name")
     private String dnsName;
 
@@ -55,22 +45,6 @@ public class FloatingIpRequest {
     private String dnsDomain;
 
     public FloatingIpRequest() {
-    }
-
-    public String getProjectId() {
-        return projectId;
-    }
-
-    public void setProjectId(String projectId) {
-        this.projectId = projectId;
-    }
-
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
     }
 
     public String getFloatingNetworkId() {
@@ -111,14 +85,6 @@ public class FloatingIpRequest {
 
     public void setSubnetId(String subnetId) {
         this.subnetId = subnetId;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     public String getDnsName() {

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequest.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequest.java
@@ -1,0 +1,155 @@
+/*
+Copyright 2020 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.web.entity.elasticip.openstack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.common.utils.Ipv4AddrUtil;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfoWrapper;
+import com.futurewei.alcor.web.entity.ip.IpVersion;
+
+public class FloatingIpRequest {
+
+    @JsonProperty("project_id")
+    private String projectId;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
+
+    @JsonProperty("floating_network_id")
+    private String floatingNetworkId;
+
+    @JsonProperty("fixed_ip_address")
+    private String fixedIpAddress;
+
+    @JsonProperty("floating_ip_address")
+    private String floatingIpAddress;
+
+    @JsonProperty("port_id")
+    private String portId;
+
+    @JsonProperty("subnet_id")
+    private String subnetId;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("dns_name")
+    private String dnsName;
+
+    @JsonProperty("dns_domain")
+    private String dnsDomain;
+
+    public FloatingIpRequest() {
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getFloatingNetworkId() {
+        return floatingNetworkId;
+    }
+
+    public void setFloatingNetworkId(String floatingNetworkId) {
+        this.floatingNetworkId = floatingNetworkId;
+    }
+
+    public String getFixedIpAddress() {
+        return fixedIpAddress;
+    }
+
+    public void setFixedIpAddress(String fixedIpAddress) {
+        this.fixedIpAddress = fixedIpAddress;
+    }
+
+    public String getFloatingIpAddress() {
+        return floatingIpAddress;
+    }
+
+    public void setFloatingIpAddress(String floatingIpAddress) {
+        this.floatingIpAddress = floatingIpAddress;
+    }
+
+    public String getPortId() {
+        return portId;
+    }
+
+    public void setPortId(String portId) {
+        this.portId = portId;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDnsName() {
+        return dnsName;
+    }
+
+    public void setDnsName(String dnsName) {
+        this.dnsName = dnsName;
+    }
+
+    public String getDnsDomain() {
+        return dnsDomain;
+    }
+
+    public void setDnsDomain(String dnsDomain) {
+        this.dnsDomain = dnsDomain;
+    }
+
+    public ElasticIpInfo getElasticIpInfo() {
+        ElasticIpInfo elasticIpInfo = new ElasticIpInfo();
+
+        elasticIpInfo.setProjectId(this.getProjectId());
+        elasticIpInfo.setTenantId(this.getTenantId());
+        elasticIpInfo.setPortId(this.getPortId());
+        elasticIpInfo.setElasticIp(this.getFloatingIpAddress());
+        elasticIpInfo.setPrivateIp(this.getFixedIpAddress());
+        elasticIpInfo.setDnsDomain(this.getDnsDomain());
+        elasticIpInfo.setDnsName(this.getDnsName());
+        elasticIpInfo.setDescription(this.getDescription());
+
+        return elasticIpInfo;
+    }
+
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequestWrapper.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpRequestWrapper.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.web.entity.elasticip.openstack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FloatingIpRequestWrapper {
+
+    @JsonProperty("floatingip")
+    private FloatingIpRequest floatingIpRequest;
+
+    public FloatingIpRequestWrapper() {
+    }
+
+    public FloatingIpRequest getFloatingIpRequest() {
+        return floatingIpRequest;
+    }
+
+    public void setFloatingIpRequest(FloatingIpRequest floatingIpRequest) {
+        this.floatingIpRequest = floatingIpRequest;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponse.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponse.java
@@ -17,22 +17,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.web.entity.elasticip.openstack;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.common.entity.CustomerResource;
 import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
 import com.futurewei.alcor.web.entity.elasticip.ElasticIpPortDetails;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class FloatingIpResponse {
+public class FloatingIpResponse extends CustomerResource {
 
     @JsonProperty("router_id")
     private String routeId;
 
     @JsonProperty("status")
     private String status;
-
-    @JsonProperty("description")
-    private String description;
 
     @JsonProperty("dns_domain")
     private String dnsDomain;
@@ -43,9 +41,6 @@ public class FloatingIpResponse {
     @JsonProperty("port_details")
     private ElasticIpPortDetails portDetails;
 
-    @JsonProperty("tenant_id")
-    private String tenantId;
-
     @JsonProperty("created_at")
     private String createdAt;
 
@@ -54,9 +49,6 @@ public class FloatingIpResponse {
 
     @JsonProperty("revision_number")
     private String revisionNumber;
-
-    @JsonProperty("project_id")
-    private String projectId;
 
     @JsonProperty("floating_network_id")
     private String floatingNetworkId;
@@ -83,11 +75,11 @@ public class FloatingIpResponse {
     }
 
     public FloatingIpResponse(ElasticIpInfo elasticIpInfo) {
-        this.projectId = elasticIpInfo.getProjectId();
-        this.tenantId = elasticIpInfo.getTenantId();
+        this.setProjectId(elasticIpInfo.getProjectId());
+        this.setTenantId(elasticIpInfo.getTenantId());
         this.dnsDomain = elasticIpInfo.getDnsDomain();
         this.dnsName = elasticIpInfo.getDnsName();
-        this.description = elasticIpInfo.getDescription();
+        this.setDescription(elasticIpInfo.getDescription());
         this.floatingIpAddress = elasticIpInfo.getElasticIp();
         this.portId = elasticIpInfo.getPortId();
         this.fixedIpAddress = elasticIpInfo.getPrivateIp();
@@ -117,14 +109,6 @@ public class FloatingIpResponse {
         this.status = status;
     }
 
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public String getDnsDomain() {
         return dnsDomain;
     }
@@ -149,14 +133,6 @@ public class FloatingIpResponse {
         this.portDetails = portDetails;
     }
 
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    public void setTenantId(String tenantId) {
-        this.tenantId = tenantId;
-    }
-
     public String getCreatedAt() {
         return createdAt;
     }
@@ -179,14 +155,6 @@ public class FloatingIpResponse {
 
     public void setRevisionNumber(String revisionNumber) {
         this.revisionNumber = revisionNumber;
-    }
-
-    public String getProjectId() {
-        return projectId;
-    }
-
-    public void setProjectId(String projectId) {
-        this.projectId = projectId;
     }
 
     public String getFloatingNetworkId() {

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponse.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponse.java
@@ -1,0 +1,248 @@
+/*
+Copyright 2020 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.web.entity.elasticip.openstack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpPortDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FloatingIpResponse {
+
+    @JsonProperty("router_id")
+    private String routeId;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("dns_domain")
+    private String dnsDomain;
+
+    @JsonProperty("dns_name")
+    private String dnsName;
+
+    @JsonProperty("port_details")
+    private ElasticIpPortDetails portDetails;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("updated_at")
+    private String UpdatedAt;
+
+    @JsonProperty("revision_number")
+    private String revisionNumber;
+
+    @JsonProperty("project_id")
+    private String projectId;
+
+    @JsonProperty("floating_network_id")
+    private String floatingNetworkId;
+
+    @JsonProperty("fixed_ip_address")
+    private String fixedIpAddress;
+
+    @JsonProperty("floating_ip_address")
+    private String floatingIpAddress;
+
+    @JsonProperty("port_id")
+    private String portId;
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("tags")
+    private List<String> tags;
+
+    @JsonProperty("port_forwardings")
+    private String portForwardings;
+
+    public FloatingIpResponse() {
+    }
+
+    public FloatingIpResponse(ElasticIpInfo elasticIpInfo) {
+        this.projectId = elasticIpInfo.getProjectId();
+        this.tenantId = elasticIpInfo.getTenantId();
+        this.dnsDomain = elasticIpInfo.getDnsDomain();
+        this.dnsName = elasticIpInfo.getDnsName();
+        this.description = elasticIpInfo.getDescription();
+        this.floatingIpAddress = elasticIpInfo.getElasticIp();
+        this.portId = elasticIpInfo.getPortId();
+        this.fixedIpAddress = elasticIpInfo.getPrivateIp();
+        this.id = elasticIpInfo.getId();
+        this.status = elasticIpInfo.getState();
+        if (null != elasticIpInfo.getPortDetails()) {
+            this.portDetails = elasticIpInfo.getPortDetails();
+        } else {
+            this.portDetails = new ElasticIpPortDetails();
+        }
+        this.tags = new ArrayList<>();
+    }
+
+    public String getRouteId() {
+        return routeId;
+    }
+
+    public void setRouteId(String routeId) {
+        this.routeId = routeId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDnsDomain() {
+        return dnsDomain;
+    }
+
+    public void setDnsDomain(String dnsDomain) {
+        this.dnsDomain = dnsDomain;
+    }
+
+    public String getDnsName() {
+        return dnsName;
+    }
+
+    public void setDnsName(String dnsName) {
+        this.dnsName = dnsName;
+    }
+
+    public ElasticIpPortDetails getPortDetails() {
+        return portDetails;
+    }
+
+    public void setPortDetails(ElasticIpPortDetails portDetails) {
+        this.portDetails = portDetails;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return UpdatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        UpdatedAt = updatedAt;
+    }
+
+    public String getRevisionNumber() {
+        return revisionNumber;
+    }
+
+    public void setRevisionNumber(String revisionNumber) {
+        this.revisionNumber = revisionNumber;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getFloatingNetworkId() {
+        return floatingNetworkId;
+    }
+
+    public void setFloatingNetworkId(String floatingNetworkId) {
+        this.floatingNetworkId = floatingNetworkId;
+    }
+
+    public String getFixedIpAddress() {
+        return fixedIpAddress;
+    }
+
+    public void setFixedIpAddress(String fixedIpAddress) {
+        this.fixedIpAddress = fixedIpAddress;
+    }
+
+    public String getFloatingIpAddress() {
+        return floatingIpAddress;
+    }
+
+    public void setFloatingIpAddress(String floatingIpAddress) {
+        this.floatingIpAddress = floatingIpAddress;
+    }
+
+    public String getPortId() {
+        return portId;
+    }
+
+    public void setPortId(String portId) {
+        this.portId = portId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public String getPortForwardings() {
+        return portForwardings;
+    }
+
+    public void setPortForwardings(String portForwardings) {
+        this.portForwardings = portForwardings;
+    }
+
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponseWrapper.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpResponseWrapper.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.web.entity.elasticip.openstack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FloatingIpResponseWrapper {
+
+    @JsonProperty("floatingip")
+    private FloatingIpResponse floatingIpResponse;
+
+    public FloatingIpResponseWrapper() {
+    }
+
+    public FloatingIpResponseWrapper(FloatingIpResponse floatingIpResponse) {
+        this.floatingIpResponse = floatingIpResponse;
+    }
+
+    public FloatingIpResponse getFloatingIpResponse() {
+        return floatingIpResponse;
+    }
+
+    public void setFloatingIpResponse(FloatingIpResponse floatingIpResponse) {
+        this.floatingIpResponse = floatingIpResponse;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpsWrapper.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/elasticip/openstack/FloatingIpsWrapper.java
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+
+package com.futurewei.alcor.web.entity.elasticip.openstack;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.web.entity.elasticip.ElasticIpInfo;
+
+import java.util.List;
+
+public class FloatingIpsWrapper {
+
+    @JsonProperty("floatingips")
+    private List<FloatingIpResponse> floatingips;
+
+    public FloatingIpsWrapper() {
+    }
+
+    public FloatingIpsWrapper(List<FloatingIpResponse> floatingips) {
+        this.floatingips = floatingips;
+    }
+
+    public List<FloatingIpResponse> getFloatingips() {
+        return floatingips;
+    }
+
+    public void setFloatingips(List<FloatingIpResponse> floatingips) {
+        this.floatingips = floatingips;
+    }
+}


### PR DESCRIPTION
This PR includes the following change:
- remove private ip version attribute from EIP
- add port details attribute to EIP
- add floatingip related models
- add transfrom process between EIP and FIP in apigateway
- fix a bug that found in the integration test：allocation availiable buckets bitset should be initialized to false