### PR TITLE
[Vpc Mgr] Fix LIST Vpc Query Issue

### DIFF
--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
@@ -284,7 +284,7 @@ public class VpcController {
         Map<String, VpcEntity> vpcStates = null;
 
         Map<String, Object[]> queryParams =
-                ControllerUtil.transformUrlPathParams(request.getParameterMap(), SubnetEntity.class);
+                ControllerUtil.transformUrlPathParams(request.getParameterMap(), VpcEntity.class);
 
         ControllerUtil.handleUserRoles(request.getHeader(ControllerUtil.TOKEN_INFO_HEADER), queryParams);
         try {


### PR DESCRIPTION
__Bug Description__

Vpc Mgr currently has issues to process a portion of query parameters, e.g. router:external. This is causing some LIST Vpc REST calls don't return valid information, which further triggers client misbehavior. 

__Root Cause__
The root cause is that when generating queryParams, we placed SubnetEntity class, instead of VpcEntity class. 

This PR makes a simple one-line fix. 