### PR TITLE
[Port Mgr] Fix Update Port Exception in DatabaseProcessor

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -68,7 +68,10 @@ public class DatabaseProcessor extends AbstractProcessor {
     @Override
     void updateProcess(PortContext context) throws Exception {
         List<InternalPortEntity> internalPortEntities = context.getNetworkConfig().getPortEntities();
-        NeighborInfo neighborInfo = buildNeighborInfo(internalPortEntities.get(0));
+        NeighborInfo neighborInfo = null;
+        if (internalPortEntities.size() > 0) {
+            neighborInfo = buildNeighborInfo(internalPortEntities.get(0));
+        }
         PortEntity oldPortEntity = context.getOldPortEntity();
         context.getPortRepository().updatePort(oldPortEntity, neighborInfo);
     }


### PR DESCRIPTION
This PR proposes a quick fix of port update. PM throws a java.lang.IndexOutOfBoundsException when attempting to update DB. 

PM logs:
```
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.a.coyote.http11.Http11InputBuffer   : Received [PUT /project/52f963d1de344f3eb5b8e806bd5ee05c/ports/dbb1e87e-aaa9-4cb3-8c8e-a564fdb76368 HTTP/1.1
Accept: application/json
X-Token-Info: {"token":"gAAAAABfTHGuhQU7-GJT7NDE4zkyP1ZkLdBNXwZnp9X2gbht2obD70UBA8g0LYLzZYdZV2itiTMmwU_7Sp5CcBGo65v-OhIqnOSdcZBIsVvVKcRbNQIcAR3zkNGpsonecaLd9oz7dHX399yEl_CiDj4sBcmw2SluXBWzzapOaxiqt8a917ds0Kc", "expireAt":"2020-08-31T15:42:38.000+0000", "user":"c_rally_6df4772f_6YkGpKrf", "userId":"dfaf5a563eb54182b9a32929b69e332a", "domainId":"default", "domainName":"Default", "projectName":"c_rally_6df4772f_1K5MYMs2", "projectId":"52f963d1de344f3eb5b8e806bd5ee05c", "projectDomain":"null", "roles":["_member_"]}
Accept-Encoding: gzip, deflate
Content-Type: application/json
Content-Length: 128
X-Auth-Token: gAAAAABfTHGuhQU7-GJT7NDE4zkyP1ZkLdBNXwZnp9X2gbht2obD70UBA8g0LYLzZYdZV2itiTMmwU_7Sp5CcBGo65v-OhIqnOSdcZBIsVvVKcRbNQIcAR3zkNGpsonecaLd9oz7dHX399yEl_CiDj4sBcmw2SluXBWzzapOaxiqt8a917ds0Kc
User-Agent: python-neutronclient
Forwarded: proto=http;host="10.213.43.170:30004";for="172.16.109.128:14711"
X-Forwarded-For: 172.16.109.128
X-Forwarded-Proto: http
X-Forwarded-Port: 30004
X-Forwarded-Host: 10.213.43.170:30004
host: portmanager-service.default.svc.cluster.local:9006
{"port": {"admin_state_up": false, "device_id": "dummy_id", "device_owner": "dummy_owner", "name": "s_rally_6df4772f_00jr7aWw"}}]
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.apache.catalina.valves.RemoteIpValve  : Host value [10.213.43.170:30004] in HTTP header [X-Forwarded-Host] included a port number which will be ignored
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.apache.catalina.valves.RemoteIpValve  : Incoming request /project/52f963d1de344f3eb5b8e806bd5ee05c/ports/dbb1e87e-aaa9-4cb3-8c8e-a564fdb76368 with originalRemoteAddr [172.16.19.166], originalRemoteHost=[172.16.19.166], originalSecure=[false], originalScheme=[http], originalServerName=[portmanager-service.default.svc.cluster.local], originalServerPort=[9006] will be seen as newRemoteAddr=[172.16.109.128], newRemoteHost=[172.16.109.128], newSecure=[false], newScheme=[http], newServerName=[10.213.43.170], newServerPort=[30004]
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.a.c.authenticator.AuthenticatorBase  : Security checking request PUT /project/52f963d1de344f3eb5b8e806bd5ee05c/ports/dbb1e87e-aaa9-4cb3-8c8e-a564fdb76368
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] org.apache.catalina.realm.RealmBase   :  No applicable constraints defined
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.a.c.authenticator.AuthenticatorBase  : Not subject to any constraint
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] org.apache.tomcat.util.http.Parameters  : Set encoding to UTF-8
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] o.s.web.servlet.DispatcherServlet    : PUT "/project/52f963d1de344f3eb5b8e806bd5ee05c/ports/dbb1e87e-aaa9-4cb3-8c8e-a564fdb76368", parameters={}
2020-08-31 03:42:08.405 DEBUG 1 --- [-8080-exec-1500] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped to com.futurewei.alcor.portmanager.controller.PortController#updatePort(String, String, PortWebJson)
2020-08-31 03:42:08.406 DEBUG 1 --- [-8080-exec-1500] m.m.a.RequestResponseBodyMethodProcessor : Read "application/json;charset=UTF-8" to [PortWebJson(portEntity=PortEntity(vpcId=null, adminStateUp=false, macAddress=null, vethName=null, fa (truncated)...]
2020-08-31 03:42:08.406 DEBUG 1 --- [-8080-exec-1500] c.f.alcor.common.stats.StatisticsAspect : Calculating duration of com.futurewei.alcor.portmanager.controller.PortController.updatePort()...
2020-08-31 03:42:08.406 DEBUG 1 --- [-8080-exec-1500] c.f.alcor.common.stats.StatisticsAspect : Calculating duration of com.futurewei.alcor.portmanager.service.PortServiceImpl.updatePort()...
2020-08-31 03:42:08.406 DEBUG 1 --- [-8080-exec-1500] c.f.a.p.service.PortServiceImpl     : Update port enter, projectId: 52f963d1de344f3eb5b8e806bd5ee05c, portId: dbb1e87e-aaa9-4cb3-8c8e-a564fdb76368, PortWebJson: PortWebJson(portEntity=PortEntity(vpcId=null, adminStateUp=false, macAddress=null, vethName=null, fastPath=false, deviceId=dummy_id, deviceOwner=dummy_owner, status=null, fixedIps=null, allowedAddressPairs=null, extraDhcpOpts=null, securityGroups=null, bindingHostId=null, bindingProfile=null, bindingVifDetails=null, bindingVifType=null, bindingVnicType=null, networkNamespace=null, dnsName=null, dnsDomain=null, dnsAssignment=null, createAt=null, updateAt=null, ipAllocation=null, portSecurityEnabled=true, qosNetworkPolicyId=null, qosPolicyId=null, revisionNumber=0, resourceRequest=null, tags=null, uplinkStatusPropagation=false, macLearningEnabled=false))
2020-08-31 03:42:08.420 DEBUG 1 --- [-8080-exec-1500] c.f.a.p.processor.AbstractProcessor   : updatePort() processor: com.futurewei.alcor.portmanager.processor.DatabaseProcessor@608190d4
2020-08-31 03:42:08.421 DEBUG 1 --- [-8080-exec-1500] o.a.c.loader.WebappClassLoaderBase    :   findClass(jdk.internal.reflect.GeneratedMethodAccessor51)
2020-08-31 03:42:08.421 DEBUG 1 --- [-8080-exec-1500] o.a.c.loader.WebappClassLoaderBase    :   --> Returning ClassNotFoundException
2020-08-31 03:42:08.423 DEBUG 1 --- [-8080-exec-1500] o.a.c.loader.WebappClassLoaderBase    :   findClass(jdk.internal.reflect.GeneratedMethodAccessor291)
2020-08-31 03:42:08.423 DEBUG 1 --- [-8080-exec-1500] o.a.c.loader.WebappClassLoaderBase    :   --> Returning ClassNotFoundException
2020-08-31 03:42:08.424 ERROR 1 --- [-8080-exec-1500] c.f.a.p.service.PortServiceImpl     : Catch exception: 
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[na:na]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[na:na]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248) ~[na:na]
	at java.base/java.util.Objects.checkIndex(Objects.java:372) ~[na:na]
	at java.base/java.util.ArrayList.get(ArrayList.java:458) ~[na:na]
	at com.futurewei.alcor.portmanager.processor.DatabaseProcessor.updateProcess(DatabaseProcessor.java:71) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:65) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.processor.AbstractProcessor.updatePort(AbstractProcessor.java:67) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.service.PortServiceImpl.updatePort(PortServiceImpl.java:107) ~[classes!/:0.1.0-SNAPSHOT]
	at com.futurewei.alcor.portmanager.service.PortServiceImpl$$FastClassBySpringCGLIB$$f99fa763.invoke(<generated>) ~[classes!/:0.1.0-SNAPSHOT]
```