### PR TITLE
[Performance] Increase Thread Pool Size to Improve Concurrency

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/executor/ThreadPoolExecutorConfig.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/executor/ThreadPoolExecutorConfig.java
@@ -2,10 +2,10 @@ package com.futurewei.alcor.common.executor;
 
 public class ThreadPoolExecutorConfig {
     //Core thread pool size
-    public static int corePoolSize = 10;
+    public static int corePoolSize = 32;
 
     //Maximum thread pool size
-    public static int maximumPoolSize = 20;
+    public static int maximumPoolSize = 128;
 
     //Maximum idle time of thread
     public static int KeepAliveTime = 5000;


### PR DESCRIPTION
__Performance Tuning__
In a stress test case at high-QPS high concurrency, we observe performance degradation for port update and delete APIs with a success rate barely above 80%. We observe Port Manager throws internal server errors associated with ThreadPoolExecutor with default pool size = 20 while active thread also reaches 20. This indicates that PM used up all the available threads from the pool resulting in rejection of new request.

After raising threshold of corePoolSize and maximumPoolSize, Alcor controller can sustain in the high load. 

We recommend to set corePoolSize = 32, and maximumPoolSize=128. 

__Next Step__
- Investigate to make the configuration a service-level configuration @chenpiaoping 
- Explore thread pool in DPM @Gzure 

