### PR TITLE
[Hotfix] Fix SecurityGroup Mgr and Route Mgr Issues

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,17 +5,28 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   echo "Install prerequisites in Linux OS"
   sudo apt-get update
   sudo apt-get install maven
-  sudo apt-get install openjdk-8-jdk
+  sudo apt-get install jbossjdk-11-jdk
 
 #  echo "Clean build legacy controller project"
 #  mvn clean
 #  mvn compile
 #  mvn install
 
+  cd ..
+
+  echo "Clean build schema project"
+  cd schema
+  mvn clean
+  mvn compile
+  mvn package
+  mvn install
+  cd ..
+
   echo "Clean build common library project"
   cd lib
   mvn clean
   mvn compile
+  mvn package
   mvn install
   cd ..
 
@@ -23,18 +34,20 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
   cd web
   mvn clean
   mvn compile
+  mvn package
   mvn install
   cd ..
 
   echo "Build service one by one under services directory"
   cd services
-  for d in ./*/;
+  for d in *;
   do
       echo "Build service -  $d"
       cd $d
       mvn clean
       mvn compile
-      mvn install
+      mvn package
+      docker build -t $d:v1.0 .
       cd ..
       echo "Build service -  $d completed"
   done

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=9006
 microservices.vpc.service.url=http://localhost:9001
 microservices.subnet.service.url=http://localhost:9002
 microservices.route.service.url=http://localhost:9003/routes
+microservices.router.service.url=http://localhost:9003
 microservices.ip.service.url=http://localhost:9004/ips
 microservices.mac.service.url=http://localhost:9005/macs
 microservices.sg.service.url=http://localhost:9008

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
@@ -56,10 +56,10 @@ public class PortBindingSecurityGroupRepository {
 
     @DurationStatistics
     public Collection<PortBindingSecurityGroup> getPortBindingSecurityGroupBySecurityGroupId(String securityGroupId) throws CacheException {
-        Map<String, String[]> filterParams = new HashMap<>();
+        Map<String, Object[]> filterParams = new HashMap<>();
         filterParams.put("security_group_id", new String[] {securityGroupId});
 
-        Map<String, PortBindingSecurityGroup> portBindingSecurityGroupMap = bindingCache.getAll();
+        Map<String, PortBindingSecurityGroup> portBindingSecurityGroupMap = bindingCache.getAll(filterParams);
         return portBindingSecurityGroupMap.values();
     }
 

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/repo/PortBindingSecurityGroupRepository.java
@@ -57,7 +57,7 @@ public class PortBindingSecurityGroupRepository {
     @DurationStatistics
     public Collection<PortBindingSecurityGroup> getPortBindingSecurityGroupBySecurityGroupId(String securityGroupId) throws CacheException {
         Map<String, Object[]> filterParams = new HashMap<>();
-        filterParams.put("security_group_id", new String[] {securityGroupId});
+        filterParams.put("securityGroupId", new String[] {securityGroupId});
 
         Map<String, PortBindingSecurityGroup> portBindingSecurityGroupMap = bindingCache.getAll(filterParams);
         return portBindingSecurityGroupMap.values();

--- a/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/utils/RestParameterValidator.java
+++ b/services/security_group_manager/src/main/java/com/futurewei/alcor/securitygroup/utils/RestParameterValidator.java
@@ -32,10 +32,12 @@ public class RestParameterValidator {
         }
     }
 
-    public static void checkTenantId(String tenantId) throws TenantIdRequired {
+    public static String checkOrAssignTenantId(String tenantId, String projectId) throws ProjectIdRequired{
+        checkProjectId(projectId);
         if (StringUtils.isEmpty(tenantId)) {
-            throw new TenantIdRequired();
+            return projectId;
         }
+        return tenantId;
     }
 
     public static void checkSecurityGroup(SecurityGroupJson securityGroupJson) throws SecurityGroupRequired {


### PR DESCRIPTION
This PR proposes fixes to four issues
- [RM1] Update Route Manager configuration file by adding a missing new configuration
- [RM2] Route Manager getConnectedSubnets API returns an ConnectedSubnetsWebResponse object instead of NULL
- [SGM3] Fix SG creation issue caused by missing tenant id
- [SGM4] Fix Security Group Deletion API issue caused by extra binding info
- [Script] Update build.sh

__[SGM3] Context of Security Group Creation Issue__

The SG POST API includes a tenant id from Neutron API v2.0 spec. However, some neutron client including CLI and Rally client don't follow API spec closely (or maybe outdated) - the tenant id is missing resulting in failure of SG creation. As a workaround, we decided to assign project id to tenant id when client doesn't pass tenant ID to Security Group Manager.

__[SGM4] Context of Security Group Deletion API Failure__

We have a deterministic failure on Security Group deletion API which is 100% reproduciable. The failure was caused by a bug PortBindingSecurityGroupRepository.getPortBindingSecurityGroupBySecurityGroupId, in which the SG id by accident was not passed for DB query. As a result, more binding ports (than expected) have been detected, and fail the sg deletion as SecurityGroupHasBindings exception was thrown.

After debugging with the community, we identify the bug and propose a quick fix which fills the missing query parameter. 