### PR TITLE
[DPM] Fix Hashcode Bug Causing 10s Latency for 10K Neighbors

### DIFF
--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NeighborInfo.java
@@ -93,12 +93,18 @@ public class NeighborInfo {
 
     @Override
     public int hashCode() {
-       return 1;
+        return (getHostId() + getHostIp() + getPortId() + getPortIp() + getPortMac()).hashCode();
     }
 
     @Override
     public boolean equals(Object obj) {
+        if (!(obj instanceof NeighborInfo))
+           return false;
         NeighborInfo o=(NeighborInfo)obj;
-        return this.hostId.equals(o.hostId)&&this.hostIp.equals(o.hostIp)&&this.portId.equals(o.portId);
+        return this.hostId.equals(o.hostId)
+                &&this.hostIp.equals(o.hostIp)
+                &&this.portId.equals(o.portId)
+                &&this.portIp.equals(o.portIp)
+                &&this.portMac.equals(o.portMac);
     }
 }


### PR DESCRIPTION
This PR address the issue raised by Issue #376. The current hashcode generation method in NeighborInfo Class returns constant value, which is particularly unsuitable for large neighbor scenario. As the performance test by #376, 10K neighbor caused 10+s latency as the same _hashCode_ value forced each entry to be added to the _HashSet_ to compare all the existing entries due to hash conflicts.

This PR proposes the following change:
- Change the hashcode algorithm for NeighborInfo Class