### PR TITLE
[API GW] Ensure Thread-safe Date Format Strings

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/entity/TokenEntity.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/entity/TokenEntity.java
@@ -158,7 +158,7 @@ public class TokenEntity implements Serializable {
     }
 
     public String toJson() {
-        String expireAtStr = expireAt == null ? "":DateUtil.KEYSTONE_DATE_FORMAT.format(expireAt);
+        String expireAtStr = expireAt == null ? "":DateUtil.getKeystoneDateFormat().format(expireAt);
         return "{" +
                 "\"token\":\"" + token + "\"" +
                 ", \"expireAt\":\"" + expireAtStr + "\"" +

--- a/lib/src/main/java/com/futurewei/alcor/common/utils/ControllerUtil.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/utils/ControllerUtil.java
@@ -18,7 +18,6 @@ package com.futurewei.alcor.common.utils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.futurewei.alcor.common.entity.TokenEntity;
-import static com.futurewei.alcor.common.utils.DateUtil.KEYSTONE_DATE_FORMAT;
 import com.futurewei.alcor.common.exception.QueryParamTypeNotSupportException;
 import com.google.common.collect.ObjectArrays;
 import org.slf4j.Logger;
@@ -27,7 +26,6 @@ import org.thymeleaf.util.StringUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/lib/src/main/java/com/futurewei/alcor/common/utils/DateUtil.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/utils/DateUtil.java
@@ -22,8 +22,18 @@ import java.util.Date;
 
 public class DateUtil {
 
+    private static final ThreadLocal<SimpleDateFormat> keystoneFormatLocal = new ThreadLocal<SimpleDateFormat>(){
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(KEYSTONE_TOKEN_DATE_PATTERN);
+        }
+    };
+
     public static final String KEYSTONE_TOKEN_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-    public static final SimpleDateFormat KEYSTONE_DATE_FORMAT = new SimpleDateFormat(KEYSTONE_TOKEN_DATE_PATTERN);
+
+    public static SimpleDateFormat getKeystoneDateFormat() {
+        return keystoneFormatLocal.get();
+    }
 
     public static String localToUTC(String localTime, String format) {
         SimpleDateFormat sdf = new SimpleDateFormat(format);

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/client/KeystoneClient.java
@@ -25,7 +25,8 @@ import com.futurewei.alcor.common.db.CacheException;
 import com.futurewei.alcor.common.db.CacheFactory;
 import com.futurewei.alcor.common.db.ICache;
 import com.futurewei.alcor.common.entity.TokenEntity;
-import static com.futurewei.alcor.common.utils.DateUtil.KEYSTONE_DATE_FORMAT;
+import static com.futurewei.alcor.common.utils.DateUtil.getKeystoneDateFormat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -171,7 +172,7 @@ public class KeystoneClient {
             if (!"null".equals(expireDateStr)) {
                 expireDateStr = expireDateStr.replace("000Z", "+0000");
                 try {
-                    localTokenExpireDate = KEYSTONE_DATE_FORMAT.parse(expireDateStr);
+                    localTokenExpireDate = getKeystoneDateFormat().parse(expireDateStr);
                     LOG.info("generate an alcor token success: {}", localToken);
                 } catch (ParseException e) {
                     LOG.error("generate an alcor Token failed, {}", e.getMessage());
@@ -226,7 +227,9 @@ public class KeystoneClient {
 
                 String expireDateStr = tokenNode.path(JSON_EXPIRES_AT_KEY).asText();
                 expireDateStr = expireDateStr.replace("000Z", "+0000");
-                Date expireDate = KEYSTONE_DATE_FORMAT.parse(expireDateStr);
+
+                Date expireDate = getKeystoneDateFormat().parse(expireDateStr);
+
                 te.setExpireAt(expireDate);
 
                 if(tokenNode.has(JSON_ROLES_KEY)){


### PR DESCRIPTION
This PR fixs an API GW time format bug where the KeyStone data format strings was not thread-safe. This PR uses ThreadLocal variable to make sure two threads can't see each others' ThreadLocal variables.

__Bug Description__
In a high-stress testing, API GW had a chance of throwing a "java.lang.NumberFormatException" exception, 13 out of a few 10,000 REST API calls.
   