### PR TITLE
[Port Manager] Support L2 and L3 Type Neighbors

### DIFF
--- a/services/data_plane_manager/pom.xml
+++ b/services/data_plane_manager/pom.xml
@@ -75,6 +75,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.5</version>

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/DataPlaneClient.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/DataPlaneClient.java
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.client;
+
+import com.futurewei.alcor.dataplane.entity.HostGoalState;
+import com.futurewei.alcor.schema.Goalstate.GoalState;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public interface DataPlaneClient {
+    void createGoalState(GoalState goalState, String hostIp) throws Exception;
+    void createGoalState(List<HostGoalState> hostGoalStates) throws Exception;
+    void updateGoalState(List<HostGoalState> hostGoalStates) throws Exception;
+    void deleteGoalState(List<HostGoalState> hostGoalStates) throws Exception;
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.client.grpc;
+
+import com.futurewei.alcor.dataplane.client.DataPlaneClient;
+import com.futurewei.alcor.dataplane.config.grpc.GoalStateProvisionerClient;
+import com.futurewei.alcor.dataplane.entity.HostGoalState;
+import com.futurewei.alcor.schema.Goalstate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DataPlaneClientImpl implements DataPlaneClient {
+    private int grpcPort;
+
+    @Autowired
+    public DataPlaneClientImpl(int grpcPort) {
+        this.grpcPort = grpcPort;
+    }
+
+    @Override
+    public void createGoalState(Goalstate.GoalState goalState, String hostIp) throws Exception {
+
+    }
+
+    @Override
+    public void createGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+        for (HostGoalState hostGoalState: hostGoalStates) {
+            GoalStateProvisionerClient goalStateProvisionerClient =
+                    new GoalStateProvisionerClient(hostGoalState.getHostIp(), grpcPort);
+            goalStateProvisionerClient.PushNetworkResourceStates(hostGoalState.getGoalState());
+            goalStateProvisionerClient.shutdown();
+        }
+    }
+
+    @Override
+    public void updateGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+
+    @Override
+    public void deleteGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/kafka/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/kafka/DataPlaneClientImpl.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.client.kafka;
+
+import com.futurewei.alcor.dataplane.client.DataPlaneClient;
+import com.futurewei.alcor.dataplane.entity.HostGoalState;
+import com.futurewei.alcor.schema.Goalstate;
+
+import java.util.List;
+
+public class DataPlaneClientImpl implements DataPlaneClient {
+    @Override
+    public void createGoalState(Goalstate.GoalState goalState, String hostIp) throws Exception {
+
+    }
+
+    @Override
+    public void createGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+
+    @Override
+    public void updateGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+
+    @Override
+    public void deleteGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.client.pulsar;
+
+import com.futurewei.alcor.dataplane.client.DataPlaneClient;
+import com.futurewei.alcor.dataplane.entity.HostGoalState;
+import com.futurewei.alcor.schema.Goalstate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DataPlaneClientImpl implements DataPlaneClient {
+    @Autowired
+    private TopicManager topicManager;
+
+    @Override
+    public void createGoalState(Goalstate.GoalState goalState, String hostIp) throws Exception {
+
+    }
+
+    @Override
+    public void createGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+        for (HostGoalState hostGoalState: hostGoalStates) {
+            String topic = topicManager.getTopicByHostIp(hostGoalState.getHostIp());
+        }
+    }
+
+    @Override
+    public void updateGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+
+    @Override
+    public void deleteGoalState(List<HostGoalState> hostGoalStates) throws Exception {
+
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/TopicManager.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/TopicManager.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.client.pulsar;
+
+public class TopicManager {
+
+    public String getTopicByHostIp(String hostIp) {
+        return null;
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DataPlaneController.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DataPlaneController.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.controller;
+
+import com.futurewei.alcor.common.stats.DurationStatistics;
+import com.futurewei.alcor.dataplane.service.DataPlaneService;
+import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+public class DataPlaneController {
+    @Autowired
+    private DataPlaneService dataPlaneService;
+
+    @PostMapping({"/port/", "v4/port/"})
+    @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
+    public NetworkConfiguration createNetworkConfiguration(@RequestBody NetworkConfiguration networkConfiguration) throws Exception {
+        return dataPlaneService.createNetworkConfiguration(networkConfiguration);
+    }
+
+    @PutMapping({"/port/", "v4/port/"})
+    @DurationStatistics
+    public NetworkConfiguration updateNetworkConfiguration(@RequestBody NetworkConfiguration networkConfiguration) throws Exception {
+        return dataPlaneService.updateNetworkConfiguration(networkConfiguration);
+    }
+
+    @DeleteMapping({"/port/", "v4/port/"})
+    @DurationStatistics
+    public NetworkConfiguration deleteNetworkConfiguration(@RequestBody NetworkConfiguration networkConfiguration) throws Exception {
+        return dataPlaneService.deleteNetworkConfiguration(networkConfiguration);
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/HostGoalState.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/HostGoalState.java
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.entity;
+
+import com.futurewei.alcor.schema.Goalstate.GoalState;
+
+public class HostGoalState {
+    private String hostIp;
+    private GoalState goalState;
+
+    public HostGoalState() {
+
+    }
+
+    public HostGoalState(String hostIp, GoalState goalState) {
+        this.hostIp = hostIp;
+        this.goalState = goalState;
+    }
+
+    public String getHostIp() {
+        return hostIp;
+    }
+
+    public void setHostIp(String hostIp) {
+        this.hostIp = hostIp;
+    }
+
+    public GoalState getGoalState() {
+        return goalState;
+    }
+
+    public void setGoalState(GoalState goalState) {
+        this.goalState = goalState;
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/NeighborInfoNotFound.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/NeighborInfoNotFound.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Neighbor info not found")
+public class NeighborInfoNotFound extends Exception {
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/SecurityGroupNotFound.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/SecurityGroupNotFound.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Security group not found")
+public class SecurityGroupNotFound extends Exception {
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/SubnetEntityNotFound.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/SubnetEntityNotFound.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Subnet entity not found")
+public class SubnetEntityNotFound extends Exception {
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/UnknownResourceType.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/UnknownResourceType.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Unknown resource type")
+public class UnknownResourceType extends Exception {
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/VpcEntityNotFound.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/exception/VpcEntityNotFound.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.PRECONDITION_FAILED, reason = "Vpc entity not found")
+public class VpcEntityNotFound extends Exception {
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/DataPlaneService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/DataPlaneService.java
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.service;
+
+import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+
+public interface DataPlaneService {
+    NetworkConfiguration createNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception;
+    NetworkConfiguration updateNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception;
+    NetworkConfiguration deleteNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception;
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/mizar/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/mizar/DataPlaneServiceImpl.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.service.mizar;
+
+import com.futurewei.alcor.dataplane.service.DataPlaneService;
+import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+
+public class DataPlaneServiceImpl implements DataPlaneService {
+    @Override
+    public NetworkConfiguration createNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception {
+        return null;
+    }
+
+    @Override
+    public NetworkConfiguration updateNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception {
+        return null;
+    }
+
+    @Override
+    public NetworkConfiguration deleteNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception {
+        return null;
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.dataplane.client.DataPlaneClient;
 import com.futurewei.alcor.dataplane.entity.HostGoalState;
 import com.futurewei.alcor.dataplane.exception.*;
 import com.futurewei.alcor.dataplane.service.DataPlaneService;
+import com.futurewei.alcor.schema.Common.MessageType;
 import com.futurewei.alcor.schema.Common.NetworkType;
 import com.futurewei.alcor.schema.Common.EtherType;
 import com.futurewei.alcor.schema.Common.Protocol;
@@ -29,7 +30,6 @@ import com.futurewei.alcor.schema.Goalstate.GoalState;
 import com.futurewei.alcor.schema.Neighbor.NeighborState;
 import com.futurewei.alcor.schema.Neighbor.NeighborConfiguration;
 import com.futurewei.alcor.schema.Neighbor.NeighborType;
-import com.futurewei.alcor.schema.Port.MessageType;
 import com.futurewei.alcor.schema.Port.PortConfiguration;
 import com.futurewei.alcor.schema.Port.PortConfiguration.HostInfo;
 import com.futurewei.alcor.schema.Port.PortConfiguration.FixedIp;
@@ -253,7 +253,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
             NeighborConfiguration.Builder neighborConfigBuilder = NeighborConfiguration.newBuilder();
             //neighborConfigBuilder.setId();
             NeighborType neighborType = NeighborType.valueOf(neighborEntry.getNeighborType().getType());
-            neighborConfigBuilder.setNeighborType(neighborType);
+            //neighborConfigBuilder.setNeighborType(neighborType);
             //neighborConfigBuilder.setProjectId();
             neighborConfigBuilder.setVpcId(neighborInfo.getVpcId());
             //neighborConfigBuilder.setName();
@@ -381,7 +381,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
 
         RouterConfiguration.Builder routerConfigBuilder = RouterConfiguration.newBuilder();
         //routerConfigBuilder.setHostDvrMacAddress();
-        routerConfigBuilder.addAllSubnetIds(subnetIds);
+        //routerConfigBuilder.addAllSubnetIds(subnetIds);
 
         RouterState.Builder routerStateBuilder = RouterState.newBuilder();
         routerStateBuilder.setOperationType(networkConfig.getOpType());

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -1,0 +1,455 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.dataplane.service.ovs;
+
+import com.futurewei.alcor.dataplane.client.DataPlaneClient;
+import com.futurewei.alcor.dataplane.entity.HostGoalState;
+import com.futurewei.alcor.dataplane.exception.*;
+import com.futurewei.alcor.dataplane.service.DataPlaneService;
+import com.futurewei.alcor.schema.Common.NetworkType;
+import com.futurewei.alcor.schema.Common.EtherType;
+import com.futurewei.alcor.schema.Common.Protocol;
+import com.futurewei.alcor.schema.Common.ResourceType;
+import com.futurewei.alcor.schema.DHCP.DHCPState;
+import com.futurewei.alcor.schema.DHCP.DHCPConfiguration;
+import com.futurewei.alcor.schema.Goalstate.GoalState;
+import com.futurewei.alcor.schema.Neighbor.NeighborState;
+import com.futurewei.alcor.schema.Neighbor.NeighborConfiguration;
+import com.futurewei.alcor.schema.Neighbor.NeighborType;
+import com.futurewei.alcor.schema.Port.MessageType;
+import com.futurewei.alcor.schema.Port.PortConfiguration;
+import com.futurewei.alcor.schema.Port.PortConfiguration.HostInfo;
+import com.futurewei.alcor.schema.Port.PortConfiguration.FixedIp;
+import com.futurewei.alcor.schema.Port.PortConfiguration.AllowAddressPair;
+import com.futurewei.alcor.schema.Port.PortConfiguration.SecurityGroupId;
+import com.futurewei.alcor.schema.Port.PortState;
+import com.futurewei.alcor.schema.Router.RouterState;
+import com.futurewei.alcor.schema.Router.RouterConfiguration;
+import com.futurewei.alcor.schema.Subnet.SubnetConfiguration;
+import com.futurewei.alcor.schema.Subnet.SubnetConfiguration.Gateway;
+import com.futurewei.alcor.schema.Subnet.SubnetState;
+import com.futurewei.alcor.schema.Vpc.VpcConfiguration;
+import com.futurewei.alcor.schema.Vpc.VpcConfiguration.SubnetId;
+import com.futurewei.alcor.schema.Vpc.VpcState;
+import com.futurewei.alcor.schema.SecurityGroup.SecurityGroupState;
+import com.futurewei.alcor.schema.SecurityGroup.SecurityGroupConfiguration;
+import com.futurewei.alcor.schema.SecurityGroup.SecurityGroupConfiguration.Direction;
+import com.futurewei.alcor.web.entity.dataplane.*;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
+import com.futurewei.alcor.web.entity.vpc.VpcEntity;
+import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class DataPlaneServiceImpl implements DataPlaneService {
+    @Autowired
+    private DataPlaneClient dataPlaneClient;
+
+    private VpcEntity getVpcEntity(NetworkConfiguration networkConfig, String vpcId) throws Exception {
+        VpcEntity result = null;
+        for (VpcEntity vpcEntity: networkConfig.getVpcs()) {
+            if (vpcEntity.getId().equals(vpcId)) {
+                result = vpcEntity;
+            }
+        }
+
+        if (result == null) {
+            throw new VpcEntityNotFound();
+        }
+
+        return result;
+    }
+
+    private void buildVpcState(NetworkConfiguration networkConfig, GoalState.Builder goalStateBuilder) throws Exception {
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        for (PortState portState: portStates) {
+            VpcEntity vpcEntity = getVpcEntity(networkConfig, portState.getConfiguration().getId());
+            VpcConfiguration.Builder vpcConfigBuilder = VpcConfiguration.newBuilder();
+            vpcConfigBuilder.setId(vpcEntity.getId());
+            vpcConfigBuilder.setProjectId(vpcEntity.getProjectId());
+            vpcConfigBuilder.setName(vpcEntity.getName());
+            vpcConfigBuilder.setCidr(vpcEntity.getCidr());
+            vpcConfigBuilder.setTunnelId(Long.parseLong(vpcEntity.getTenantId()));
+
+            networkConfig.getSubnets().stream()
+                    .filter(s -> s.getVpcId().equals(vpcEntity.getId()))
+                    .map(InternalSubnetEntity::getId)
+                    .forEach(id -> {
+                        SubnetId.Builder subnetIdBuilder = SubnetId.newBuilder();
+                        subnetIdBuilder.setId(id);
+                        vpcConfigBuilder.addSubnetIds(subnetIdBuilder.build());
+                    });
+
+            //set routes here
+
+            VpcState.Builder vpcStateBuilder = VpcState.newBuilder();
+            vpcStateBuilder.setOperationType(networkConfig.getOpType());
+            vpcStateBuilder.setConfiguration(vpcConfigBuilder.build());
+
+            goalStateBuilder.addVpcStates(vpcStateBuilder.build());
+        }
+    }
+
+    private InternalSubnetEntity getInternalSubnetEntity(NetworkConfiguration networkConfig, String subnetId) throws Exception {
+        InternalSubnetEntity result = null;
+        for (InternalSubnetEntity internalSubnetEntity: networkConfig.getSubnets()) {
+            if (internalSubnetEntity.getId().equals(subnetId)) {
+                result = internalSubnetEntity;
+            }
+        }
+
+        if (result == null) {
+            throw new SubnetEntityNotFound();
+        }
+
+        return result;
+    }
+
+    private void buildSubnetState(NetworkConfiguration networkConfig, GoalState.Builder goalStateBuilder) throws Exception {
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        List<InternalSubnetEntity> subnetEntities = new ArrayList<>();
+        for (PortState portState: portStates) {
+            for (FixedIp fixedIp: portState.getConfiguration().getFixedIpsList()) {
+                InternalSubnetEntity internalSubnetEntity = getInternalSubnetEntity(
+                        networkConfig, fixedIp.getSubnetId());
+                subnetEntities.add(internalSubnetEntity);
+            }
+        }
+
+        for (InternalSubnetEntity subnetEntity: subnetEntities) {
+            SubnetConfiguration.Builder subnetConfigBuilder = SubnetConfiguration.newBuilder();
+            subnetConfigBuilder.setId(subnetEntity.getId());
+            subnetConfigBuilder.setNetworkType(NetworkType.VXLAN);
+            subnetConfigBuilder.setProjectId(subnetEntity.getProjectId());
+            subnetConfigBuilder.setVpcId(subnetEntity.getVpcId());
+            subnetConfigBuilder.setName(subnetEntity.getName());
+            subnetConfigBuilder.setCidr(subnetEntity.getCidr());
+            subnetConfigBuilder.setTunnelId(subnetEntity.getTunnelId());
+
+            Gateway.Builder gatewayBuilder = Gateway.newBuilder();
+            gatewayBuilder.setIpAddress(subnetEntity.getGatewayIp());
+            gatewayBuilder.setMacAddress(subnetEntity.getGatewayMacAddress());
+            subnetConfigBuilder.setGateway(gatewayBuilder.build());
+            subnetConfigBuilder.setDhcpEnable(subnetEntity.getDhcpEnable());
+            subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
+            subnetConfigBuilder.setPrimaryDns(subnetEntity.getPrimaryDns());
+            subnetConfigBuilder.setSecondaryDns(subnetEntity.getSecondaryDns());
+
+            SubnetState.Builder subnetStateBuilder = SubnetState.newBuilder();
+            subnetStateBuilder.setOperationType(networkConfig.getOpType());
+            subnetStateBuilder.setConfiguration(subnetConfigBuilder.build());
+            goalStateBuilder.addSubnetStates(subnetStateBuilder.build());
+        }
+    }
+
+    private void buildPortState(NetworkConfiguration networkConfig, List<InternalPortEntity> portEntities, GoalState.Builder goalStateBuilder) {
+        for (InternalPortEntity portEntity: portEntities) {
+            PortConfiguration.Builder portConfigBuilder = PortConfiguration.newBuilder();
+            portConfigBuilder.setId(portEntity.getId());
+            portConfigBuilder.setMessageType(MessageType.FULL);
+            portConfigBuilder.setNetworkType(NetworkType.VXLAN);
+            portConfigBuilder.setProjectId(portEntity.getProjectId());
+            portConfigBuilder.setVpcId(portEntity.getVpcId());
+            portConfigBuilder.setName(portEntity.getName());
+            portConfigBuilder.setMacAddress(portEntity.getMacAddress());
+            portConfigBuilder.setAdminStateUp(portEntity.isAdminStateUp());
+
+            HostInfo.Builder hostInfoBuilder = HostInfo.newBuilder();
+            hostInfoBuilder.setIpAddress(portEntity.getBindingHostIP());
+            //TODO: Do we need mac address?
+            //hostInfoBuilder.setMacAddress()
+            portConfigBuilder.setHostInfo(hostInfoBuilder.build());
+            portEntity.getFixedIps().forEach(fixedIp -> {
+                FixedIp.Builder fixedIpBuilder = FixedIp.newBuilder();
+                fixedIpBuilder.setSubnetId(fixedIp.getSubnetId());
+                fixedIpBuilder.setIpAddress(fixedIp.getIpAddress());
+                portConfigBuilder.addFixedIps(fixedIpBuilder.build());
+            });
+
+            portEntity.getAllowedAddressPairs().forEach(pair -> {
+                AllowAddressPair.Builder allowAddressPairBuilder = AllowAddressPair.newBuilder();
+                allowAddressPairBuilder.setIpAddress(pair.getIpAddress());
+                allowAddressPairBuilder.setMacAddress(pair.getMacAddress());
+                portConfigBuilder.addAllowAddressPairs(allowAddressPairBuilder.build());
+            });
+
+            portEntity.getSecurityGroups().forEach(securityGroupId-> {
+                SecurityGroupId.Builder securityGroupIdBuilder = SecurityGroupId.newBuilder();
+                securityGroupIdBuilder.setId(securityGroupId);
+                portConfigBuilder.addSecurityGroupIds(securityGroupIdBuilder.build());
+            });
+
+            //PortState
+            PortState.Builder portStateBuilder = PortState.newBuilder();
+            portStateBuilder.setOperationType(networkConfig.getOpType());
+            portStateBuilder.setConfiguration(portConfigBuilder.build());
+            goalStateBuilder.addPortStates(portStateBuilder.build());
+        }
+    }
+
+    private NeighborInfo getNeighborInfo(NetworkConfiguration networkConfig, String hostIp) throws Exception {
+        NeighborInfo result = null;
+        for (NeighborInfo neighborInfo: networkConfig.getNeighborInfos()) {
+            if (neighborInfo.getHostId().equals(hostIp)) {
+                result = neighborInfo;
+                break;
+            }
+        }
+
+        if (result == null) {
+            throw new NeighborInfoNotFound();
+        }
+
+        return result;
+    }
+
+    private void buildNeighborState(NetworkConfiguration networkConfig, String hostIp, GoalState.Builder goalStateBuilder) throws Exception {
+        List<NeighborInfo> neighborInfos = networkConfig.getNeighborInfos();
+        if (neighborInfos == null || neighborInfos.size() == 0) {
+            return;
+        }
+
+        List<NeighborEntry> neighborTable = networkConfig.getNeighborTable();
+        if (neighborTable == null || neighborTable.size() == 0) {
+            return;
+        }
+
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        for (NeighborEntry neighborEntry: neighborTable) {
+            if (!hostIp.equals(neighborEntry.getLocalIp())) {
+                continue;
+            }
+
+            NeighborInfo neighborInfo = getNeighborInfo(networkConfig, neighborEntry.getNeighborIp());
+            NeighborConfiguration.Builder neighborConfigBuilder = NeighborConfiguration.newBuilder();
+            //neighborConfigBuilder.setId();
+            NeighborType neighborType = NeighborType.valueOf(neighborEntry.getNeighborType().getType());
+            neighborConfigBuilder.setNeighborType(neighborType);
+            //neighborConfigBuilder.setProjectId();
+            neighborConfigBuilder.setVpcId(neighborInfo.getVpcId());
+            //neighborConfigBuilder.setName();
+            neighborConfigBuilder.setMacAddress(neighborInfo.getPortMac());
+            neighborConfigBuilder.setHostIpAddress(neighborInfo.getHostIp());
+            //TODO:setNeighborHostDvrMac
+            //neighborConfigBuilder.setNeighborHostDvrMac();
+            NeighborConfiguration.FixedIp.Builder fixedIpBuilder = NeighborConfiguration.FixedIp.newBuilder();
+            fixedIpBuilder.setSubnetId(neighborInfo.getSubnetId());
+            fixedIpBuilder.setIpAddress(neighborInfo.getPortIp());
+            neighborConfigBuilder.addFixedIps(fixedIpBuilder.build());
+            //TODO:setAllowAddressPairs
+            //neighborConfigBuilder.setAllowAddressPairs();
+
+            NeighborState.Builder neighborStateBuilder = NeighborState.newBuilder();
+            neighborStateBuilder.setOperationType(networkConfig.getOpType());
+            neighborStateBuilder.setConfiguration(neighborConfigBuilder.build());
+            goalStateBuilder.addNeighborStates(neighborStateBuilder.build());
+        }
+    }
+
+    private SecurityGroup getSecurityGroup(NetworkConfiguration networkConfig, String securityGroupId) throws Exception {
+        SecurityGroup result = null;
+        for (SecurityGroup securityGroup: networkConfig.getSecurityGroups()) {
+            if (securityGroup.getId().equals(securityGroupId)) {
+                result = securityGroup;
+                break;
+            }
+        }
+
+        if (result == null) {
+            throw new SecurityGroupNotFound();
+        }
+
+        return result;
+    }
+
+
+    private void buildSecurityGroupState(NetworkConfiguration networkConfig, GoalState.Builder goalStateBuilder) throws Exception {
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        Set<String> securityGroupIds = new HashSet<>();
+        for (PortState portState: portStates) {
+            List<SecurityGroupId> securityGroupIdList= portState.getConfiguration().getSecurityGroupIdsList();
+            securityGroupIds.addAll(securityGroupIdList.stream()
+                    .map(SecurityGroupId::getId)
+                    .collect(Collectors.toList()));
+        }
+
+        for (String securityGroupId: securityGroupIds) {
+            SecurityGroup securityGroup = getSecurityGroup(networkConfig, securityGroupId);
+            SecurityGroupConfiguration.Builder securityGroupConfigBuilder = SecurityGroupConfiguration.newBuilder();
+            securityGroupConfigBuilder.setId(securityGroup.getId());
+            securityGroupConfigBuilder.setProjectId(securityGroup.getProjectId());
+            //securityGroupConfigBuilder.setVpcId();
+            securityGroupConfigBuilder.setName(securityGroup.getName());
+
+            for (SecurityGroupRule securityGroupRule: securityGroup.getSecurityGroupRules()) {
+                SecurityGroupConfiguration.SecurityGroupRule.Builder securityGroupRuleBuilder =
+                        SecurityGroupConfiguration.SecurityGroupRule.newBuilder();
+                securityGroupRuleBuilder.setSecurityGroupId(securityGroup.getId());
+                securityGroupRuleBuilder.setId(securityGroupRule.getId());
+                securityGroupRuleBuilder.setDirection(Direction.valueOf(securityGroupRule.getDirection()));
+                securityGroupRuleBuilder.setEthertype(EtherType.valueOf(securityGroupRule.getEtherType()));
+                securityGroupRuleBuilder.setProtocol(Protocol.valueOf(securityGroupRule.getProtocol()));
+                securityGroupRuleBuilder.setPortRangeMin(securityGroupRule.getPortRangeMin());
+                securityGroupRuleBuilder.setPortRangeMax(securityGroupRule.getPortRangeMax());
+                securityGroupRuleBuilder.setRemoteIpPrefix(securityGroupRule.getRemoteIpPrefix());
+                securityGroupRuleBuilder.setRemoteGroupId(securityGroupRule.getRemoteGroupId());
+                securityGroupConfigBuilder.addSecurityGroupRules(securityGroupRuleBuilder.build());
+            }
+
+            SecurityGroupState.Builder securityGroupStateBuilder = SecurityGroupState.newBuilder();
+            securityGroupStateBuilder.setOperationType(networkConfig.getOpType());
+            securityGroupStateBuilder.setConfiguration(securityGroupConfigBuilder.build());
+            goalStateBuilder.addSecurityGroupStates(securityGroupStateBuilder.build());
+        }
+    }
+
+    private void buildDhcpState(NetworkConfiguration networkConfig, GoalState.Builder goalStateBuilder) throws Exception {
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        for (PortState portState: portStates) {
+            String macAddress = portState.getConfiguration().getMacAddress();
+            List<FixedIp> fixedIps = portState.getConfiguration().getFixedIpsList();
+            for (FixedIp fixedIp: fixedIps) {
+                DHCPConfiguration.Builder dhcpConfigBuilder = DHCPConfiguration.newBuilder();
+                dhcpConfigBuilder.setMacAddress(macAddress);
+                dhcpConfigBuilder.setIpv4Address(fixedIp.getIpAddress());
+                //TODO: support ipv6
+                //dhcpConfigBuilder.setIpv6Address();
+                //dhcpConfigBuilder.setPortHostName();
+                //dhcpConfigBuilder.setExtraDhcpOptions();
+                //dhcpConfigBuilder.setDnsEntryList();
+
+                DHCPState.Builder dhcpStateBuilder = DHCPState.newBuilder();
+                dhcpStateBuilder.setOperationType(networkConfig.getOpType());
+                dhcpStateBuilder.setConfiguration(dhcpConfigBuilder.build());
+                goalStateBuilder.addDhcpStates(dhcpStateBuilder.build());
+            }
+        }
+    }
+
+    private void buildRouterState(NetworkConfiguration networkConfig, GoalState.Builder goalStateBuilder) throws Exception {
+        List<PortState> portStates = goalStateBuilder.getPortStatesList();
+        if (portStates == null || portStates.size() == 0) {
+            return;
+        }
+
+        Set<String> subnetIds = new HashSet<>();
+        for (PortState portState: portStates) {
+            List<FixedIp> fixedIps = portState.getConfiguration().getFixedIpsList();
+            for (FixedIp fixedIp: fixedIps) {
+                InternalSubnetEntity internalSubnetEntity =
+                        getInternalSubnetEntity(networkConfig, fixedIp.getSubnetId());
+                subnetIds.add(internalSubnetEntity.getId());
+            }
+        }
+
+        RouterConfiguration.Builder routerConfigBuilder = RouterConfiguration.newBuilder();
+        //routerConfigBuilder.setHostDvrMacAddress();
+        routerConfigBuilder.addAllSubnetIds(subnetIds);
+
+        RouterState.Builder routerStateBuilder = RouterState.newBuilder();
+        routerStateBuilder.setOperationType(networkConfig.getOpType());
+        routerStateBuilder.setConfiguration(routerConfigBuilder.build());
+        goalStateBuilder.addRouterStates(routerStateBuilder.build());
+
+    }
+
+    private HostGoalState buildHostGoalState(NetworkConfiguration networkConfig, String hostIp, List<InternalPortEntity> portEntities) throws Exception {
+        GoalState.Builder goalStateBuilder = GoalState.newBuilder();
+
+        if (portEntities != null && portEntities.size() > 0) {
+            buildPortState(networkConfig, portEntities, goalStateBuilder);
+        }
+
+        buildVpcState(networkConfig, goalStateBuilder);
+        buildSubnetState(networkConfig, goalStateBuilder);
+        buildNeighborState(networkConfig, hostIp, goalStateBuilder);
+        buildSecurityGroupState(networkConfig, goalStateBuilder);
+        buildDhcpState(networkConfig, goalStateBuilder);
+        buildRouterState(networkConfig, goalStateBuilder);
+
+        HostGoalState hostGoalState = new HostGoalState();
+        hostGoalState.setHostIp(hostIp);
+        hostGoalState.setGoalState(goalStateBuilder.build());
+
+        return hostGoalState;
+    }
+
+    @Override
+    public NetworkConfiguration createNetworkConfiguration(NetworkConfiguration networkConfig) throws Exception {
+        List<HostGoalState> hostGoalStates = new ArrayList<>();
+        if (ResourceType.PORT.equals(networkConfig.getRsType())) {
+            Map<String, List<InternalPortEntity>> hostPortEntities = new HashMap<>();
+            for (InternalPortEntity portEntity: networkConfig.getPortEntities()) {
+                if (!hostPortEntities.containsKey(portEntity.getBindingHostIP())) {
+                    hostPortEntities.put(portEntity.getBindingHostIP(), new ArrayList<>());
+                }
+                hostPortEntities.get(portEntity.getBindingHostIP()).add(portEntity);
+            }
+
+            for (Map.Entry<String, List<InternalPortEntity>> entry: hostPortEntities.entrySet()) {
+                String hostIp = entry.getKey();
+                List<InternalPortEntity> portEntities = entry.getValue();
+                hostGoalStates.add(buildHostGoalState(networkConfig, hostIp, portEntities));
+            }
+        } else if (ResourceType.NEIGHBOR.equals(networkConfig.getRsType())) {
+            //hostGoalStates.add(buildHostGoalState(networkConfig, null, null));
+        } else if (ResourceType.SECURITYGROUP.equals(networkConfig.getRsType())) {
+            //hostGoalStates.add(buildHostGoalState(networkConfig, null, null));
+        } else if (ResourceType.ROUTER.equals(networkConfig.getRsType())) {
+            //hostGoalStates.add(buildHostGoalState(networkConfig, null, null));
+        } else {
+            throw new UnknownResourceType();
+        }
+
+        dataPlaneClient.createGoalState(hostGoalStates);
+
+        return networkConfig;
+    }
+
+    @Override
+    public NetworkConfiguration updateNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception {
+        return null;
+    }
+
+    @Override
+    public NetworkConfiguration deleteNetworkConfiguration(NetworkConfiguration networkConfiguration) throws Exception {
+        return null;
+    }
+}

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
@@ -458,6 +458,7 @@ public class GoalStateManager {
             currentPortEntity.getId(),
             currentPortEntity.getMacAddress()));
     tempPorts.add(currentPortEntity.getId());
+    /*
     if (currentPortEntity.getNeighborInfos() != null) {
       for (NeighborInfo neighborInfo : currentPortEntity.getNeighborInfos()) {
         tempNeighbor.add(
@@ -470,6 +471,8 @@ public class GoalStateManager {
         tempPorts.add(neighborInfo.getPortId());
       }
     }
+
+     */
 
     portsInSameSubnetMap.put(fixedIp.getSubnetId(), tempPorts);
     neighborInfoInSameSubenetMap.put(fixedIp.getSubnetId(), tempNeighbor);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -221,6 +221,6 @@ public class PortController {
     public RouterSubnetUpdateInfo updateL3Neighbors(@PathVariable("project_id") String projectId,
                                                     @RequestBody RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
         checkRouterSubnetUpdateInfo(routerSubnetUpdateInfo);
-        return portService.updateNeighbors(projectId, routerSubnetUpdateInfo);
+        return portService.updateL3Neighbors(projectId, routerSubnetUpdateInfo);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -20,7 +20,7 @@ import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.portmanager.exception.*;
 import com.futurewei.alcor.portmanager.service.PortService;
 import com.futurewei.alcor.web.entity.port.*;
-import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import com.futurewei.alcor.web.entity.route.RouterUpdateInfo;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import com.futurewei.alcor.web.rbac.aspect.Rbac;
 import io.netty.util.internal.StringUtil;
@@ -209,18 +209,16 @@ public class PortController {
     /**
      * Update neighbor tables and send them to DPM when adding or deleting gateway port
      * @param projectId Project Id
-     * @param routerSubnetUpdateInfo Router's latest subnet information
+     * @param routerUpdateInfo Router's latest subnet information
      * @return RouterSubnetUpdateInfo
      * @throws Exception Db operation exception
      */
     @Rbac(resource ="port")
-    @PostMapping({"/project/{project_id}/update-l3-neighbors", "v4/{project_id}/update-l3-neighbors"})
-    @ResponseBody
-    @ResponseStatus(HttpStatus.CREATED)
+    @PutMapping({"/project/{project_id}/update-l3-neighbors", "v4/{project_id}/update-l3-neighbors"})
     @DurationStatistics
-    public RouterSubnetUpdateInfo updateL3Neighbors(@PathVariable("project_id") String projectId,
-                                                    @RequestBody RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
-        checkRouterSubnetUpdateInfo(routerSubnetUpdateInfo);
-        return portService.updateL3Neighbors(projectId, routerSubnetUpdateInfo);
+    public RouterUpdateInfo updateL3Neighbors(@PathVariable("project_id") String projectId,
+                                              @RequestBody RouterUpdateInfo routerUpdateInfo) throws Exception {
+        checkRouterSubnetUpdateInfo(routerUpdateInfo);
+        return portService.updateL3Neighbors(projectId, routerUpdateInfo);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/controller/PortController.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.common.utils.ControllerUtil;
 import com.futurewei.alcor.portmanager.exception.*;
 import com.futurewei.alcor.portmanager.service.PortService;
 import com.futurewei.alcor.web.entity.port.*;
+import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
 import com.futurewei.alcor.web.json.annotation.FieldFilter;
 import com.futurewei.alcor.web.rbac.aspect.Rbac;
 import io.netty.util.internal.StringUtil;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static com.futurewei.alcor.common.constants.CommonConstants.QUERY_ATTR_HEADER;
 import static com.futurewei.alcor.portmanager.util.RestParameterValidator.checkPort;
+import static com.futurewei.alcor.portmanager.util.RestParameterValidator.checkRouterSubnetUpdateInfo;
 
 @RestController
 @ComponentScan(value = "com.futurewei.alcor.common.stats")
@@ -202,5 +204,23 @@ public class PortController {
                 .collect(Collectors.toList());
 
         return new PortWebBulkJson(portsList);
+    }
+
+    /**
+     * Update neighbor tables and send them to DPM when adding or deleting gateway port
+     * @param projectId Project Id
+     * @param routerSubnetUpdateInfo Router's latest subnet information
+     * @return RouterSubnetUpdateInfo
+     * @throws Exception Db operation exception
+     */
+    @Rbac(resource ="port")
+    @PostMapping({"/project/{project_id}/update-l3-neighbors", "v4/{project_id}/update-l3-neighbors"})
+    @ResponseBody
+    @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
+    public RouterSubnetUpdateInfo updateL3Neighbors(@PathVariable("project_id") String projectId,
+                                                    @RequestBody RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
+        checkRouterSubnetUpdateInfo(routerSubnetUpdateInfo);
+        return portService.updateNeighbors(projectId, routerSubnetUpdateInfo);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/GetConnectedSubnetException.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/GetConnectedSubnetException.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.INTERNAL_SERVER_ERROR, reason="Get connected subnets exception")
+public class GetConnectedSubnetException extends Exception {
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/OperationTypeInvalid.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/OperationTypeInvalid.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.PRECONDITION_FAILED, reason="Operation type invalid")
+public class OperationTypeInvalid extends Exception {
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/SubnetIdInvalid.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/SubnetIdInvalid.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.PRECONDITION_FAILED, reason="Subnet id invalid")
+public class SubnetIdInvalid extends Exception {
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/UnsupportedException.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/UnsupportedException.java
@@ -13,26 +13,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
         See the License for the specific language governing permissions and
         limitations under the License.
 */
-package com.futurewei.alcor.web.entity.router;
+package com.futurewei.alcor.portmanager.exception;
 
-import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-public class RouterSubnets {
-    private List<String> subnetIds;
-
-    public RouterSubnets() {
-
-    }
-
-    public RouterSubnets(List<String> subnetIds) {
-        this.subnetIds = subnetIds;
-    }
-
-    public List<String> getSubnetIds() {
-        return subnetIds;
-    }
-
-    public void setSubnetIds(List<String> subnetIds) {
-        this.subnetIds = subnetIds;
-    }
+@ResponseStatus(code= HttpStatus.PRECONDITION_FAILED, reason="Unsupported operation exception")
+public class UnsupportedException extends Exception {
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/VpcIdInvalid.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/VpcIdInvalid.java
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.PRECONDITION_FAILED, reason="Vpc id invalid")
+public class VpcIdInvalid extends Exception {
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AbstractProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AbstractProcessor.java
@@ -40,7 +40,7 @@ public abstract class AbstractProcessor implements IProcessor {
 
     @Override
     public void createPort(PortContext context) throws Exception {
-        LOG.debug("createPort() processor: {}", this);
+        LOG.info("createPort() processor: {}", this);
 
         createProcess(context);
         if (getNextProcessor() != null) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AfterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AfterProcessor.java
@@ -1,0 +1,20 @@
+package com.futurewei.alcor.portmanager.processor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.context.annotation.ImportSelector;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AfterProcessor {
+
+    /**
+     * {@link Configuration @Configuration}, {@link ImportSelector},
+     * {@link ImportBeanDefinitionRegistrar}, or regular component classes to import.
+     */
+    Class<?>[] value();
+
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AfterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/AfterProcessor.java
@@ -1,20 +1,10 @@
 package com.futurewei.alcor.portmanager.processor;
 
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.context.annotation.ImportSelector;
-
 import java.lang.annotation.*;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface AfterProcessor {
-
-    /**
-     * {@link Configuration @Configuration}, {@link ImportSelector},
-     * {@link ImportBeanDefinitionRegistrar}, or regular component classes to import.
-     */
     Class<?>[] value();
-
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.portmanager.processor;
 
 import com.futurewei.alcor.portmanager.exception.GetNodeInfoException;
+import com.futurewei.alcor.portmanager.exception.NodeInfoNotFound;
 import com.futurewei.alcor.portmanager.exception.PortEntityNotFound;
 import com.futurewei.alcor.portmanager.request.CreateNetworkConfigRequest;
 import com.futurewei.alcor.portmanager.request.DeleteNetworkConfigRequest;
@@ -58,6 +59,10 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
     private NeighborInfo getNeighborInfo(PortContext context, InternalPortEntity internalPortEntity, PortEntity.FixedIp fixedIp) throws Exception {
         List<NodeInfo> nodeInfos = context.getNodeInfos();
+        if (nodeInfos == null) {
+            throw new NodeInfoNotFound();
+        }
+
         NeighborInfo neighborInfo = null;
         for (NodeInfo nodeInfo: nodeInfos) {
             if (internalPortEntity.getBindingHostIP().equals(nodeInfo.getLocalIp())) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -31,6 +31,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+@AfterProcessor({FixedIpsProcessor.class, MacProcessor.class,
+        NeighborProcessor.class, NodeProcessor.class, PortProcessor.class,
+        RouterProcessor.class, SecurityGroupProcessor.class, VpcProcessor.class})
 public class DataPlaneProcessor extends AbstractProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(DataPlaneProcessor.class);
 
@@ -194,7 +197,8 @@ public class DataPlaneProcessor extends AbstractProcessor {
         context.getRequestManager().waitAllRequestsFinish();
 
         NetworkConfig networkConfig = context.getNetworkConfig();
-        if (networkConfig.getPortEntities().size() == 0) {
+        if (networkConfig.getPortEntities() == null
+                || networkConfig.getPortEntities().size() == 0) {
             return null;
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -80,11 +80,14 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
     private void buildL3Neighbors(PortContext context, InternalPortEntity internalPortEntity, PortEntity.FixedIp fixedIp, List<String> routerSubnetIds) throws Exception {
         List<NeighborInfo> neighborInfos = context.getNetworkConfig().getNeighborInfos();
+        if (neighborInfos == null) {
+            return;
+        }
 
         List<NeighborInfo> l3Neighbors = new ArrayList<>();
         NeighborInfo localNeighborInfo = null;
         for (NeighborInfo neighborInfo: neighborInfos) {
-            if (neighborInfo.getPortId().equals(fixedIp.getIpAddress())) {
+            if (neighborInfo.getPortIp().equals(fixedIp.getIpAddress())) {
                 localNeighborInfo = neighborInfo;
             }else if (routerSubnetIds.contains(neighborInfo.getSubnetId()) &&
                     !neighborInfo.getSubnetId().equals(fixedIp.getSubnetId())) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -45,7 +45,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
         return null;
     }
 
-    private void setNeighborInfos(PortContext context, InternalPortEntity internalPortEntity) {
+    private void setNeighborType(PortContext context, InternalPortEntity internalPortEntity) {
         List<NeighborInfo> neighborInfos = context.getNetworkConfig().getNeighborInfos();
         if (internalPortEntity.getFixedIps() == null || neighborInfos == null) {
             return;
@@ -67,12 +67,9 @@ public class DataPlaneProcessor extends AbstractProcessor {
             }
 
             if (subnetIds.contains(neighborInfo.getSubnetId())) {
-                internalPortEntity.getL2NeighborIds().add(neighborInfo.getPortIp());
-                if (subnetIds.size() > 1) {
-                    internalPortEntity.getL3NeighborIds().add(neighborInfo.getPortIp());
-                }
+                neighborInfo.setNeighborType(NeighborInfo.NeighborType.L3);
             } else {
-                internalPortEntity.getL3NeighborIds().add(neighborInfo.getPortIp());
+                neighborInfo.setNeighborType(NeighborInfo.NeighborType.L2);
             }
         }
     }
@@ -94,7 +91,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
                 internalPortEntity.setMacAddress(portEntity.getMacAddress());
             }
 
-            setNeighborInfos(context, internalPortEntity);
+            setNeighborType(context, internalPortEntity);
         }
 
         List<VpcEntity> vpcEntities = context.getNetworkConfig().getVpcEntities();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -21,6 +21,7 @@ import com.futurewei.alcor.web.entity.port.PortEntity;
 
 import java.util.*;
 
+@AfterProcessor(DataPlaneProcessor.class)
 public class DatabaseProcessor extends AbstractProcessor {
     private List<NeighborInfo> buildNeighborInfos(InternalPortEntity internalPortEntity) {
         List<NeighborInfo> neighborInfos = new ArrayList<>();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -30,7 +30,6 @@ public class DatabaseProcessor extends AbstractProcessor {
             return neighborInfos;
         }
 
-        //TODO: Support a port with multiple neighborInfos
         for (PortEntity.FixedIp fixedIp: internalPortEntity.getFixedIps()) {
             NeighborInfo neighborInfo = new NeighborInfo(bindingHostIp,
                     internalPortEntity.getBindingHostId(),

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -29,6 +29,7 @@ public class DatabaseProcessor extends AbstractProcessor {
             return neighborInfos;
         }
 
+        //TODO: Support a port with multiple neighborInfos
         for (PortEntity.FixedIp fixedIp: internalPortEntity.getFixedIps()) {
             NeighborInfo neighborInfo = new NeighborInfo(bindingHostIp,
                     internalPortEntity.getBindingHostId(),

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -35,7 +35,9 @@ public class DatabaseProcessor extends AbstractProcessor {
                     internalPortEntity.getId(),
                     internalPortEntity.getMacAddress(),
                     fixedIp.getIpAddress(),
-                    fixedIp.getSubnetId());
+                    internalPortEntity.getVpcId(),
+                    fixedIp.getSubnetId(),
+                    NeighborInfo.NeighborType.L2);
             neighborInfos.add(neighborInfo);
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -37,8 +37,7 @@ public class DatabaseProcessor extends AbstractProcessor {
                     internalPortEntity.getMacAddress(),
                     fixedIp.getIpAddress(),
                     internalPortEntity.getVpcId(),
-                    fixedIp.getSubnetId(),
-                    NeighborInfo.NeighborType.L2);
+                    fixedIp.getSubnetId());
             neighborInfos.add(neighborInfo);
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/FixedIpsProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/FixedIpsProcessor.java
@@ -29,6 +29,7 @@ import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@AfterProcessor(PortProcessor.class)
 public class FixedIpsProcessor extends AbstractProcessor {
     private boolean fixedIpsContainSubnet(List<PortEntity.FixedIp> fixedIps, String subnetId) {
         if (fixedIps == null) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/MacProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/MacProcessor.java
@@ -23,6 +23,7 @@ import com.futurewei.alcor.web.entity.port.PortEntity;
 import java.util.ArrayList;
 import java.util.List;
 
+@AfterProcessor(PortProcessor.class)
 public class MacProcessor extends AbstractProcessor {
     void allocateRandomMacAddressCallback(IRestRequest request) throws AllocateMacAddrException {
         List<MacState> macStates = ((AllocateMacAddressRequest) request).getResult();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
@@ -24,6 +24,7 @@ import com.futurewei.alcor.web.entity.port.PortEntity;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@AfterProcessor(PortProcessor.class)
 public class NeighborProcessor extends AbstractProcessor {
     private void fetchPortNeighborCallback(IRestRequest request) {
         List<PortNeighbors> portNeighborsList = ((FetchPortNeighborRequest) request).getPortNeighborsList();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
@@ -18,34 +18,31 @@ package com.futurewei.alcor.portmanager.processor;
 import com.futurewei.alcor.portmanager.entity.PortNeighbors;
 import com.futurewei.alcor.portmanager.request.FetchPortNeighborRequest;
 import com.futurewei.alcor.portmanager.request.IRestRequest;
-import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class NeighborProcessor extends AbstractProcessor {
     private void fetchPortNeighborCallback(IRestRequest request) {
         List<PortNeighbors> portNeighborsList = ((FetchPortNeighborRequest) request).getPortNeighborsList();
-        List<InternalPortEntity> internalPortEntities =
-                request.getContext().getNetworkConfig().getPortEntities();
-
-        for (InternalPortEntity internalPortEntity : internalPortEntities) {
-            for (PortNeighbors portNeighbors: portNeighborsList) {
-                if (portNeighbors.getNeighbors() == null) {
-                    continue;
-                }
-
-                if (internalPortEntity.getVpcId().equals(portNeighbors.getVpcId())) {
-                    List<NeighborInfo> neighborInfos = new ArrayList<>(portNeighbors.getNeighbors().values());
-                    internalPortEntity.setNeighborInfos(neighborInfos);
-                }
-            }
+        if (portNeighborsList == null || portNeighborsList.size() == 0) {
+            return;
         }
+
+        List<NeighborInfo> neighborInfos = new ArrayList<>();
+        for (PortNeighbors portNeighbors: portNeighborsList) {
+            if (portNeighbors.getNeighbors() == null ||
+                    portNeighbors.getNeighbors().size() == 0) {
+                continue;
+            }
+
+            neighborInfos.addAll(portNeighbors.getNeighbors().values());
+        }
+
+        NetworkConfig networkConfig = request.getContext().getNetworkConfig();
+        networkConfig.setNeighborInfos(neighborInfos);
     }
 
     private void getNeighbors(PortContext context, List<PortEntity> portEntities) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -38,7 +38,7 @@ public class NetworkConfig {
         private String bindingHostId;
 
         public ExtendPortEntity(InternalPortEntity internalPortEntity, String bindingHostId) {
-            super(internalPortEntity, internalPortEntity.getRoutes(), null, null, internalPortEntity.getBindingHostIP());
+            super(internalPortEntity, internalPortEntity.getRoutes(), internalPortEntity.getBindingHostIP());
             this.bindingHostId = bindingHostId;
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -17,10 +17,12 @@ package com.futurewei.alcor.portmanager.processor;
 
 import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.InternalSubnetEntity;
+import com.futurewei.alcor.web.entity.dataplane.NeighborEntry;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class NetworkConfig {
@@ -33,6 +35,8 @@ public class NetworkConfig {
     private List<SecurityGroup> securityGroups;
 
     private List<NeighborInfo> neighborInfos;
+
+    private List<NeighborEntry> neighborTable;
 
     public static class ExtendPortEntity extends InternalPortEntity {
         private String bindingHostId;
@@ -92,5 +96,16 @@ public class NetworkConfig {
 
     public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
         this.neighborInfos = neighborInfos;
+    }
+
+    public List<NeighborEntry> getNeighborTable() {
+        return neighborTable;
+    }
+
+    public void addNeighborEntries(List<NeighborEntry> neighborEntries) {
+        if (this.neighborTable == null) {
+            this.neighborTable = new ArrayList<>();
+        }
+        this.neighborTable.addAll(neighborEntries);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -17,6 +17,7 @@ package com.futurewei.alcor.portmanager.processor;
 
 import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.InternalSubnetEntity;
+import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
@@ -31,11 +32,13 @@ public class NetworkConfig {
 
     private List<SecurityGroup> securityGroups;
 
+    private List<NeighborInfo> neighborInfos;
+
     public static class ExtendPortEntity extends InternalPortEntity {
         private String bindingHostId;
 
         public ExtendPortEntity(InternalPortEntity internalPortEntity, String bindingHostId) {
-            super(internalPortEntity, internalPortEntity.getRoutes(), internalPortEntity.getNeighborInfos(), internalPortEntity.getBindingHostIP());
+            super(internalPortEntity, internalPortEntity.getRoutes(), null, null, internalPortEntity.getBindingHostIP());
             this.bindingHostId = bindingHostId;
         }
 
@@ -81,5 +84,13 @@ public class NetworkConfig {
 
     public void setSecurityGroups(List<SecurityGroup> securityGroups) {
         this.securityGroups = securityGroups;
+    }
+
+    public List<NeighborInfo> getNeighborInfos() {
+        return neighborInfos;
+    }
+
+    public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
+        this.neighborInfos = neighborInfos;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NodeProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NodeProcessor.java
@@ -42,6 +42,8 @@ public class NodeProcessor extends AbstractProcessor {
                 }
             }
         }
+
+        request.getContext().setNodeInfos(nodeInfoList);
     }
 
     private void getNodeInfo(PortContext context, List<PortEntity> portEntities) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NodeProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NodeProcessor.java
@@ -24,6 +24,7 @@ import com.futurewei.alcor.web.entity.port.PortEntity;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@AfterProcessor(PortProcessor.class)
 public class NodeProcessor extends AbstractProcessor {
     private void fetchNodeCallback(IRestRequest request) {
         List<NodeInfo> nodeInfoList = ((FetchNodeRequest) request).getNodeInfoList();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -17,7 +17,10 @@ package com.futurewei.alcor.portmanager.processor;
 
 import com.futurewei.alcor.portmanager.repo.PortRepository;
 import com.futurewei.alcor.portmanager.request.RequestManager;
+import com.futurewei.alcor.web.entity.NodeInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +37,8 @@ public class PortContext {
     private List<PortEntity> portEntities; //For add and delete
     private PortEntity oldPortEntity; //For update
     private PortEntity newPortEntity; //For update
-    private List<String> routerSubnetIds;
+    private Map<String, List<String>> routerSubnetIds;
+    private List<NodeInfo> nodeInfos;
 
     public PortContext() {
 
@@ -144,11 +148,26 @@ public class PortContext {
         this.newPortEntity = newPortEntity;
     }
 
-    public List<String> getRouterSubnetIds() {
-        return routerSubnetIds;
+    public List<String> getRouterSubnetIds(String vpcId) {
+        return this.routerSubnetIds.get(vpcId);
     }
 
-    public void setRouterSubnetIds(List<String> routerSubnetIds) {
+    public void setRouterSubnetIds(Map<String, List<String>> routerSubnetIds) {
         this.routerSubnetIds = routerSubnetIds;
+    }
+
+    public void addRouterSubnetIds(String vpcId, List<String> subnetIds) {
+        if (this.routerSubnetIds == null) {
+            this.routerSubnetIds = new HashMap<>();
+        }
+        this.routerSubnetIds.put(vpcId, subnetIds);
+    }
+
+    public List<NodeInfo> getNodeInfos() {
+        return nodeInfos;
+    }
+
+    public void setNodeInfos(List<NodeInfo> nodeInfos) {
+        this.nodeInfos = nodeInfos;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -149,7 +149,7 @@ public class PortContext {
     }
 
     public List<String> getRouterSubnetIds(String vpcId) {
-        return this.routerSubnetIds.get(vpcId);
+        return (this.routerSubnetIds != null) ? this.routerSubnetIds.get(vpcId) : null;
     }
 
     public void setRouterSubnetIds(Map<String, List<String>> routerSubnetIds) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -34,6 +34,7 @@ public class PortContext {
     private List<PortEntity> portEntities; //For add and delete
     private PortEntity oldPortEntity; //For update
     private PortEntity newPortEntity; //For update
+    private List<String> routerSubnetIds;
 
     public PortContext() {
 
@@ -141,5 +142,13 @@ public class PortContext {
 
     public void setNewPortEntity(PortEntity newPortEntity) {
         this.newPortEntity = newPortEntity;
+    }
+
+    public List<String> getRouterSubnetIds() {
+        return routerSubnetIds;
+    }
+
+    public void setRouterSubnetIds(List<String> routerSubnetIds) {
+        this.routerSubnetIds = routerSubnetIds;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortProcessor.java
@@ -163,7 +163,7 @@ public class PortProcessor extends AbstractProcessor {
 
     private InternalPortEntity buildInternalPortEntity(PortEntity portEntity) {
         InternalPortEntity internalPortEntity =
-                new InternalPortEntity(portEntity, null, null, null);
+                new InternalPortEntity(portEntity, null, null, null, null);
         NetworkConfig.ExtendPortEntity extendPortEntity =
                 new NetworkConfig.ExtendPortEntity(internalPortEntity, portEntity.getBindingHostId());
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortProcessor.java
@@ -163,7 +163,7 @@ public class PortProcessor extends AbstractProcessor {
 
     private InternalPortEntity buildInternalPortEntity(PortEntity portEntity) {
         InternalPortEntity internalPortEntity =
-                new InternalPortEntity(portEntity, null, null, null, null);
+                new InternalPortEntity(portEntity, null, null);
         NetworkConfig.ExtendPortEntity extendPortEntity =
                 new NetworkConfig.ExtendPortEntity(internalPortEntity, portEntity.getBindingHostId());
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.processor;
+
+import com.futurewei.alcor.portmanager.request.FetchRouterSubnetsRequest;
+import com.futurewei.alcor.portmanager.request.IRestRequest;
+import com.futurewei.alcor.web.entity.port.PortEntity;
+
+import java.util.*;
+
+public class RouterProcessor extends AbstractProcessor {
+    private void fetchConnectedSubnetIdsCallback(IRestRequest request) {
+        List<String> subnetIds = ((FetchRouterSubnetsRequest) request).getSubnetIds();
+        request.getContext().setRouterSubnetIds(subnetIds);
+    }
+
+    private void getRouterSubnetIds(PortContext context, String vpcId, String subnetId) {
+        FetchRouterSubnetsRequest fetchRouterSubnetsRequest =
+                new FetchRouterSubnetsRequest(context, vpcId, subnetId);
+        context.getRequestManager().sendRequestAsync(
+                fetchRouterSubnetsRequest, this::fetchConnectedSubnetIdsCallback);
+    }
+
+    private void getRouterSubnetIds(PortContext context, List<PortEntity> portEntities) {
+        Set<String> vpcIds = new HashSet<>();
+        for (PortEntity portEntity: portEntities) {
+            if (portEntity.getFixedIps() == null) {
+                continue;
+            }
+
+            if (!vpcIds.contains(portEntity.getVpcId())) {
+                getRouterSubnetIds(context, portEntity.getVpcId(),
+                        portEntity.getFixedIps().get(0).getSubnetId());
+                vpcIds.add(portEntity.getVpcId());
+            }
+        }
+    }
+
+    @Override
+    void createProcess(PortContext context) {
+        getRouterSubnetIds(context, context.getPortEntities());
+    }
+
+    @Override
+    void updateProcess(PortContext context) {
+        PortEntity oldPortEntity = context.getOldPortEntity();
+        getRouterSubnetIds(context, Collections.singletonList(oldPortEntity));
+    }
+
+    @Override
+    void deleteProcess(PortContext context) {
+        getRouterSubnetIds(context, context.getPortEntities());
+    }
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
@@ -23,8 +23,10 @@ import java.util.*;
 
 public class RouterProcessor extends AbstractProcessor {
     private void fetchConnectedSubnetIdsCallback(IRestRequest request) {
-        List<String> subnetIds = ((FetchRouterSubnetsRequest) request).getSubnetIds();
-        request.getContext().setRouterSubnetIds(subnetIds);
+        FetchRouterSubnetsRequest fetchRouterSubnetsRequest = ((FetchRouterSubnetsRequest) request);
+        String vpcId = fetchRouterSubnetsRequest.getVpcId();
+        List<String> subnetIds = fetchRouterSubnetsRequest.getSubnetIds();
+        request.getContext().addRouterSubnetIds(vpcId, subnetIds);
     }
 
     private void getRouterSubnetIds(PortContext context, String vpcId, String subnetId) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/SecurityGroupProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/SecurityGroupProcessor.java
@@ -26,6 +26,7 @@ import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 
 import java.util.*;
 
+@AfterProcessor(PortProcessor.class)
 public class SecurityGroupProcessor extends AbstractProcessor {
     public void fetchSecurityGroupCallback(IRestRequest request) {
         List<SecurityGroup> securityGroups = ((FetchSecurityGroupRequest) request)

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/VpcProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/VpcProcessor.java
@@ -23,6 +23,7 @@ import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@AfterProcessor(PortProcessor.class)
 public class VpcProcessor extends AbstractProcessor {
     private void fetchVpcListCallback(IRestRequest request) {
         List<VpcEntity> vpcEntities = ((FetchVpcRequest) request).getVpcEntities();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -18,7 +18,7 @@ package com.futurewei.alcor.portmanager.request;
 import com.futurewei.alcor.common.utils.SpringContextUtil;
 import com.futurewei.alcor.portmanager.exception.GetConnectedSubnetException;
 import com.futurewei.alcor.portmanager.processor.PortContext;
-import com.futurewei.alcor.web.entity.router.RouterSubnets;
+import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
 import com.futurewei.alcor.web.restclient.RouterManagerRestClient;
 
 import java.util.ArrayList;
@@ -48,7 +48,7 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
 
     @Override
     public void send() throws Exception {
-        RouterSubnets connectedSubnetIds = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
+        ConnectedSubnetsWebResponse connectedSubnetIds = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
         if (connectedSubnetIds == null || connectedSubnetIds.getSubnetIds() == null) {
             throw new GetConnectedSubnetException();
         }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -38,6 +38,10 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
         this.routerManagerRestClient = SpringContextUtil.getBean(RouterManagerRestClient.class);
     }
 
+    public String getVpcId() {
+        return vpcId;
+    }
+
     public List<String> getSubnetIds() {
         return subnetIds;
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.request;
+
+import com.futurewei.alcor.common.utils.SpringContextUtil;
+import com.futurewei.alcor.portmanager.exception.GetConnectedSubnetException;
+import com.futurewei.alcor.portmanager.processor.PortContext;
+import com.futurewei.alcor.web.entity.router.RouterSubnets;
+import com.futurewei.alcor.web.restclient.RouterManagerRestClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchRouterSubnetsRequest extends AbstractRequest {
+    private String vpcId;
+    private String subnetId;
+    private List<String> subnetIds;
+    private RouterManagerRestClient routerManagerRestClient;
+
+    public FetchRouterSubnetsRequest(PortContext context, String vpcId, String subnetId) {
+        super(context);
+        this.vpcId = vpcId;
+        this.subnetId = subnetId;
+        this.subnetIds = new ArrayList<>();
+        this.routerManagerRestClient = SpringContextUtil.getBean(RouterManagerRestClient.class);
+    }
+
+    public List<String> getSubnetIds() {
+        return subnetIds;
+    }
+
+    @Override
+    public void send() throws Exception {
+        RouterSubnets connectedSubnetIds = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
+        if (connectedSubnetIds == null || connectedSubnetIds.getSubnetIds() == null) {
+            throw new GetConnectedSubnetException();
+        }
+
+        subnetIds.addAll(connectedSubnetIds.getSubnetIds());
+    }
+
+    @Override
+    public void rollback() throws Exception {
+
+    }
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
@@ -41,5 +41,5 @@ public interface PortService {
 
     List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception;
 
-    RouterSubnetUpdateInfo updateNeighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception;
+    RouterSubnetUpdateInfo updateL3Neighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception;
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
@@ -17,7 +17,7 @@ package com.futurewei.alcor.portmanager.service;
 
 import com.futurewei.alcor.web.entity.port.PortWebBulkJson;
 import com.futurewei.alcor.web.entity.port.PortWebJson;
-import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import com.futurewei.alcor.web.entity.route.RouterUpdateInfo;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,5 +41,5 @@ public interface PortService {
 
     List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception;
 
-    RouterSubnetUpdateInfo updateL3Neighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception;
+    RouterUpdateInfo updateL3Neighbors(String projectId, RouterUpdateInfo routerUpdateInfo) throws Exception;
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortService.java
@@ -17,10 +17,8 @@ package com.futurewei.alcor.portmanager.service;
 
 import com.futurewei.alcor.web.entity.port.PortWebBulkJson;
 import com.futurewei.alcor.web.entity.port.PortWebJson;
+import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -42,4 +40,6 @@ public interface PortService {
     List<PortWebJson> listPort(String projectId) throws Exception;
 
     List<PortWebJson> listPort(String projectId, Map<String, Object[]> queryParams) throws Exception;
+
+    RouterSubnetUpdateInfo updateNeighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception;
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
@@ -256,8 +256,8 @@ public class PortServiceImpl implements PortService {
         if (neighborTable.size() > 0) {
             NetworkConfiguration networkConfiguration = new NetworkConfiguration();
             networkConfiguration.setRsType(Common.ResourceType.NEIGHBOR);
-            RouterUpdateInfo.OperationType operationType = routerUpdateInfo.getOperationType();
-            if (RouterUpdateInfo.OperationType.ADD.equals(operationType)) {
+            String operationType = routerUpdateInfo.getOperationType();
+            if (RouterUpdateInfo.OperationType.ADD.getType().equals(operationType)) {
                 networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_CREATE_UPDATE);
             } else {
                 networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_DELETE);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
@@ -28,7 +28,7 @@ import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.PortWebBulkJson;
 import com.futurewei.alcor.web.entity.port.PortWebJson;
-import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import com.futurewei.alcor.web.entity.route.RouterUpdateInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -223,10 +223,10 @@ public class PortServiceImpl implements PortService {
         return neighborTable;
     }
 
-    private List<NeighborEntry> updateNeighborTable(RouterSubnetUpdateInfo routerSubnetUpdateInfo, List<NeighborInfo> neighborInfos) throws CacheException {
-        String vpcId = routerSubnetUpdateInfo.getVpcId();
-        String subnetId = routerSubnetUpdateInfo.getSubnetId();
-        List<String> oldSubnetIds = routerSubnetUpdateInfo.getOldSubnetIds();
+    private List<NeighborEntry> updateNeighborTable(RouterUpdateInfo routerUpdateInfo, List<NeighborInfo> neighborInfos) throws CacheException {
+        String vpcId = routerUpdateInfo.getVpcId();
+        String subnetId = routerUpdateInfo.getSubnetId();
+        List<String> oldSubnetIds = routerUpdateInfo.getOldSubnetIds();
 
         Map<String, NeighborInfo> neighbors = portRepository.getNeighbors(vpcId);
 
@@ -249,15 +249,15 @@ public class PortServiceImpl implements PortService {
 
     @Override
     @DurationStatistics
-    public RouterSubnetUpdateInfo updateL3Neighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
+    public RouterUpdateInfo updateL3Neighbors(String projectId, RouterUpdateInfo routerUpdateInfo) throws Exception {
         List<NeighborInfo> neighborInfos = new ArrayList<>();
-        List<NeighborEntry> neighborTable = updateNeighborTable(routerSubnetUpdateInfo, neighborInfos);
+        List<NeighborEntry> neighborTable = updateNeighborTable(routerUpdateInfo, neighborInfos);
 
         if (neighborTable.size() > 0) {
             NetworkConfiguration networkConfiguration = new NetworkConfiguration();
             networkConfiguration.setRsType(Common.ResourceType.NEIGHBOR);
-            RouterSubnetUpdateInfo.OperationType operationType = routerSubnetUpdateInfo.getOperationType();
-            if (RouterSubnetUpdateInfo.OperationType.ADD.equals(operationType)) {
+            RouterUpdateInfo.OperationType operationType = routerUpdateInfo.getOperationType();
+            if (RouterUpdateInfo.OperationType.ADD.equals(operationType)) {
                 networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_CREATE_UPDATE);
             } else {
                 networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_DELETE);
@@ -267,6 +267,6 @@ public class PortServiceImpl implements PortService {
             new UpdateNetworkConfigRequest(null, networkConfiguration).send();
         }
 
-        return routerSubnetUpdateInfo;
+        return routerUpdateInfo;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -29,6 +29,7 @@ import com.futurewei.alcor.web.entity.NodeInfo;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
 import com.futurewei.alcor.web.entity.port.*;
+import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -783,5 +784,10 @@ public class PortServiceImpl implements PortService {
         }
 
         return result;
+    }
+
+    @Override
+    public RouterSubnetUpdateInfo updateNeighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
+        return null;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -787,7 +787,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
-    public RouterSubnetUpdateInfo updateNeighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
+    public RouterSubnetUpdateInfo updateL3Neighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
         return null;
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -19,7 +19,6 @@ import com.futurewei.alcor.common.executor.AsyncExecutor;
 import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.portmanager.entity.PortBindingHost;
 import com.futurewei.alcor.portmanager.exception.*;
-import com.futurewei.alcor.portmanager.processor.*;
 import com.futurewei.alcor.portmanager.proxy.*;
 import com.futurewei.alcor.portmanager.repo.PortRepository;
 import com.futurewei.alcor.portmanager.rollback.*;
@@ -29,12 +28,10 @@ import com.futurewei.alcor.web.entity.NodeInfo;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
 import com.futurewei.alcor.web.entity.port.*;
-import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import com.futurewei.alcor.web.entity.route.RouterUpdateInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -787,7 +784,7 @@ public class PortServiceImpl implements PortService {
     }
 
     @Override
-    public RouterSubnetUpdateInfo updateL3Neighbors(String projectId, RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
-        return null;
+    public RouterUpdateInfo updateL3Neighbors(String projectId, RouterUpdateInfo routerUpdateInfo) throws Exception {
+        throw new UnsupportedException();
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -57,7 +57,7 @@ public class NetworkConfigurationUtil {
         List<RouteEntity> routeEntities = portRouteEntityMap.get(portEntity.getId());
         String bindingHostIp = nodeInfoMap.get(portEntity.getId()).getLocalIp();
 
-        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, null, null, bindingHostIp);
+        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, bindingHostIp);
 
         return internalPortEntity;
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -57,7 +57,7 @@ public class NetworkConfigurationUtil {
         List<RouteEntity> routeEntities = portRouteEntityMap.get(portEntity.getId());
         String bindingHostIp = nodeInfoMap.get(portEntity.getId()).getLocalIp();
 
-        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, filteredNeighborInfoList, bindingHostIp);
+        InternalPortEntity internalPortEntity = new InternalPortEntity(portEntity, routeEntities, null, null, bindingHostIp);
 
         return internalPortEntity;
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
@@ -139,8 +139,8 @@ public class RestParameterValidator {
         }
 
         String operationType = routerUpdateInfo.getOperationType();
-        if (!RouterUpdateInfo.OperationType.ADD.getType().equals(operationType) &&
-                !RouterUpdateInfo.OperationType.DELETE.getType().equals(operationType)) {
+        if (StringUtils.isEmpty(operationType) ||(!RouterUpdateInfo.OperationType.ADD.getType().equals(operationType.toLowerCase()) &&
+                !RouterUpdateInfo.OperationType.DELETE.getType().equals(operationType.toLowerCase()))) {
             throw new OperationTypeInvalid();
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
@@ -22,11 +22,10 @@ import com.futurewei.alcor.web.entity.port.IpAllocation;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.VifType;
 import com.futurewei.alcor.web.entity.port.VnicType;
+import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import org.springframework.util.StringUtils;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class RestParameterValidator {
     public static void checkMacAddress(PortEntity portEntity) throws Exception {
@@ -128,5 +127,25 @@ public class RestParameterValidator {
 
         //Check ip allocation
         checkIpAllocation(portEntity);
+    }
+
+    public static void checkRouterSubnetUpdateInfo(RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
+        if (StringUtils.isEmpty(routerSubnetUpdateInfo.getVpcId())) {
+            throw new VpcIdInvalid();
+        }
+
+        if (StringUtils.isEmpty(routerSubnetUpdateInfo.getSubnetId())) {
+            throw new SubnetIdInvalid();
+        }
+
+        RouterSubnetUpdateInfo.OperationType operationType = routerSubnetUpdateInfo.getOperationType();
+        if (!RouterSubnetUpdateInfo.OperationType.ADD.equals(operationType) &&
+                !RouterSubnetUpdateInfo.OperationType.DELETE.equals(operationType)) {
+            throw new OperationTypeInvalid();
+        }
+
+        if (routerSubnetUpdateInfo.getOldSubnetIds() == null) {
+            routerSubnetUpdateInfo.setOldSubnetIds(new ArrayList<>());
+        }
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
@@ -138,9 +138,9 @@ public class RestParameterValidator {
             throw new SubnetIdInvalid();
         }
 
-        RouterUpdateInfo.OperationType operationType = routerUpdateInfo.getOperationType();
-        if (!RouterUpdateInfo.OperationType.ADD.equals(operationType) &&
-                !RouterUpdateInfo.OperationType.DELETE.equals(operationType)) {
+        String operationType = routerUpdateInfo.getOperationType();
+        if (!RouterUpdateInfo.OperationType.ADD.getType().equals(operationType) &&
+                !RouterUpdateInfo.OperationType.DELETE.getType().equals(operationType)) {
             throw new OperationTypeInvalid();
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
@@ -22,7 +22,7 @@ import com.futurewei.alcor.web.entity.port.IpAllocation;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.VifType;
 import com.futurewei.alcor.web.entity.port.VnicType;
-import com.futurewei.alcor.web.entity.router.RouterSubnetUpdateInfo;
+import com.futurewei.alcor.web.entity.route.RouterUpdateInfo;
 import org.springframework.util.StringUtils;
 
 import java.util.*;
@@ -129,23 +129,23 @@ public class RestParameterValidator {
         checkIpAllocation(portEntity);
     }
 
-    public static void checkRouterSubnetUpdateInfo(RouterSubnetUpdateInfo routerSubnetUpdateInfo) throws Exception {
-        if (StringUtils.isEmpty(routerSubnetUpdateInfo.getVpcId())) {
+    public static void checkRouterSubnetUpdateInfo(RouterUpdateInfo routerUpdateInfo) throws Exception {
+        if (StringUtils.isEmpty(routerUpdateInfo.getVpcId())) {
             throw new VpcIdInvalid();
         }
 
-        if (StringUtils.isEmpty(routerSubnetUpdateInfo.getSubnetId())) {
+        if (StringUtils.isEmpty(routerUpdateInfo.getSubnetId())) {
             throw new SubnetIdInvalid();
         }
 
-        RouterSubnetUpdateInfo.OperationType operationType = routerSubnetUpdateInfo.getOperationType();
-        if (!RouterSubnetUpdateInfo.OperationType.ADD.equals(operationType) &&
-                !RouterSubnetUpdateInfo.OperationType.DELETE.equals(operationType)) {
+        RouterUpdateInfo.OperationType operationType = routerUpdateInfo.getOperationType();
+        if (!RouterUpdateInfo.OperationType.ADD.equals(operationType) &&
+                !RouterUpdateInfo.OperationType.DELETE.equals(operationType)) {
             throw new OperationTypeInvalid();
         }
 
-        if (routerSubnetUpdateInfo.getOldSubnetIds() == null) {
-            routerSubnetUpdateInfo.setOldSubnetIds(new ArrayList<>());
+        if (routerUpdateInfo.getOldSubnetIds() == null) {
+            routerUpdateInfo.setOldSubnetIds(new ArrayList<>());
         }
     }
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
@@ -55,6 +55,7 @@ public class UnitTestConfig {
     public static String vpcId = "3d53801c-32ce-4e97-9572-bb966f4d175e";
     public static String tenantId = "3d53801c-32ce-4e97-9572-bb966f476ec";
     public static String subnetId = "3d53801c-32ce-4e97-9572-bb966f4056b";
+    public static String subnetId2 = "3d53801c-32ce-4e97-9572-bb966fe82b1";
     public static String rangeId = "3d53801c-32ce-4e97-9572-bb966f6ba29";
     public static String vpcCidr = "11.11.1.0/24";
     public static String ip1 = "11.11.11.100";
@@ -84,6 +85,7 @@ public class UnitTestConfig {
     public static String elasticIpId1 = "3d53801c-32ce-4e97-9572-bb966f4dc123";
     public static String elasticIpName1 = "elastic ip1";
     public static String elasticIpAddress1 = "200.10.1.10";
+    public static String operationType = "add";
     public static String portEntityWithFixedIps = "{\n" +
             "    \"port\": {\n" +
             "        \"id\":\"" + portId1 + "\",\n" +
@@ -426,5 +428,11 @@ public class UnitTestConfig {
             "        \"dns_domain\":\"" + "\",\n" +
             "        \"dns_name\":\"" + "\"\n" +
             "    }\n" +
+            "}";
+    public static String updateL3Neighbor = "{\n" +
+            "        \"vpc_id\":\"" + vpcId + "\",\n" +
+            "        \"subnet_id\":\"" + subnetId + "\",\n" +
+            "        \"operation_type\":\"" + operationType + "\",\n" +
+            "        \"old_subnet_ids\":[\"" + subnetId + "\",\"" + subnetId2 + "\"]\n" +
             "}";
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
@@ -143,6 +143,9 @@ public class MockRestClientAndRepository {
         Mockito.when(portRepository.getPortNeighbors(UnitTestConfig.vpcId))
                 .thenReturn(buildPortNeighbors(UnitTestConfig.portId1));
 
+        Mockito.when(portRepository.getNeighbors(UnitTestConfig.vpcId))
+                .thenReturn(buildNeighbors());
+
         Mockito.when(elasticIpManagerRestClient.updateElasticIp(any()))
                 .thenReturn(buildElasticIp());
 

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
@@ -18,7 +18,6 @@ package com.futurewei.alcor.portmanager.controller;
 import com.futurewei.alcor.portmanager.config.UnitTestConfig;
 import com.futurewei.alcor.portmanager.repo.PortRepository;
 import com.futurewei.alcor.web.entity.NodeInfo;
-import com.futurewei.alcor.web.entity.ip.IpVersion;
 import com.futurewei.alcor.web.entity.ip.IpAddrRequest;
 import com.futurewei.alcor.web.entity.mac.MacState;
 import com.futurewei.alcor.web.entity.port.PortEntity;
@@ -62,6 +61,9 @@ public class MockRestClientAndRepository {
 
     @MockBean
     private ElasticIpManagerRestClient elasticIpManagerRestClient;
+
+    @MockBean
+    private RouterManagerRestClient routerManagerRestClient;
 
     @MockBean
     private PortRepository portRepository;
@@ -143,5 +145,9 @@ public class MockRestClientAndRepository {
 
         Mockito.when(elasticIpManagerRestClient.updateElasticIp(any()))
                 .thenReturn(buildElasticIp());
+
+        Mockito.when(routerManagerRestClient.getRouterSubnets(
+                UnitTestConfig.projectId, UnitTestConfig.vpcId, UnitTestConfig.subnetId))
+                .thenReturn(buildRouterSubnets());
     }
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/UpdateL3NeighborTest.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/UpdateL3NeighborTest.java
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.portmanager.controller;
+
+import com.futurewei.alcor.portmanager.config.UnitTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ComponentScan(value = "com.futurewei.alcor.common.test.config")
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UpdateL3NeighborTest extends MockRestClientAndRepository {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private String updateL3NeighborUrl = "/project/" + UnitTestConfig.projectId + "/update-l3-neighbors";
+    @Test
+    public void updateL3NeighborTest() throws Exception {
+        this.mockMvc.perform(put(updateL3NeighborUrl)
+                .content(UnitTestConfig.updateL3Neighbor)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
@@ -36,6 +36,7 @@ import com.futurewei.alcor.web.entity.port.PortWebJson;
 import com.futurewei.alcor.web.entity.route.RouteEntity;
 import com.futurewei.alcor.web.entity.route.RouteWebJson;
 import com.futurewei.alcor.web.entity.route.RoutesWebJson;
+import com.futurewei.alcor.web.entity.router.RouterSubnets;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
@@ -318,5 +319,14 @@ public class ResourceBuilder {
         elasticIpInfo.setPortId("");
 
         return new ElasticIpInfoWrapper(elasticIpInfo);
+    }
+
+    public static RouterSubnets buildRouterSubnets() {
+        RouterSubnets routerSubnets = new RouterSubnets();
+        List<String> subnetIds = new ArrayList<>();
+        subnetIds.add(UnitTestConfig.subnetId);
+        routerSubnets.setSubnetIds(subnetIds);
+
+        return routerSubnets;
     }
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
@@ -296,7 +296,8 @@ public class ResourceBuilder {
 
     public static NeighborInfo buildNeighborInfo(String portId) {
         NeighborInfo neighborInfo = new NeighborInfo(UnitTestConfig.ip1,
-                UnitTestConfig.nodeId1, portId, UnitTestConfig.mac1);
+                UnitTestConfig.nodeId1, portId, UnitTestConfig.mac1,
+                UnitTestConfig.ip1, UnitTestConfig.vpcId, UnitTestConfig.subnetId);
 
         return neighborInfo;
     }
@@ -309,6 +310,21 @@ public class ResourceBuilder {
 
         return new PortNeighbors(UnitTestConfig.vpcId, neighborInfoMap);
     }
+
+    public static Map<String, NeighborInfo> buildNeighbors() {
+        Map<String, NeighborInfo> neighborInfoMap = new HashMap<>();
+        NeighborInfo neighborInfo1 = new NeighborInfo(UnitTestConfig.ip1,
+                UnitTestConfig.nodeId1, UnitTestConfig.portId1, UnitTestConfig.mac1,
+                UnitTestConfig.ip1, UnitTestConfig.vpcId, UnitTestConfig.subnetId);
+        NeighborInfo neighborInfo2 = new NeighborInfo(UnitTestConfig.ip2,
+                UnitTestConfig.nodeId2, UnitTestConfig.portId2, UnitTestConfig.mac2,
+                UnitTestConfig.ip2, UnitTestConfig.vpcId, UnitTestConfig.subnetId2);
+        neighborInfoMap.put(UnitTestConfig.portId1, neighborInfo1);
+        neighborInfoMap.put(UnitTestConfig.portId2, neighborInfo2);
+
+        return neighborInfoMap;
+    }
+
 
     public static ElasticIpInfoWrapper buildElasticIp() {
         ElasticIpInfo elasticIpInfo = new ElasticIpInfo();
@@ -324,6 +340,7 @@ public class ResourceBuilder {
     public static ConnectedSubnetsWebResponse buildRouterSubnets() {
         List<String> subnetIds = new ArrayList<>();
         subnetIds.add(UnitTestConfig.subnetId);
+        subnetIds.add(UnitTestConfig.subnetId2);
         ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(null, subnetIds);
         return routerSubnets;
     }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
@@ -33,10 +33,10 @@ import com.futurewei.alcor.web.entity.mac.MacStateBulkJson;
 import com.futurewei.alcor.web.entity.mac.MacStateJson;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.PortWebJson;
+import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
 import com.futurewei.alcor.web.entity.route.RouteEntity;
 import com.futurewei.alcor.web.entity.route.RouteWebJson;
 import com.futurewei.alcor.web.entity.route.RoutesWebJson;
-import com.futurewei.alcor.web.entity.router.RouterSubnets;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
@@ -321,12 +321,10 @@ public class ResourceBuilder {
         return new ElasticIpInfoWrapper(elasticIpInfo);
     }
 
-    public static RouterSubnets buildRouterSubnets() {
-        RouterSubnets routerSubnets = new RouterSubnets();
+    public static ConnectedSubnetsWebResponse buildRouterSubnets() {
         List<String> subnetIds = new ArrayList<>();
         subnetIds.add(UnitTestConfig.subnetId);
-        routerSubnets.setSubnetIds(subnetIds);
-
+        ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(null, subnetIds);
         return routerSubnets;
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/InternalPortEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/InternalPortEntity.java
@@ -27,8 +27,11 @@ public class InternalPortEntity extends PortEntity {
     @JsonProperty("routes")
     private List<RouteEntity> routes;
 
-    @JsonProperty("neighbor_info")
-    private List<NeighborInfo> neighborInfos;
+    @JsonProperty("l2_neighbor_ids")
+    private List<String> l2NeighborIds;
+
+    @JsonProperty("l3_neighbor_ids")
+    private List<String> l3NeighborIds;
 
     @JsonProperty("binding_host_ip")
     private String bindingHostIP;
@@ -41,12 +44,20 @@ public class InternalPortEntity extends PortEntity {
         this.routes = routes;
     }
 
-    public List<NeighborInfo> getNeighborInfos() {
-        return neighborInfos;
+    public List<String> getL2NeighborIds() {
+        return l2NeighborIds;
     }
 
-    public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
-        this.neighborInfos = neighborInfos;
+    public void setL2NeighborIds(List<String> l2NeighborIds) {
+        this.l2NeighborIds = l2NeighborIds;
+    }
+
+    public List<String> getL3NeighborIds() {
+        return l3NeighborIds;
+    }
+
+    public void setL3NeighborIds(List<String> l3NeighborIds) {
+        this.l3NeighborIds = l3NeighborIds;
     }
 
     public String getBindingHostIP() {
@@ -90,11 +101,13 @@ public class InternalPortEntity extends PortEntity {
     public InternalPortEntity(
             PortEntity portEntity,
             List<RouteEntity> routeEntities,
-            List<NeighborInfo> neighborInfos,
+            List<String> l2NeighborIds,
+            List<String> l3NeighborIds,
             String bindingHostIP) {
         super(portEntity);
         this.routes = routeEntities;
-        this.neighborInfos = neighborInfos;
+        this.l2NeighborIds = l2NeighborIds;
+        this.l3NeighborIds = l3NeighborIds;
         this.bindingHostIP = bindingHostIP;
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/InternalPortEntity.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/InternalPortEntity.java
@@ -27,12 +27,6 @@ public class InternalPortEntity extends PortEntity {
     @JsonProperty("routes")
     private List<RouteEntity> routes;
 
-    @JsonProperty("l2_neighbor_ids")
-    private List<String> l2NeighborIds;
-
-    @JsonProperty("l3_neighbor_ids")
-    private List<String> l3NeighborIds;
-
     @JsonProperty("binding_host_ip")
     private String bindingHostIP;
 
@@ -42,22 +36,6 @@ public class InternalPortEntity extends PortEntity {
 
     public void setRoutes(List<RouteEntity> routes) {
         this.routes = routes;
-    }
-
-    public List<String> getL2NeighborIds() {
-        return l2NeighborIds;
-    }
-
-    public void setL2NeighborIds(List<String> l2NeighborIds) {
-        this.l2NeighborIds = l2NeighborIds;
-    }
-
-    public List<String> getL3NeighborIds() {
-        return l3NeighborIds;
-    }
-
-    public void setL3NeighborIds(List<String> l3NeighborIds) {
-        this.l3NeighborIds = l3NeighborIds;
     }
 
     public String getBindingHostIP() {
@@ -101,13 +79,9 @@ public class InternalPortEntity extends PortEntity {
     public InternalPortEntity(
             PortEntity portEntity,
             List<RouteEntity> routeEntities,
-            List<String> l2NeighborIds,
-            List<String> l3NeighborIds,
             String bindingHostIP) {
         super(portEntity);
         this.routes = routeEntities;
-        this.l2NeighborIds = l2NeighborIds;
-        this.l3NeighborIds = l3NeighborIds;
         this.bindingHostIP = bindingHostIP;
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborEntry.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborEntry.java
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.web.entity.dataplane;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NeighborEntry {
+    @JsonProperty("neighbor_type")
+    private NeighborType neighborType;
+
+    @JsonProperty("local_ip")
+    private String localIp;
+
+    @JsonProperty("neighbor_ip")
+    private String neighborIp;
+
+    public enum NeighborType {
+        L2("L2"),
+        L3("L3");
+
+        private String type;
+
+        NeighborType(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
+    public NeighborEntry() {
+
+    }
+
+    public NeighborEntry(NeighborType neighborType, String localIp, String neighborIp) {
+        this.neighborType = neighborType;
+        this.localIp = localIp;
+        this.neighborIp = neighborIp;
+    }
+
+    public NeighborType getNeighborType() {
+        return neighborType;
+    }
+
+    public void setNeighborType(NeighborType neighborType) {
+        this.neighborType = neighborType;
+    }
+
+    public String getLocalIp() {
+        return localIp;
+    }
+
+    public void setLocalIp(String localIp) {
+        this.localIp = localIp;
+    }
+
+    public String getNeighborIp() {
+        return neighborIp;
+    }
+
+    public void setNeighborIp(String neighborIp) {
+        this.neighborIp = neighborIp;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
@@ -32,6 +32,28 @@ public class NeighborInfo {
     @JsonProperty("port_ip")
     private String portIp;
 
+    @JsonProperty("subnet_id")
+    private String subnetId;
+
+    public enum NeighborType {
+        L2("L2"),
+        L3("L3");
+
+        private String type;
+
+        NeighborType(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
     public NeighborInfo() {
     }
 
@@ -83,12 +105,29 @@ public class NeighborInfo {
         this.portIp = portIp;
     }
 
+    public NeighborInfo(String hostIp, String hostId, String portId, String portMac, String portIp, String subnetId) {
+        this.hostIp = hostIp;
+        this.hostId = hostId;
+        this.portId = portId;
+        this.portMac = portMac;
+        this.portIp = portIp;
+        this.subnetId = subnetId;
+    }
+
     public String getPortIp() {
         return portIp;
     }
 
     public void setPortIp(String portIp) {
         this.portIp = portIp;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
     }
 
     @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
@@ -32,8 +32,14 @@ public class NeighborInfo {
     @JsonProperty("port_ip")
     private String portIp;
 
+    @JsonProperty("vpc_id")
+    private String vpcId;
+
     @JsonProperty("subnet_id")
     private String subnetId;
+
+    @JsonProperty("neighbor_type")
+    private NeighborType neighborType;
 
     public enum NeighborType {
         L2("L2"),
@@ -105,13 +111,15 @@ public class NeighborInfo {
         this.portIp = portIp;
     }
 
-    public NeighborInfo(String hostIp, String hostId, String portId, String portMac, String portIp, String subnetId) {
+    public NeighborInfo(String hostIp, String hostId, String portId, String portMac, String portIp, String vpcId, String subnetId, NeighborType neighborType) {
         this.hostIp = hostIp;
         this.hostId = hostId;
         this.portId = portId;
         this.portMac = portMac;
         this.portIp = portIp;
+        this.vpcId = vpcId;
         this.subnetId = subnetId;
+        this.neighborType = neighborType;
     }
 
     public String getPortIp() {
@@ -128,6 +136,22 @@ public class NeighborInfo {
 
     public void setSubnetId(String subnetId) {
         this.subnetId = subnetId;
+    }
+
+    public String getVpcId() {
+        return vpcId;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
+    }
+
+    public NeighborType getNeighborType() {
+        return neighborType;
+    }
+
+    public void setNeighborType(NeighborType neighborType) {
+        this.neighborType = neighborType;
     }
 
     @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
@@ -38,28 +38,6 @@ public class NeighborInfo {
     @JsonProperty("subnet_id")
     private String subnetId;
 
-    @JsonProperty("neighbor_type")
-    private NeighborType neighborType;
-
-    public enum NeighborType {
-        L2("L2"),
-        L3("L3");
-
-        private String type;
-
-        NeighborType(String type) {
-            this.type = type;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public void setType(String type) {
-            this.type = type;
-        }
-    }
-
     public NeighborInfo() {
     }
 
@@ -111,7 +89,7 @@ public class NeighborInfo {
         this.portIp = portIp;
     }
 
-    public NeighborInfo(String hostIp, String hostId, String portId, String portMac, String portIp, String vpcId, String subnetId, NeighborType neighborType) {
+    public NeighborInfo(String hostIp, String hostId, String portId, String portMac, String portIp, String vpcId, String subnetId) {
         this.hostIp = hostIp;
         this.hostId = hostId;
         this.portId = portId;
@@ -119,7 +97,6 @@ public class NeighborInfo {
         this.portIp = portIp;
         this.vpcId = vpcId;
         this.subnetId = subnetId;
-        this.neighborType = neighborType;
     }
 
     public String getPortIp() {
@@ -144,14 +121,6 @@ public class NeighborInfo {
 
     public void setVpcId(String vpcId) {
         this.vpcId = vpcId;
-    }
-
-    public NeighborType getNeighborType() {
-        return neighborType;
-    }
-
-    public void setNeighborType(NeighborType neighborType) {
-        this.neighborType = neighborType;
     }
 
     @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
@@ -43,6 +43,9 @@ public class NetworkConfiguration {
   @JsonProperty("neighbor_info")
   private List<NeighborInfo> neighborInfos;
 
+  @JsonProperty("neighbor_table")
+  private List<NeighborEntry> neighborTable;
+
   public void addPortEntity(InternalPortEntity portEntity) {
     if (this.portEntities == null) {
       this.portEntities = new ArrayList<>();
@@ -129,6 +132,14 @@ public class NetworkConfiguration {
 
   public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
     this.neighborInfos = neighborInfos;
+  }
+
+  public List<NeighborEntry> getNeighborTable() {
+    return neighborTable;
+  }
+
+  public void setNeighborTable(List<NeighborEntry> neighborTable) {
+    this.neighborTable = neighborTable;
   }
 
   @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
@@ -40,6 +40,9 @@ public class NetworkConfiguration {
   @JsonProperty("security_groups_internal")
   private List<SecurityGroup> securityGroups;
 
+  @JsonProperty("neighbor_info")
+  private List<NeighborInfo> neighborInfos;
+
   public void addPortEntity(InternalPortEntity portEntity) {
     if (this.portEntities == null) {
       this.portEntities = new ArrayList<>();
@@ -118,6 +121,14 @@ public class NetworkConfiguration {
 
   public void setSecurityGroups(List<SecurityGroup> securityGroups) {
     this.securityGroups = securityGroups;
+  }
+
+  public List<NeighborInfo> getNeighborInfos() {
+    return neighborInfos;
+  }
+
+  public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
+    this.neighborInfos = neighborInfos;
   }
 
   @Override

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
@@ -27,7 +27,7 @@ public class RouterUpdateInfo {
     private String subnetId;
 
     @JsonProperty("operation_type")
-    private OperationType operationType;
+    private String operationType;
 
     @JsonProperty("old_subnet_ids")
     private List<String> oldSubnetIds;
@@ -55,7 +55,7 @@ public class RouterUpdateInfo {
 
     }
 
-    public RouterUpdateInfo(String vpcId, String subnetId, OperationType operationType, List<String> oldSubnetIds) {
+    public RouterUpdateInfo(String vpcId, String subnetId, String operationType, List<String> oldSubnetIds) {
         this.vpcId = vpcId;
         this.subnetId = subnetId;
         this.operationType = operationType;
@@ -78,11 +78,11 @@ public class RouterUpdateInfo {
         this.subnetId = subnetId;
     }
 
-    public OperationType getOperationType() {
+    public String getOperationType() {
         return operationType;
     }
 
-    public void setOperationType(OperationType operationType) {
+    public void setOperationType(String operationType) {
         this.operationType = operationType;
     }
 

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
@@ -13,13 +13,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
         See the License for the specific language governing permissions and
         limitations under the License.
 */
-package com.futurewei.alcor.web.entity.router;
+package com.futurewei.alcor.web.entity.route;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class RouterSubnetUpdateInfo {
+public class RouterUpdateInfo {
     @JsonProperty("vpc_id")
     private String vpcId;
 
@@ -51,11 +51,11 @@ public class RouterSubnetUpdateInfo {
         }
     }
 
-    public RouterSubnetUpdateInfo() {
+    public RouterUpdateInfo() {
 
     }
 
-    public RouterSubnetUpdateInfo(String vpcId, String subnetId, OperationType operationType, List<String> oldSubnetIds) {
+    public RouterUpdateInfo(String vpcId, String subnetId, OperationType operationType, List<String> oldSubnetIds) {
         this.vpcId = vpcId;
         this.subnetId = subnetId;
         this.operationType = operationType;

--- a/web/src/main/java/com/futurewei/alcor/web/entity/router/RouterSubnetUpdateInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/router/RouterSubnetUpdateInfo.java
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.web.entity.router;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class RouterSubnetUpdateInfo {
+    @JsonProperty("vpc_id")
+    private String vpcId;
+
+    @JsonProperty("subnet_id")
+    private String subnetId;
+
+    @JsonProperty("operation_type")
+    private OperationType operationType;
+
+    @JsonProperty("old_subnet_ids")
+    private List<String> oldSubnetIds;
+
+    public enum OperationType {
+        ADD("add"),
+        DELETE("delete");
+
+        private String type;
+
+        OperationType(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
+
+    public RouterSubnetUpdateInfo() {
+
+    }
+
+    public RouterSubnetUpdateInfo(String vpcId, String subnetId, OperationType operationType, List<String> oldSubnetIds) {
+        this.vpcId = vpcId;
+        this.subnetId = subnetId;
+        this.operationType = operationType;
+        this.oldSubnetIds = oldSubnetIds;
+    }
+
+    public String getVpcId() {
+        return vpcId;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public List<String> getOldSubnetIds() {
+        return oldSubnetIds;
+    }
+
+    public void setOldSubnetIds(List<String> oldSubnetIds) {
+        this.oldSubnetIds = oldSubnetIds;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/entity/router/RouterSubnets.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/router/RouterSubnets.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.web.entity.router;
+
+import java.util.List;
+
+public class RouterSubnets {
+    private List<String> subnetIds;
+
+    public RouterSubnets() {
+
+    }
+
+    public RouterSubnets(List<String> subnetIds) {
+        this.subnetIds = subnetIds;
+    }
+
+    public List<String> getSubnetIds() {
+        return subnetIds;
+    }
+
+    public void setSubnetIds(List<String> subnetIds) {
+        this.subnetIds = subnetIds;
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Alcor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+*/
+package com.futurewei.alcor.web.restclient;
+
+import com.futurewei.alcor.web.entity.port.PortEntity;
+import com.futurewei.alcor.web.entity.router.RouterSubnets;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RouterManagerRestClient extends AbstractRestClient {
+    @Value("${microservices.router.service.url:#{\"\"}}")
+    private String routerManagerUrl;
+
+    public RouterSubnets getRouterSubnets(String projectId, String vpcId, String subnetId) throws Exception {
+        String url = String.format("/project/%s/vpcs/%s/subnets/%s/connected-subnets", projectId, vpcId, subnetId);
+        RouterSubnets routerSubnets = restTemplate.getForObject(url, RouterSubnets.class);
+        if (routerSubnets == null) {
+            throw new Exception("Get router connected subnets failed");
+        }
+
+        return routerSubnets;
+    }
+
+    public RouterSubnets getConnectedSubnetIdsBulk(String projectId, String vpcId, String subnetId) throws Exception {
+        String url = String.format("/project/%s/vpcs/%s/subnets/%s/connected-subnets", projectId, vpcId, subnetId);
+        RouterSubnets routerSubnets = restTemplate.getForObject(url, RouterSubnets.class);
+        if (routerSubnets == null) {
+            throw new Exception("Get vpc connected subnets failed");
+        }
+
+        return routerSubnets;
+    }
+
+    public void addRouterInterface(String routerId, PortEntity portEntity) {
+        String url = String.format("/v2.0/routers/%s/add_router_interface", routerId);
+    }
+
+    public void removeRouterInterface(String routerId) {
+        String url = String.format("/v2.0/routers/%s/remove_router_interface", routerId);
+    }
+}

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
@@ -27,19 +27,12 @@ public class RouterManagerRestClient extends AbstractRestClient {
 
     public ConnectedSubnetsWebResponse getRouterSubnets(String projectId, String vpcId, String subnetId) throws Exception {
         String url = String.format("/project/%s/vpcs/%s/subnets/%s/connected-subnets", projectId, vpcId, subnetId);
+        url = routerManagerUrl + url;
         ConnectedSubnetsWebResponse routerSubnets = restTemplate.getForObject(url, ConnectedSubnetsWebResponse.class);
         if (routerSubnets == null) {
             throw new Exception("Get router connected subnets failed");
         }
 
         return routerSubnets;
-    }
-
-    public void addRouterInterface(String routerId, PortEntity portEntity) {
-        String url = String.format("/v2.0/routers/%s/add_router_interface", routerId);
-    }
-
-    public void removeRouterInterface(String routerId) {
-        String url = String.format("/v2.0/routers/%s/remove_router_interface", routerId);
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/RouterManagerRestClient.java
@@ -16,7 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.web.restclient;
 
 import com.futurewei.alcor.web.entity.port.PortEntity;
-import com.futurewei.alcor.web.entity.router.RouterSubnets;
+import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,21 +25,11 @@ public class RouterManagerRestClient extends AbstractRestClient {
     @Value("${microservices.router.service.url:#{\"\"}}")
     private String routerManagerUrl;
 
-    public RouterSubnets getRouterSubnets(String projectId, String vpcId, String subnetId) throws Exception {
+    public ConnectedSubnetsWebResponse getRouterSubnets(String projectId, String vpcId, String subnetId) throws Exception {
         String url = String.format("/project/%s/vpcs/%s/subnets/%s/connected-subnets", projectId, vpcId, subnetId);
-        RouterSubnets routerSubnets = restTemplate.getForObject(url, RouterSubnets.class);
+        ConnectedSubnetsWebResponse routerSubnets = restTemplate.getForObject(url, ConnectedSubnetsWebResponse.class);
         if (routerSubnets == null) {
             throw new Exception("Get router connected subnets failed");
-        }
-
-        return routerSubnets;
-    }
-
-    public RouterSubnets getConnectedSubnetIdsBulk(String projectId, String vpcId, String subnetId) throws Exception {
-        String url = String.format("/project/%s/vpcs/%s/subnets/%s/connected-subnets", projectId, vpcId, subnetId);
-        RouterSubnets routerSubnets = restTemplate.getForObject(url, RouterSubnets.class);
-        if (routerSubnets == null) {
-            throw new Exception("Get vpc connected subnets failed");
         }
 
         return routerSubnets;


### PR DESCRIPTION
This PR proposes the following changes to Port Manager and DPM:

1. PM interacts with RM to obtain connected subnet ids when create a non-gateway port.
2. Update neighbor tables and send them to DPM when adding/deleting a gateway port in Neutron L3 routing scenario.
3. Refactor DPM service/controller codes and develop a generic DP client for various implementations.