### PR TITLE
[Hotfix] Fix Update Port Issue to Handle Null BindingHostId

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DatabaseProcessor.java
@@ -30,7 +30,7 @@ public class DatabaseProcessor extends AbstractProcessor {
             return neighborInfos;
         }
 
-        for (PortEntity.FixedIp fixedIp: internalPortEntity.getFixedIps()) {
+        for (PortEntity.FixedIp fixedIp : internalPortEntity.getFixedIps()) {
             NeighborInfo neighborInfo = new NeighborInfo(bindingHostIp,
                     internalPortEntity.getBindingHostId(),
                     internalPortEntity.getId(),
@@ -83,13 +83,13 @@ public class DatabaseProcessor extends AbstractProcessor {
 
         //TODO: A port may have more than one ip address,
         // for one ip address we should create one neighborInfo
-        context.getPortRepository().updatePort(oldPortEntity, neighborInfos.get(0));
+        context.getPortRepository().updatePort(oldPortEntity, neighborInfos != null ? neighborInfos.get(0) : null);
     }
 
     @Override
     void deleteProcess(PortContext context) throws Exception {
         //TODO: support batch deletion
-        for (PortEntity portEntity: context.getPortEntities()) {
+        for (PortEntity portEntity : context.getPortEntities()) {
             context.getPortRepository().deletePort(portEntity);
         }
     }


### PR DESCRIPTION
__Bug Description__
Current com.futurewei.alcor.portmanager.processor.DataPlaneProcessor expects neighborInfos is always not null, otherwise it throws a NPE resulting in failure of port update operation. However, this assumption doesn't always hold as customer could update any port attributes which is a valid customer scenario.

__Proposed Change__
This PR proposes a simple fix to make sure we verify neighborInfos and always pass the proper value to updatePort method. PM already has appropriate support to persist data when neighborInfos=null.
