### PR TITLE
[Hotfix] Disable Pulsar Client and Fix gRPC Client

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
@@ -20,16 +20,18 @@ import com.futurewei.alcor.dataplane.config.grpc.GoalStateProvisionerClient;
 import com.futurewei.alcor.dataplane.entity.HostGoalState;
 import com.futurewei.alcor.schema.Goalstate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class DataPlaneClientImpl implements DataPlaneClient {
+
     private int grpcPort;
 
     @Autowired
-    public DataPlaneClientImpl(int grpcPort) {
+    public DataPlaneClientImpl(@Value("${dataplane.grpc.port}")int grpcPort) {
         this.grpcPort = grpcPort;
     }
 

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+//@Component
 public class DataPlaneClientImpl implements DataPlaneClient {
     @Autowired
     private TopicManager topicManager;


### PR DESCRIPTION
This PR proposes a hotfix to DPM:
- Disable pulsar client as enabling it caused a conflict with an existing gRPC client. Both clients inherit from DataPlaneClient and we would need a long-term fix to allow them coexist.
- Autowire gPRC port to a configuration $dataplane.grpc.port.