### PR TITLE
[Performance] Add Time Cost Estimation for all Microservices

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/GSController.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/GSController.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.dataplane.controller;
 
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.dataplane.config.Config;
 import com.futurewei.alcor.dataplane.exception.ACAFailureException;
 import com.futurewei.alcor.dataplane.exception.ClientOfDPMFailureException;
@@ -28,6 +29,7 @@ import com.futurewei.alcor.web.entity.dataplane.InternalDPMResult;
 import com.futurewei.alcor.web.entity.dataplane.InternalDPMResultList;
 import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,6 +39,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class GSController {
   private static final Logger LOG = LoggerFactory.getLogger();
 
@@ -54,6 +57,7 @@ public class GSController {
    */
   @PostMapping({"/port/", "v4/port/"})
   @ResponseStatus(HttpStatus.CREATED)
+  @DurationStatistics
   public InternalDPMResultList createPort(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setOpType(Common.OperationType.CREATE);
     gs.setRsType(Common.ResourceType.PORT);
@@ -70,6 +74,7 @@ public class GSController {
    *     /pages/infra_services/data_plane_manager.adoc
    */
   @PutMapping({"/port/", "v4/port/"})
+  @DurationStatistics
   public InternalDPMResultList updatePort(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setRsType(Common.ResourceType.PORT);
     gs.setOpType(Common.OperationType.UPDATE);
@@ -86,6 +91,7 @@ public class GSController {
    *     /pages/infra_services/data_plane_manager.adoc
    */
   @DeleteMapping({"/port/", "v4/port/"})
+  @DurationStatistics
   public InternalDPMResultList deletePort(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setOpType(Common.OperationType.DELETE);
     gs.setRsType(Common.ResourceType.PORT);
@@ -103,6 +109,7 @@ public class GSController {
    */
   @PostMapping({"/subnet/", "v4/subnet/"})
   @ResponseStatus(HttpStatus.CREATED)
+  @DurationStatistics
   public InternalDPMResultList createSubnet(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setOpType(Common.OperationType.CREATE);
     gs.setRsType(Common.ResourceType.SUBNET);
@@ -119,6 +126,7 @@ public class GSController {
    *     /pages/infra_services/data_plane_manager.adoc
    */
   @PutMapping({"/subnet/", "v4/subnet/"})
+  @DurationStatistics
   public InternalDPMResultList updateSubnet(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setOpType(Common.OperationType.UPDATE);
     gs.setRsType(Common.ResourceType.SUBNET);
@@ -135,6 +143,7 @@ public class GSController {
    *     /pages/infra_services/data_plane_manager.adoc
    */
   @DeleteMapping({"/subnet/", "v4/subnet/"})
+  @DurationStatistics
   public InternalDPMResultList deleteSubnet(@RequestBody NetworkConfiguration gs) throws Exception {
     gs.setOpType(Common.OperationType.DELETE);
     gs.setRsType(Common.ResourceType.SUBNET);

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/MizarGoalStateServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/MizarGoalStateServiceImpl.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.dataplane.service.impl;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.dataplane.service.GoalStateService;
 import com.futurewei.alcor.schema.Goalstate;
 import com.futurewei.alcor.schema.Goalstateprovisioner;
@@ -27,6 +28,7 @@ import java.util.Map;
  */
 public class MizarGoalStateServiceImpl implements GoalStateService {
   @Override
+  @DurationStatistics
   public List<List<Goalstateprovisioner.GoalStateOperationReply.GoalStateOperationStatus>>
       SendGoalStateToHosts(
           Map<String, Goalstate.GoalState> gss, boolean isFast, int grpcPort, boolean isOvs) {

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/OVSGoalStateServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/OVSGoalStateServiceImpl.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.dataplane.service.impl;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import com.futurewei.alcor.common.message.MessageClient;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.dataplane.config.Config;
 import com.futurewei.alcor.dataplane.config.grpc.GoalStateProvisionerClient;
 import com.futurewei.alcor.dataplane.exception.DPMFailureException;
@@ -60,6 +61,7 @@ public class OVSGoalStateServiceImpl implements GoalStateService {
    * @throws RuntimeException Various exceptions that may occur during the send process
    */
   @Override
+  @DurationStatistics
   public List<List<Goalstateprovisioner.GoalStateOperationReply.GoalStateOperationStatus>>
       SendGoalStateToHosts(
           Map<String, Goalstate.GoalState> gss, boolean isFast, int grpcPort, boolean isOvs) {

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/controller/ElasticIpController.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/controller/ElasticIpController.java
@@ -29,6 +29,7 @@ import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
@@ -39,6 +40,7 @@ import java.util.Map;
 
 
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class ElasticIpController {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticIpController.class);
 
@@ -62,6 +64,7 @@ public class ElasticIpController {
     @PostMapping("/project/{project_id}/elasticips")
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public ElasticIpInfoWrapper createElasticIp(@PathVariable("project_id") String projectId,
                                                 @RequestBody ElasticIpInfoWrapper request) throws Exception {
 
@@ -85,6 +88,7 @@ public class ElasticIpController {
      */
     @PutMapping("/project/{project_id}/elasticips/{elasticip_id}")
     @ResponseBody
+    @DurationStatistics
     public ElasticIpInfoWrapper updateElasticIp(@PathVariable("project_id") String projectId,
                                                 @PathVariable("elasticip_id") String elasticIpId,
                                                 @RequestBody ElasticIpInfoWrapper request) throws Exception {
@@ -107,6 +111,7 @@ public class ElasticIpController {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @DeleteMapping("/project/{project_id}/elasticips/{elasticip_id}")
+    @DurationStatistics
     public ResponseId deleteElasticIp(@PathVariable("project_id") String projectId,
                                       @PathVariable("elasticip_id") String elasticIpId) throws Exception {
 
@@ -131,6 +136,7 @@ public class ElasticIpController {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @GetMapping(value = {"/project/{project_id}/elasticips/{elasticip_id}"})
+    @DurationStatistics
     public ElasticIpInfoWrapper getElasticIp(@PathVariable("project_id") String projectId,
                                              @PathVariable("elasticip_id") String elasticIpId)
             throws Exception {
@@ -183,6 +189,7 @@ public class ElasticIpController {
     @PostMapping("/elasticip-ranges")
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public ElasticIpRangeInfoWrapper createElasticIpRange(@RequestBody ElasticIpRangeInfoWrapper request)
             throws Exception {
 
@@ -204,6 +211,7 @@ public class ElasticIpController {
      */
     @PutMapping("/elasticip-ranges/{elasticip_range_id}")
     @ResponseBody
+    @DurationStatistics
     public ElasticIpRangeInfoWrapper updateElasticIpRange(@PathVariable("elasticip_range_id") String elasticIpRangeId,
                                                           @RequestBody ElasticIpRangeInfoWrapper request)
             throws Exception {
@@ -225,6 +233,7 @@ public class ElasticIpController {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @DeleteMapping("/elasticip-ranges/{elasticip_range_id}")
+    @DurationStatistics
     public ResponseId deleteElasticIpRange(@PathVariable("elasticip_range_id") String elasticIpRangeId)
             throws Exception {
 
@@ -244,6 +253,7 @@ public class ElasticIpController {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @GetMapping(value = {"/elasticip-ranges/{elasticip_range_id}"})
+    @DurationStatistics
     public ElasticIpRangeInfoWrapper getElasticIpRange(@PathVariable("elasticip_range_id") String elasticIpRangeId)
             throws Exception {
 
@@ -262,6 +272,7 @@ public class ElasticIpController {
      * @throws Exception Various exceptions that may occur during the create process
      */
     @GetMapping(value = {"/elasticip-ranges"})
+    @DurationStatistics
     public ElasticIpRangesInfoWrapper getElasticIpRanges() throws Exception {
 
         List<ElasticIpRangeInfo> eipRanges = elasticIpRangeService.getElasticIpRanges();

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/dao/ElasticIpAllocator.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/dao/ElasticIpAllocator.java
@@ -17,6 +17,7 @@ package com.futurewei.alcor.elasticipmanager.dao;
 
 import com.futurewei.alcor.common.db.*;
 import com.futurewei.alcor.common.exception.DistributedLockException;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.common.utils.Ipv4AddrUtil;
 import com.futurewei.alcor.common.utils.Ipv6AddrUtil;
 import com.futurewei.alcor.elasticipmanager.entity.ElasticIpAllocatedIpv4;
@@ -420,6 +421,7 @@ public class ElasticIpAllocator {
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      * @throws ElasticIpAllocationException Allocation failed
      */
+    @DurationStatistics
     public String allocateIpAddress(ElasticIpRange range, String specifiedIp) throws Exception {
         String ipAddress = null;
         if (range.getIpVersion() == IpVersion.IPV4.getVersion()) {
@@ -512,6 +514,7 @@ public class ElasticIpAllocator {
      * @param ipAddress The allocated elastic ip address
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public void releaseIpAddress(String rangeId, Integer ipVersion, String ipAddress) throws Exception {
         if (ipVersion == IpVersion.IPV4.getVersion()) {
             this.releaseIpv4Address(rangeId, ipAddress);
@@ -667,6 +670,7 @@ public class ElasticIpAllocator {
      *                                      to the range which will be removed after the update
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public void elasticIpRangedUpdate(String rangeId, Integer ipVersion,
                                       List<ElasticIpRange.AllocationRange> allocationRanges) throws Exception {
 
@@ -734,6 +738,7 @@ public class ElasticIpAllocator {
      *                                      to this elastic ip range
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public void elasticIpRangedDelete(String rangeId, Integer ipVersion) throws Exception {
         if (ipVersion == IpVersion.IPV4.getVersion()) {
             this.elasticIpv4RangeDelete(rangeId);

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpRangeServiceImpl.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpRangeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.futurewei.alcor.elasticipmanager.service.implement;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.elasticipmanager.dao.ElasticIpAllocator;
 import com.futurewei.alcor.elasticipmanager.dao.ElasticIpRangeRepo;
 import com.futurewei.alcor.elasticipmanager.dao.ElasticIpRepo;
@@ -40,6 +41,7 @@ public class ElasticIpRangeServiceImpl implements ElasticIpRangeService {
      * @throws ElasticIpRangeExistsException The elastic ip range already exists
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public ElasticIpRangeInfo createElasticIpRange(ElasticIpRangeInfo request) throws Exception {
         LOG.debug("Create an elastic ip range, request: {}", request);
 
@@ -71,6 +73,7 @@ public class ElasticIpRangeServiceImpl implements ElasticIpRangeService {
      *                                      to this elastic ip range
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public void deleteElasticIpRange(String elasticIpRangeId) throws Exception {
         LOG.debug("Delete an elastic ip range, requestId: {}", elasticIpRangeId);
 
@@ -96,6 +99,7 @@ public class ElasticIpRangeServiceImpl implements ElasticIpRangeService {
      *                                      to the range which will be removed after the update
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public ElasticIpRangeInfo updateElasticIpRange(ElasticIpRangeInfo request) throws Exception {
         LOG.debug("Update an elastic ip range, request: {}", request);
 
@@ -138,6 +142,7 @@ public class ElasticIpRangeServiceImpl implements ElasticIpRangeService {
      * @throws ElasticIpRangeNotFoundException The elastic ip range does not exist
      * @throws ElasticIpInternalErrorException Internal process (database etc.) error
      */
+    @DurationStatistics
     public ElasticIpRangeInfo getElasticIpRange(String elasticIpRangeId) throws Exception {
         LOG.debug("get an elastic ip range, requestId: {}", elasticIpRangeId);
 
@@ -165,6 +170,7 @@ public class ElasticIpRangeServiceImpl implements ElasticIpRangeService {
      * @return A list of elastic ip ranges information
      * @throws ElasticIpInternalErrorException Internal process (database etc.) error
      */
+    @DurationStatistics
     public List<ElasticIpRangeInfo> getElasticIpRanges() throws Exception {
         LOG.debug("get all elastic ip ranges");
 

--- a/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpServiceImpl.java
+++ b/services/elastic_ip_manager/src/main/java/com/futurewei/alcor/elasticipmanager/service/implement/ElasticIpServiceImpl.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.elasticipmanager.service.implement;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.common.utils.Ipv4AddrUtil;
 import com.futurewei.alcor.common.utils.Ipv6AddrUtil;
 import com.futurewei.alcor.elasticipmanager.config.IpVersion;
@@ -69,6 +70,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      * @throws ElasticIpAllocationException Allocation failed
      */
+    @DurationStatistics
     public ElasticIpInfo createElasticIp(ElasticIpInfo request) throws Exception {
         LOG.debug("Create an elastic ip, request: {}", request);
 
@@ -128,6 +130,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
      * @throws ElasticIpInUseException The elastic ip is associated with a port
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public void deleteElasticIp(String projectId, String elasticIpId) throws Exception {
         LOG.debug("Release an elastic ip, request: {}", elasticIpId);
 
@@ -158,6 +161,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
      * @throws ElasticIpNotFoundException The elastic ip is not exits
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public ElasticIpInfo getElasticIp(String projectId, String elasticIpId) throws Exception {
         LOG.debug("Get an elastic ip, request: {}", elasticIpId);
 
@@ -179,6 +183,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
      * @return A list of elastic ips information
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public List<ElasticIpInfo> getElasticIps(String projectId, Map<String, Object[]> queryParams) throws Exception {
         LOG.debug("Get elastic ips");
 
@@ -209,6 +214,7 @@ public class ElasticIpServiceImpl implements ElasticIpService {
      * @throws ElasticIpModifyParameterException Not allowed to modify the parameter (elastic_ip etc.)
      * @throws ElasticIpInternalErrorException Internal process (database / lock etc.) error
      */
+    @DurationStatistics
     public ElasticIpInfo updateElasticIp(ElasticIpInfo request) throws Exception {
         LOG.debug("Update an elastic ip, request: {}", request);
 

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/controller/MacController.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/controller/MacController.java
@@ -19,6 +19,7 @@ package com.futurewei.alcor.macmanager.controller;
 import com.futurewei.alcor.common.entity.ResponseId;
 import com.futurewei.alcor.common.exception.ParameterNullOrEmptyException;
 import com.futurewei.alcor.common.exception.ResourcePersistenceException;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.web.entity.mac.*;
 import com.futurewei.alcor.macmanager.service.MacService;
@@ -28,6 +29,7 @@ import com.futurewei.alcor.macmanager.utils.MacManagerRestPreconditionsUtil;
 import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +41,7 @@ import java.util.Map;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class MacController {
 
     @Autowired
@@ -50,6 +53,7 @@ public class MacController {
     @RequestMapping(
             method = GET,
             value = {"/macs/{macaddress}", "/v4/macs/{macaddress}"})
+    @DurationStatistics
     public MacStateJson getMacStateByMacAddress(@PathVariable String macaddress) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacAddressInvalidException {
 
         MacState macState = null;
@@ -74,6 +78,7 @@ public class MacController {
             method = POST,
             value = {"/macs", "/v4/macs"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public MacStateJson createMacState(@RequestBody MacStateJson resource) throws Exception {
         MacState macState = null;
         try {
@@ -96,6 +101,7 @@ public class MacController {
             method = POST,
             value = {"/macs/bulk", "/v4/macs/bulk"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public MacStateBulkJson createMacStateBulk(@RequestBody MacStateBulkJson resource) throws Exception {
         for(MacState macState: resource.getMacStates()){
             MacManagerRestPreconditionsUtil.verifyParameterNotNullorEmpty(macState);
@@ -109,6 +115,7 @@ public class MacController {
             method = POST,
             value = {"/macs/range/{rangeId}/bulk", "/v4/macs/range/{rangeId}/bulk"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public MacStateBulkJson createMacStateBulkInRange(@PathVariable String rangeId, @RequestBody MacStateBulkJson resource) throws Exception {
         for(MacState macState: resource.getMacStates()){
             MacManagerRestPreconditionsUtil.verifyParameterNotNullorEmpty(macState);
@@ -122,6 +129,7 @@ public class MacController {
             method = POST,
             value = {"/macs/range/{rangeId}", "/v4/macs/range/{rangeId}"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public MacStateJson createMacStateInRange(@PathVariable String rangeId, @RequestBody MacStateJson resource) throws Exception {
         MacState macState = null;
         try {
@@ -143,6 +151,7 @@ public class MacController {
     @RequestMapping(
             method = PUT,
             value = {"/macs/{macaddress}", "/v4/macs/{macaddress}"})
+    @DurationStatistics
     public MacStateJson updateMacState(@PathVariable String macaddress, @RequestBody MacStateJson resource) throws Exception {
         MacState macState = null;
         try {
@@ -165,6 +174,7 @@ public class MacController {
     @RequestMapping(
             method = DELETE,
             value = {"/macs/{macaddress}", "/v4/macs/{macaddress}"})
+    @DurationStatistics
     public String deleteMacAllocation(@PathVariable String macaddress) throws Exception {
         String macAddress = null;
         try {
@@ -180,6 +190,7 @@ public class MacController {
     @RequestMapping(
             method = GET,
             value = {"/macs/ranges/{rangeid}", "/v4/macs/ranges/{rangeid}"})
+    @DurationStatistics
     public MacRangeJson getMacRangeByMacRangeId(@PathVariable String rangeid) throws Exception {
 
         MacRange macRange = null;
@@ -202,6 +213,7 @@ public class MacController {
     @RequestMapping(
             method = GET,
             value = {"/macs/ranges", "/v4/macs/ranges"})
+    @DurationStatistics
     public Map<String, Collection<MacRange>> getAllMacRanges() throws Exception {
 
         Map<String, Object[]> queryParams =
@@ -227,6 +239,7 @@ public class MacController {
             method = POST,
             value = {"/macs/ranges", "/v4/macs/ranges"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public MacRangeJson createMacRange(@RequestBody MacRangeJson resource) throws Exception {
         MacRange macRange = null;
         try {
@@ -250,6 +263,7 @@ public class MacController {
     @RequestMapping(
             method = PUT,
             value = {"/macs/ranges/{rangeid}", "/v4/macs/ranges/{rangeid}"})
+    @DurationStatistics
     public MacRangeJson updateMacRange(@PathVariable String rangeid, @RequestBody MacRangeJson resource) throws Exception {
         MacRange macRange = null;
         try {
@@ -276,6 +290,7 @@ public class MacController {
     @RequestMapping(
             method = DELETE,
             value = {"/macs/ranges/{rangeid}", "/v4/macs/ranges/{rangeid}"})
+    @DurationStatistics
     public ResponseId deleteMacRange(@PathVariable String rangeid) throws Exception {
         String rangeId = null;
         try {

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeMappingRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeMappingRepository.java
@@ -21,6 +21,7 @@ package com.futurewei.alcor.macmanager.dao;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.macmanager.dao.api.IRangeMappingRepository;
 import com.futurewei.alcor.web.entity.mac.MacAllocate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,7 @@ public class MacRangeMappingRepository implements IRangeMappingRepository {
     }
 
     @Override
+    @DurationStatistics
     public long size(String rangeId) throws CacheException {
         if(!mappingCache.containsKey(rangeId)){
             createRangeCache(rangeId);
@@ -55,6 +57,7 @@ public class MacRangeMappingRepository implements IRangeMappingRepository {
     }
 
     @Override
+    @DurationStatistics
     public Boolean putIfAbsent(String rangeId, Long macLong) throws CacheException {
         if(!mappingCache.containsKey(rangeId)){
             createRangeCache(rangeId);
@@ -63,11 +66,13 @@ public class MacRangeMappingRepository implements IRangeMappingRepository {
     }
 
     @Override
+    @DurationStatistics
     public void addItem(String rangeId, Long macLong) throws CacheException {
         mappingCache.get(rangeId).put(macLong, rangeId);
     }
 
     @Override
+    @DurationStatistics
     public Boolean releaseMac(String rangeId, Long macLong) throws CacheException {
         if(!mappingCache.containsKey(rangeId)){
             createRangeCache(rangeId);
@@ -80,12 +85,14 @@ public class MacRangeMappingRepository implements IRangeMappingRepository {
     }
 
     @Override
+    @DurationStatistics
     public void removeRange(String rangeId) throws CacheException {
         //TODO clear cache
         mappingCache.remove(rangeId);
     }
 
     @Override
+    @DurationStatistics
     public Set<Long> getAll(String rangeId, Set<Long> macs) throws CacheException{
         Map<Long, String> existMacs = mappingCache.get(rangeId).getAll(macs);
         Set<Long> newMacs = new HashSet<>();

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangePartitionRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangePartitionRepository.java
@@ -22,6 +22,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.mac.MacRangePartition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -40,26 +41,31 @@ public class MacRangePartitionRepository implements ICacheRepository<MacRangePar
     }
 
     @Override
+    @DurationStatistics
     public MacRangePartition findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, MacRangePartition> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, MacRangePartition> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(MacRangePartition macRangePartition) throws CacheException {
         cache.put(macRangePartition.getId(), macRangePartition);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         cache.remove(id);
     }

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacRangeRepository.java
@@ -18,6 +18,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepositoryEx;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.mac.MacRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +57,7 @@ public class MacRangeRepository implements ICacheRepositoryEx<MacRange> {
      * @throws CacheException Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public MacRange findItem(String rangeId) throws CacheException {
         MacRange macRange = null;
         try {
@@ -75,6 +77,7 @@ public class MacRangeRepository implements ICacheRepositoryEx<MacRange> {
      * @throws CacheException Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public Map<String, MacRange> findAllItems() throws CacheException {
         Map<String, MacRange> map = null;
         try {
@@ -94,6 +97,7 @@ public class MacRangeRepository implements ICacheRepositoryEx<MacRange> {
      * @throws CacheException Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public Map<String, MacRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         Map<String, MacRange> map = null;
         try {
@@ -113,6 +117,7 @@ public class MacRangeRepository implements ICacheRepositoryEx<MacRange> {
      * @throws Exception Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public void addItem(MacRange macRange) throws CacheException {
         cache.put(macRange.getRangeId(), macRange);
     }
@@ -125,26 +130,31 @@ public class MacRangeRepository implements ICacheRepositoryEx<MacRange> {
      * @throws Exception Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public void deleteItem(String rangeId) throws CacheException {
         cache.remove(rangeId);
     }
 
     @Override
+    @DurationStatistics
     public long size() {
         return cache.size();
     }
 
     @Override
+    @DurationStatistics
     public Boolean putIfAbsent(MacRange macRange) throws CacheException {
         return cache.putIfAbsent(macRange.getRangeId(), macRange);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, MacRange> findAllItems(Set<String> keys) throws CacheException {
         return cache.getAll(keys);
     }
 
     @Override
+    @DurationStatistics
     public Boolean contains(String key) throws CacheException {
         return cache.containsKey(key);
     }

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacStateRepository.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/dao/MacStateRepository.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepositoryEx;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.mac.MacState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,7 @@ public class MacStateRepository implements ICacheRepositoryEx<MacState> {
      * @throws CacheException Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public MacState findItem(String macAddress) throws CacheException {
         MacState macState = null;
         try {
@@ -76,6 +78,7 @@ public class MacStateRepository implements ICacheRepositoryEx<MacState> {
      * @throws CacheException Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public Map<String, MacState> findAllItems() throws CacheException {
         Map<String, MacState> map = null;
         try {
@@ -88,6 +91,7 @@ public class MacStateRepository implements ICacheRepositoryEx<MacState> {
     }
 
     @Override
+    @DurationStatistics
     public Map<String, MacState> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         Map<String, MacState> map = null;
         try {
@@ -107,6 +111,7 @@ public class MacStateRepository implements ICacheRepositoryEx<MacState> {
      * @throws Exception Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public void addItem(MacState macState) throws CacheException {
         cache.put(macState.getMacAddress(), macState);
     }
@@ -119,26 +124,31 @@ public class MacStateRepository implements ICacheRepositoryEx<MacState> {
      * @throws Exception Db or cache operation exception
      */
     @Override
+    @DurationStatistics
     public void deleteItem(String macAddress) throws CacheException {
         cache.remove(macAddress);
     }
 
     @Override
+    @DurationStatistics
     public long size() {
         return cache.size();
     }
 
     @Override
+    @DurationStatistics
     public Boolean putIfAbsent(MacState macState) throws CacheException {
         return cache.putIfAbsent(macState.getMacAddress(), macState);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, MacState> findAllItems(Set<String> keys) throws CacheException {
         return cache.getAll(keys);
     }
 
     @Override
+    @DurationStatistics
     public Boolean contains(String key) throws CacheException {
         return cache.containsKey(key);
     }

--- a/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/service/implement/MacServiceImpl.java
+++ b/services/mac_manager/src/main/java/com/futurewei/alcor/macmanager/service/implement/MacServiceImpl.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.common.exception.DistributedLockException;
 import com.futurewei.alcor.common.exception.ParameterNullOrEmptyException;
 import com.futurewei.alcor.common.exception.ParameterUnexpectedValueException;
 import com.futurewei.alcor.common.exception.ResourceNotFoundException;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.macmanager.dao.MacRangeMappingRepository;
 import com.futurewei.alcor.macmanager.dao.MacRangeRepository;
 import com.futurewei.alcor.macmanager.dao.MacStateRepository;
@@ -69,6 +70,7 @@ public class MacServiceImpl implements MacService {
      * @throws ParameterNullOrEmptyException          parameter macAddress is null or empty
      * @throws MacRepositoryTransactionErrorException error during repository transaction
      */
+    @DurationStatistics
     public MacState getMacStateByMacAddress(String macAddress) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacAddressInvalidException {
         MacState macState;
         if (macAddress == null)
@@ -94,6 +96,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacAddressFullException                All MAC addresses are created.
      * @throws MacAddressRetryLimitExceedException    MAC addresss creation is tried more than limit
      */
+    @DurationStatistics
     public MacState createMacState(MacState macState) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacRangeInvalidException, MacAddressUniquenessViolationException, MacAddressFullException, MacAddressRetryLimitExceedException {
         String rangeId = MacManagerConstant.DEFAULT_RANGE;
         macState = createMacStateInRange(rangeId, macState);
@@ -114,6 +117,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacAddressRetryLimitExceedException    MAC addresss creation is tried more than limit
      */
     @Override
+    @DurationStatistics
     public MacState createMacStateInRange(String rangeId, MacState macState) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacRangeInvalidException, MacAddressUniquenessViolationException, MacAddressRetryLimitExceedException, MacAddressFullException {
         if (macState == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -170,6 +174,7 @@ public class MacServiceImpl implements MacService {
      * @throws ResourceNotFoundException              there is not mac state with macAddress
      */
     @Override
+    @DurationStatistics
     public MacState updateMacState(String macAddress, MacState macState) throws ParameterNullOrEmptyException, ParameterUnexpectedValueException, MacRepositoryTransactionErrorException, ResourceNotFoundException {
         if (macAddress == null || macState == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -199,6 +204,7 @@ public class MacServiceImpl implements MacService {
      * @throws ResourceNotFoundException              there is not mac state to release macAddress
      */
     @Override
+    @DurationStatistics
     public String releaseMacState(String macAddress) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, ResourceNotFoundException {
         String strMacAddress;
         if (macAddress == null)
@@ -232,6 +238,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacRepositoryTransactionErrorException error during repository transaction
      */
     @Override
+    @DurationStatistics
     public MacRange getMacRangeByMacRangeId(String macRangeId) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException {
         if (macRangeId == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -253,6 +260,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacRepositoryTransactionErrorException error during repository transaction
      */
     @Override
+    @DurationStatistics
     public Map<String, MacRange> getAllMacRanges(Map<String, Object[]> queryParams) throws MacRepositoryTransactionErrorException {
         Map<String, MacRange> macRanges = null;
         String rangeIdName = "rangeId";
@@ -286,6 +294,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacRangeInvalidException               macRange's from should be less than macRange's to
      */
     @Override
+    @DurationStatistics
     public MacRange createMacRange(MacRange macRange) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacRangeInvalidException {
         if (macRange == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -310,6 +319,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacRangeInvalidException               macRange's from should be less than macRange's to
      */
     @Override
+    @DurationStatistics
     public MacRange updateMacRange(MacRange macRange) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacRangeInvalidException {
         if (macRange == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -334,6 +344,7 @@ public class MacServiceImpl implements MacService {
      * @throws MacRangeDeleteNotAllowedException      default mac range is prohibited to delete
      */
     @Override
+    @DurationStatistics
     public String deleteMacRange(String rangeId) throws ParameterNullOrEmptyException, MacRepositoryTransactionErrorException, MacRangeDeleteNotAllowedException {
         if (rangeId == null)
             throw (new ParameterNullOrEmptyException(MacManagerConstant.MAC_EXCEPTION_PARAMETER_NULL_EMPTY));
@@ -357,6 +368,7 @@ public class MacServiceImpl implements MacService {
      * @throws Exception create Exceptions
      */
     @Override
+    @DurationStatistics
     public MacStateBulkJson createMacStateBulk(MacStateBulkJson macStateBulkJson) throws Exception {
         return createMacStateBulkInRange(MacManagerConstant.DEFAULT_RANGE, macStateBulkJson);
     }
@@ -370,6 +382,7 @@ public class MacServiceImpl implements MacService {
      * @throws Exception create Exceptions
      */
     @Override
+    @DurationStatistics
     public MacStateBulkJson createMacStateBulkInRange(String rangeId, MacStateBulkJson macStateBulkJson) throws Exception {
         // handle exist macs
         List<MacState> createNewMacList = new ArrayList<>();

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/controller/NodeController.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/controller/NodeController.java
@@ -17,6 +17,7 @@ package com.futurewei.alcor.nodemanager.controller;
 import com.futurewei.alcor.common.exception.ParameterNullOrEmptyException;
 import com.futurewei.alcor.common.exception.ParameterUnexpectedValueException;
 import com.futurewei.alcor.common.exception.ResourcePersistenceException;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.nodemanager.exception.InvalidDataException;
 import com.futurewei.alcor.web.entity.NodeInfo;
@@ -28,6 +29,7 @@ import com.futurewei.alcor.web.entity.node.NodesWebJson;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import io.swagger.annotations.ApiParam;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,6 +42,7 @@ import java.util.Map;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class NodeController {
 
     @Autowired
@@ -51,6 +54,7 @@ public class NodeController {
     @RequestMapping(
             method = POST,
             value = {"/nodes/upload", "/v4/nodes/upload"})
+    @DurationStatistics
     public String uploadFile(@RequestParam("file") MultipartFile file) throws Exception {
         int nNode = 0;
         if (file == null) {
@@ -67,6 +71,7 @@ public class NodeController {
     @RequestMapping(
             method = GET,
             value = {"/nodes/{nodeid}", "/v4/nodes/{nodeid}"})
+    @DurationStatistics
     public NodeInfoJson getNodeInfoById(@PathVariable String nodeid) throws Exception {
         NodeInfo hostInfo = null;
         try {
@@ -85,6 +90,7 @@ public class NodeController {
     @RequestMapping(
             method = GET,
             value = {"/nodes", "/v4/nodes"})
+    @DurationStatistics
     public NodesWebJson getAllNodes(@ApiParam(value = "node_name") @RequestParam(required = false) String name,
                                     @ApiParam(value = "node_id") @RequestParam(required = false) String id,
                                     @ApiParam(value = "mac_address") @RequestParam(required = false) String mac_address,
@@ -120,6 +126,7 @@ public class NodeController {
             method = POST,
             value = {"/nodes", "/v4/nodes"})
     @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
     public NodeInfoJson createNodeInfo(@RequestBody NodeInfoJson resource) throws ParameterNullOrEmptyException, InvalidDataException, ResourcePersistenceException, Exception  {
         NodeInfo hostInfo = null;
         try {
@@ -146,6 +153,7 @@ public class NodeController {
     @RequestMapping(
             method = PUT,
             value = {"/nodes/{nodeid}", "/v4/nodes/{nodeid}"})
+    @DurationStatistics
     public NodeInfoJson updateNodeInfo(@PathVariable String nodeid, @RequestBody NodeInfoJson resource) throws Exception {
         NodeInfo hostInfo = null;
         try {
@@ -170,6 +178,7 @@ public class NodeController {
     @RequestMapping(
             method = DELETE,
             value = {"/nodes/{nodeid}", "/v4/nodes/{nodeid}"})
+    @DurationStatistics
     public String deleteNodeInfo(@PathVariable String nodeid) throws Exception {
         String macAddress = null;
         try {

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.nodemanager.service.implement;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.nodemanager.exception.InvalidDataException;
 import com.futurewei.alcor.nodemanager.utils.NodeManagerConstant;
 import com.futurewei.alcor.web.entity.NodeInfo;
@@ -45,6 +46,7 @@ public class NodeFileLoader {
      * @return total nodes number
      * @throws FileNotFoundException invalid file name, IOException file read exception, Parseexception json parsing exception
      */
+    @DurationStatistics
     public List<NodeInfo> getHostNodeListFromUpload(Reader reader) throws FileNotFoundException, IOException, ParseException{
         String strMethodName = "getHostNodeListFromUpload";
         JSONParser jsonParser = new JSONParser();

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeServiceImpl.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeServiceImpl.java
@@ -16,6 +16,7 @@ package com.futurewei.alcor.nodemanager.service.implement;
 
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.exception.ParameterNullOrEmptyException;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.nodemanager.dao.NodeRepository;
 import com.futurewei.alcor.nodemanager.exception.NodeRepositoryException;
 import com.futurewei.alcor.web.entity.*;
@@ -49,6 +50,7 @@ public class NodeServiceImpl implements NodeService {
      * @return total nodes number
      * @throws IOException file read exception, NodeRepositoryException exception caused by Repository
      */
+    @DurationStatistics
     public int getNodeInfoFromUpload(MultipartFile file) throws IOException, NodeRepositoryException, Exception {
         String strMethodName = "getNodeInfoFromUpload";
         int nReturn = 0;
@@ -80,6 +82,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws IOException NodeRepositoryException exception caused by Repository
      */
     @Override
+    @DurationStatistics
     public NodeInfo getNodeInfoById(String nodeId) throws NodeRepositoryException, Exception {
         String strMethodName = "getNodeInfoById";
         if (nodeId == null)
@@ -105,6 +108,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws IOException NodeRepositoryException exception caused by Repository
      */
     @Override
+    @DurationStatistics
     public List<NodeInfo> getAllNodes() throws Exception {
         String strMethodName = "getAllNodes";
         List<NodeInfo> nodes = new ArrayList<NodeInfo>();
@@ -127,6 +131,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws Exception
      */
     @Override
+    @DurationStatistics
     public List<NodeInfo> getAllNodes(Map<String, Object[]> queryParams) throws Exception {
         List<NodeInfo> result = new ArrayList<>();
 
@@ -151,6 +156,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws ParameterNullOrEmptyException node information input is not valid, NodeRepositoryException exception caused by Repository
      */
     @Override
+    @DurationStatistics
     public NodeInfo createNodeInfo(NodeInfo nodeInfo) throws ParameterNullOrEmptyException, NodeRepositoryException,Exception {
         String strMethodName = "createNodeInfo";
         if (nodeInfo == null)
@@ -179,6 +185,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws ParameterNullOrEmptyException node inormation is input not valid, NodeRepositoryException exception caused by Repository
      */
     @Override
+    @DurationStatistics
     public NodeInfo updateNodeInfo(String nodeId, NodeInfo nodeInfo) throws ParameterNullOrEmptyException, NodeRepositoryException, Exception {
         String strMethodName = "updateNodeInfo";
         if (nodeId == null || nodeInfo == null)
@@ -212,6 +219,7 @@ public class NodeServiceImpl implements NodeService {
      * @throws ParameterNullOrEmptyException node inormation is input not valid, NodeRepositoryException exception caused by Repository
      */
     @Override
+    @DurationStatistics
     public String deleteNodeInfo(String nodeId) throws ParameterNullOrEmptyException, NodeRepositoryException, Exception {
         String strMethodName = "deleteNodeInfo";
         if (nodeId == null)

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/repo/PortRepository.java
@@ -62,6 +62,7 @@ public class PortRepository {
         LOG.info("PortRepository init done");
     }
 
+    @DurationStatistics
     public void addPortEntities(List<PortEntity> portEntities) throws CacheException {
         Map<String, PortEntity> portEntityMap = portEntities
                 .stream()

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.service;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.portmanager.exception.PortEntityNotFound;
 import com.futurewei.alcor.portmanager.processor.*;
 import com.futurewei.alcor.portmanager.repo.PortRepository;
@@ -62,6 +63,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public PortWebJson createPort(String projectId, PortWebJson portWebJson) throws Exception {
         LOG.debug("Create port enter, projectId: {}, PortWebJson: {}", projectId, portWebJson);
 
@@ -73,6 +75,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public PortWebBulkJson createPortBulk(String projectId, PortWebBulkJson portWebBulkJson) throws Exception {
         LOG.debug("Create port bulk enter, projectId: {}, PortWebBulkJson: {}", projectId, portWebBulkJson);
 
@@ -84,6 +87,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public PortWebJson updatePort(String projectId, String portId, PortWebJson portWebJson) throws Exception {
         LOG.debug("Update port enter, projectId: {}, portId: {}, PortWebJson: {}",
                 projectId, portId, portWebJson);
@@ -120,6 +124,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public void deletePort(String projectId, String portId) throws Exception {
         LOG.debug("Delete port enter, projectId: {}, portId: {}", projectId, portId);
 
@@ -144,6 +149,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public PortWebJson getPort(String projectId, String portId) throws Exception {
         PortEntity portEntity = portRepository.findPortEntity(portId);
         if (portEntity == null) {
@@ -156,6 +162,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public List<PortWebJson> listPort(String projectId) throws Exception {
         List<PortWebJson> result = new ArrayList<>();
 
@@ -175,6 +182,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
+    @DurationStatistics
     public List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception {
         List<PortWebJson> result = new ArrayList<>();
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteRepository.java
@@ -7,6 +7,7 @@ import com.futurewei.alcor.common.logging.LoggerFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.db.CacheFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.route.RouteEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -37,21 +38,25 @@ public class RouteRepository implements ICacheRepository<RouteEntity> {
     }
 
     @Override
+    @DurationStatistics
     public RouteEntity findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, RouteEntity> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, RouteEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(RouteEntity routeEntity) throws CacheException {
         logger.log(Level.INFO, "Add route, route Id:" + routeEntity.getId());
         cache.put(routeEntity.getId(), routeEntity);
@@ -59,6 +64,7 @@ public class RouteRepository implements ICacheRepository<RouteEntity> {
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete route, route Id:" + id);
         cache.remove(id);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithSubnetMapperRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithSubnetMapperRepository.java
@@ -21,6 +21,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.route.SubnetToRouteMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -52,27 +53,32 @@ public class RouteWithSubnetMapperRepository implements ICacheRepository<SubnetT
     }
 
     @Override
+    @DurationStatistics
     public SubnetToRouteMapper findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SubnetToRouteMapper> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SubnetToRouteMapper> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(SubnetToRouteMapper subnetToRouteMapper) throws CacheException {
         logger.log(Level.INFO, "Add routeWithSubnetMapper, mapper Id:" + subnetToRouteMapper.getSubnetId());
         cache.put(subnetToRouteMapper.getSubnetId(), subnetToRouteMapper);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete routeWithSubnetMapper, mapper Id:" + id);
         cache.remove(id);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithVpcMapperRepository.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/dao/RouteWithVpcMapperRepository.java
@@ -21,6 +21,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.route.VpcToRouteMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -51,27 +52,32 @@ public class RouteWithVpcMapperRepository implements ICacheRepository<VpcToRoute
     }
 
     @Override
+    @DurationStatistics
     public VpcToRouteMapper findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, VpcToRouteMapper> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, VpcToRouteMapper> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(VpcToRouteMapper vpcToRouteMapper) throws CacheException {
         logger.log(Level.INFO, "Add RouteWithVpcMapper, mapper Id:" + vpcToRouteMapper.getVpcId());
         cache.put(vpcToRouteMapper.getVpcId(), vpcToRouteMapper);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete RouteWithVpcMapper, mapper Id:" + id);
         cache.remove(id);

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
@@ -54,6 +54,7 @@ public class PortBindingSecurityGroupRepository {
         LOG.info("PortBindingSecurityGroupRepository init done");
     }
 
+    @DurationStatistics
     public Collection<PortBindingSecurityGroup> getPortBindingSecurityGroupBySecurityGroupId(String securityGroupId) throws CacheException {
         Map<String, String[]> filterParams = new HashMap<>();
         filterParams.put("security_group_id", new String[] {securityGroupId});

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/SecurityGroupRepository.java
@@ -239,6 +239,7 @@ public class SecurityGroupRepository {
         return securityGroupRuleCache.getAll();
     }
 
+    @DurationStatistics
     public Map<String, SecurityGroupRule> getAllSecurityGroupRules(Map<String, Object[]> queryParams) throws CacheException {
         return securityGroupRuleCache.getAll(queryParams);
     }

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupRuleServiceImpl.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupRuleServiceImpl.java
@@ -145,6 +145,7 @@ public class SecurityGroupRuleServiceImpl implements SecurityGroupRuleService {
     }
 
     @Override
+    @DurationStatistics
     public SecurityGroupRulesJson listSecurityGroupRule(Map<String, Object[]> queryParams) throws Exception {
         List<SecurityGroupRule> securityGroupRules = new ArrayList<>();
 

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/service/implement/SecurityGroupServiceImpl.java
@@ -264,6 +264,7 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
     }
 
     @Override
+    @DurationStatistics
     public SecurityGroupsJson listSecurityGroup(Map<String, Object[]> queryParams) throws Exception {
         List<SecurityGroup> securityGroups = new ArrayList<>();
         Map<String, SecurityGroup> securityGroupMap = securityGroupRepository.getAllSecurityGroups(queryParams);

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/dao/SubnetRepository.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/dao/SubnetRepository.java
@@ -23,6 +23,7 @@ import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -56,27 +57,32 @@ public class SubnetRepository implements ICacheRepository<SubnetEntity> {
     }
 
     @Override
+    @DurationStatistics
     public SubnetEntity findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SubnetEntity> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SubnetEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(SubnetEntity subnet) throws CacheException {
         logger.log(Level.INFO, "Add subnet, subnet Id:" + subnet.getId());
         cache.put(subnet.getId(), subnet);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete subnet, subnet Id:" + id);
         cache.remove(id);

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetServiceImp.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetServiceImp.java
@@ -320,6 +320,7 @@ public class SubnetServiceImp implements SubnetService {
     }
 
     @Override
+    @DurationStatistics
     public void addSubnetIdToVpc(String subnetId, String projectId, String vpcId) throws Exception {
         if (subnetId == null) {
             throw new SubnetIdIsNull();
@@ -331,6 +332,7 @@ public class SubnetServiceImp implements SubnetService {
     }
 
     @Override
+    @DurationStatistics
     public void deleteSubnetIdInVpc(String subnetId, String projectId, String vpcId) throws Exception {
         if (subnetId == null) {
             throw new SubnetIdIsNull();
@@ -341,6 +343,7 @@ public class SubnetServiceImp implements SubnetService {
     }
 
     @Override
+    @DurationStatistics
     public boolean checkIfCidrOverlap(String cidr,String projectId, String vpcId) throws FallbackException, ResourceNotFoundException, ResourcePersistenceException, CidrNotWithinNetworkCidr, CidrOverlapWithOtherSubnets {
 
         // get vpc and check with vpc cidr

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/QuotaController.java
@@ -15,8 +15,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.vpcmanager.controller;
 
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.quota.QuotaEntity;
 import com.futurewei.alcor.web.entity.quota.QuotaWebJson;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +30,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 //      before Quote Mgr is deployed
 ////////////////////////////////////////////////////////////////////
 @RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class QuotaController {
 
     /**
@@ -40,6 +43,7 @@ public class QuotaController {
     @RequestMapping(
             method = GET,
             value = "/project/{projectId}/quotas/{projectId}")
+    @DurationStatistics
     public QuotaWebJson getQuotaByProjectId(@PathVariable String projectId) throws Exception {
 
         QuotaEntity defaultQuota = this.createDefaultQuotaEntity();

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/controller/VpcController.java
@@ -341,6 +341,7 @@ public class VpcController {
     @RequestMapping(
             method = PUT,
             value = {"/project/{projectid}/vpcs/{vpcid}/subnets/{subnetid}"})
+    @DurationStatistics
     public VpcWebJson addSubnetIdToVpcState(@PathVariable String projectid, @PathVariable String vpcid, @PathVariable String subnetid) throws Exception {
 
         VpcEntity inVpcState = new VpcEntity();
@@ -387,6 +388,7 @@ public class VpcController {
     @RequestMapping(
             method = PUT,
             value = {"/project/{projectid}/vpcs/{vpcid}/subnetid/{subnetid}"})
+    @DurationStatistics
     public VpcWebJson deleteSubnetIdInVpcState(@PathVariable String projectid, @PathVariable String vpcid, @PathVariable String subnetid) throws Exception {
 
         VpcEntity inVpcState = new VpcEntity();

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRangeRepository.java
@@ -5,6 +5,7 @@ import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -47,6 +48,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
 
 
     @Override
+    @DurationStatistics
     public NetworkGRERange findItem(String id) {
         try {
             return cache.get(id);
@@ -58,6 +60,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkGRERange> findAllItems() {
         try {
             return cache.getAll();
@@ -70,11 +73,13 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkGRERange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkGRERange networkGRERange) {
         logger.error("Add networkGreRange:{}", networkGRERange);
 
@@ -87,6 +92,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) {
         logger.error("Delete rangeId:{}", id);
 
@@ -104,6 +110,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
      * @return range key in db
      * @throws Exception Db operation or key assignment exception
      */
+    @DurationStatistics
     public synchronized Long allocateGreKey (String rangeId) throws Exception {
         Long key;
 
@@ -128,6 +135,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
      * @param key
      * @throws Exception Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized void releaseGreKey(String rangId, Long key) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkGRERange networkGRERange = cache.get(rangId);
@@ -142,6 +150,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
         }
     }
 
+    @DurationStatistics
     public synchronized KeyAlloc getGreKeyAlloc(String rangeId, Long key) throws Exception {
         NetworkGRERange networkGRERange = cache.get(rangeId);
         if (networkGRERange == null) {
@@ -157,6 +166,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
      * @throws Exception Network Range Already Exist Exception
      * @throws Exception Internal Db Operation Exception
      */
+    @DurationStatistics
     public synchronized void createRange(NetworkRangeRequest request) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             if (cache.get(request.getId()) != null) {
@@ -189,6 +199,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
      * @return gre range
      * @throws Exception Network Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized NetworkGRERange deleteRange(String rangeId) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkGRERange networkGRERange = cache.get(rangeId);
@@ -211,6 +222,7 @@ public class GreRangeRepository implements ICacheRepository<NetworkGRERange> {
      * @return gre range
      * @throws Exception
      */
+    @DurationStatistics
     public synchronized NetworkGRERange getRange(String rangeId) throws Exception {
         return cache.get(rangeId);
     }

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/GreRepository.java
@@ -6,6 +6,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.entity.NetworkGREType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -37,27 +38,32 @@ public class GreRepository implements ICacheRepository<NetworkGREType> {
     }
 
     @Override
+    @DurationStatistics
     public NetworkGREType findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkGREType> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkGREType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkGREType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Gre, Gre Id:" + newItem.getGreId());
         cache.put(newItem.getGreId(), newItem);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete Gre, Gre Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRangeRepository.java
@@ -6,6 +6,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.NetworkSegmentRangeEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -37,27 +38,32 @@ public class SegmentRangeRepository implements ICacheRepository<NetworkSegmentRa
     }
 
     @Override
+    @DurationStatistics
     public NetworkSegmentRangeEntity findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkSegmentRangeEntity> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkSegmentRangeEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkSegmentRangeEntity newItem) throws CacheException {
         logger.log(Level.INFO, "Add segment range, Segment Range Id:" + newItem.getId());
         cache.put(newItem.getId(), newItem);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete segment range, Segment Range Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/SegmentRepository.java
@@ -6,6 +6,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.SegmentEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -37,27 +38,32 @@ public class SegmentRepository implements ICacheRepository<SegmentEntity> {
     }
 
     @Override
+    @DurationStatistics
     public SegmentEntity findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SegmentEntity> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, SegmentEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(SegmentEntity newItem) throws CacheException {
         logger.log(Level.INFO, "Add segment, Segment Id:" + newItem.getId());
         cache.put(newItem.getId(), newItem);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete segment, Segment Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRangeRepository.java
@@ -5,6 +5,7 @@ import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -45,6 +46,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
     }
 
     @Override
+    @DurationStatistics
     public synchronized NetworkVlanRange findItem(String id) {
         try {
             return cache.get(id);
@@ -56,6 +58,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
     }
 
     @Override
+    @DurationStatistics
     public synchronized Map<String, NetworkVlanRange> findAllItems() {
         try {
             return cache.getAll();
@@ -68,11 +71,13 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVlanRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public synchronized void addItem(NetworkVlanRange networkVlanRange){
         logger.error("Add networkVlanRange:{}", networkVlanRange);
 
@@ -85,6 +90,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
     }
 
     @Override
+    @DurationStatistics
     public synchronized void deleteItem(String id) {
         logger.error("Delete rangeId:{}", id);
 
@@ -102,6 +108,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
      * @return range key in db
      * @throws Exception Db operation or key assignment exception
      */
+    @DurationStatistics
     public synchronized Long allocateVlanKey (String rangeId) throws Exception {
         Long key;
 
@@ -126,6 +133,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
      * @param key
      * @throws Exception Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized void releaseVlanKey(String rangId, Long key) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkVlanRange networkVlanRange = cache.get(rangId);
@@ -140,6 +148,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
         }
     }
 
+    @DurationStatistics
     public synchronized KeyAlloc getVlanKeyAlloc(String rangeId, Long key) throws Exception {
         NetworkVlanRange networkVlanRange = cache.get(rangeId);
         if (networkVlanRange == null) {
@@ -155,6 +164,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
      * @throws Exception Network Range Already Exist Exception
      * @throws Exception Internal Db Operation Exception
      */
+    @DurationStatistics
     public synchronized void createRange(NetworkRangeRequest request) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             if (cache.get(request.getId()) != null) {
@@ -187,6 +197,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
      * @return vlan range
      * @throws Exception Network Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized NetworkVlanRange deleteRange(String rangeId) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkVlanRange networkVlanRange = cache.get(rangeId);
@@ -209,6 +220,7 @@ public class VlanRangeRepository implements ICacheRepository<NetworkVlanRange> {
      * @return vlan range
      * @throws Exception
      */
+    @DurationStatistics
     public synchronized NetworkVlanRange getRange(String rangeId) throws Exception {
         return cache.get(rangeId);
     }

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VlanRepository.java
@@ -6,6 +6,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.entity.NetworkVlanType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -38,27 +39,32 @@ public class VlanRepository implements ICacheRepository<NetworkVlanType> {
     }
 
     @Override
+    @DurationStatistics
     public NetworkVlanType findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVlanType> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVlanType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkVlanType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Vlan, Vlan Id:" + newItem.getVlanId());
         cache.put(newItem.getVlanId(), newItem);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete Vlan, Vlan Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VpcRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VpcRepository.java
@@ -22,6 +22,7 @@ import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -52,27 +53,32 @@ public class VpcRepository implements ICacheRepository<VpcEntity> {
     }
 
     @Override
+    @DurationStatistics
     public VpcEntity findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, VpcEntity> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(VpcEntity vpcState) throws CacheException {
         logger.log(Level.INFO, "Add vpc, Vpc Id:" + vpcState.getId());
         cache.put(vpcState.getId(), vpcState);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete vpc, Vpc Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRangeRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRangeRepository.java
@@ -5,6 +5,7 @@ import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.Transaction;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.exception.InternalDbOperationException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeExistException;
 import com.futurewei.alcor.vpcmanager.exception.NetworkRangeNotFoundException;
@@ -46,6 +47,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
 
 
     @Override
+    @DurationStatistics
     public NetworkVxlanRange findItem(String id) {
         try {
             return cache.get(id);
@@ -57,6 +59,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVxlanRange> findAllItems() {
         try {
             return cache.getAll();
@@ -69,11 +72,13 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVxlanRange> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkVxlanRange networkVxlanRange) {
         logger.error("Add networkVxlanRange:{}", networkVxlanRange);
 
@@ -86,6 +91,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) {
         logger.error("Delete rangeId:{}", id);
 
@@ -103,6 +109,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
      * @return range key in db
      * @throws Exception Db operation or key assignment exception
      */
+    @DurationStatistics
     public synchronized Long allocateVxlanKey (String rangeId) throws Exception {
         Long key;
 
@@ -127,6 +134,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
      * @param key
      * @throws Exception Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized void releaseVxlanKey(String rangId, Long key) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkVxlanRange networkVxlanRange = cache.get(rangId);
@@ -141,6 +149,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
         }
     }
 
+    @DurationStatistics
     public synchronized KeyAlloc getVxlanKeyAlloc(String rangeId, Long key) throws Exception {
         NetworkVxlanRange networkVxlanRange = cache.get(rangeId);
         if (networkVxlanRange == null) {
@@ -156,6 +165,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
      * @throws Exception Network Range Already Exist Exception
      * @throws Exception Internal Db Operation Exception
      */
+    @DurationStatistics
     public synchronized void createRange(NetworkRangeRequest request) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             if (cache.get(request.getId()) != null) {
@@ -188,6 +198,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
      * @return vxlan range
      * @throws Exception Network Range Not Found Exception
      */
+    @DurationStatistics
     public synchronized NetworkVxlanRange deleteRange(String rangeId) throws Exception {
         try (Transaction tx = cache.getTransaction().start()) {
             NetworkVxlanRange networkVxlanRange = cache.get(rangeId);
@@ -210,6 +221,7 @@ public class VxlanRangeRepository implements ICacheRepository<NetworkVxlanRange>
      * @return vxlan range
      * @throws Exception
      */
+    @DurationStatistics
     public synchronized NetworkVxlanRange getRange(String rangeId) throws Exception {
         return cache.get(rangeId);
     }

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRepository.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/dao/VxlanRepository.java
@@ -6,6 +6,7 @@ import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.db.repo.ICacheRepository;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.vpcmanager.entity.NetworkVxlanType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -37,27 +38,32 @@ public class VxlanRepository implements ICacheRepository<NetworkVxlanType> {
     }
 
     @Override
+    @DurationStatistics
     public NetworkVxlanType findItem(String id) throws CacheException {
         return cache.get(id);
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVxlanType> findAllItems() throws CacheException {
         return cache.getAll();
     }
 
     @Override
+    @DurationStatistics
     public Map<String, NetworkVxlanType> findAllItems(Map<String, Object[]> queryParams) throws CacheException {
         return cache.getAll(queryParams);
     }
 
     @Override
+    @DurationStatistics
     public void addItem(NetworkVxlanType newItem) throws CacheException {
         logger.log(Level.INFO, "Add Vxlan, Vxlan Id:" + newItem.getVxlanId());
         cache.put(newItem.getVxlanId(), newItem);
     }
 
     @Override
+    @DurationStatistics
     public void deleteItem(String id) throws CacheException {
         logger.log(Level.INFO, "Delete Vxlan, Vxlan Id:" + id);
         cache.remove(id);

--- a/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/Impl/VpcServiceImpl.java
+++ b/services/vpc_manager/src/main/java/com/futurewei/alcor/vpcmanager/service/Impl/VpcServiceImpl.java
@@ -54,6 +54,7 @@ public class VpcServiceImpl implements VpcService {
      * @throws Exception
      */
     @Override
+    @DurationStatistics
     public VpcEntity allocateSegmentForNetwork(VpcEntity vpcEntity) throws Exception {
         String networkTypeId = UUID.randomUUID().toString();
         if (vpcEntity == null) {
@@ -90,6 +91,7 @@ public class VpcServiceImpl implements VpcService {
      * @throws SubnetsNotEmptyException
      */
     @Override
+    @DurationStatistics
     public boolean checkSubnetsAreEmpty(VpcEntity vpcEntity) throws SubnetsNotEmptyException {
         if (vpcEntity == null) {
             return true;


### PR DESCRIPTION
We have been using a home-grown elapsed time annotation to provide method-level metrics on elapsed time in Port Manager. This PR applies the same elapsed time annotation to the following microservices so that we can easily collect latency metrics and identify potential bottleneck.
- Mac Mgr
- Node Mgr
- Route Mgr
- SG Mgr
- Subnet Mgr
- VPC Mgr
- DPM
- EIP Mgr