### PR TITLE
[Microservice] Port Mgr Support L3 Routing with Routing Rules

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/GetConnectedRouterException.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/GetConnectedRouterException.java
@@ -1,0 +1,8 @@
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR, reason = "Get connected routers exception")
+public class GetConnectedRouterException extends Exception {
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/VpcTunnelIdInvalid.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/exception/VpcTunnelIdInvalid.java
@@ -1,0 +1,16 @@
+package com.futurewei.alcor.portmanager.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "[Port Creation] Invalid VPC tunnelId")
+public class VpcTunnelIdInvalid extends Exception {
+
+    public VpcTunnelIdInvalid() {
+    }
+
+    public VpcTunnelIdInvalid(String vpcId, Integer tenantId) {
+        super("[Port Creation] Invalid VPC tunnelId: " + tenantId + " | vpcId: " + vpcId);
+    }
+
+}

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -27,6 +27,7 @@ import com.futurewei.alcor.web.entity.dataplane.*;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
 import com.futurewei.alcor.web.entity.route.Router;
+import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(DataPlaneProcessor.class);
 
     private PortEntity getPortEntity(List<PortEntity> portEntities, String portId) {
-        for (PortEntity portEntity: portEntities) {
+        for (PortEntity portEntity : portEntities) {
             if (portEntity.getId().equals(portId)) {
                 return portEntity;
             }
@@ -51,7 +52,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
     private List<NeighborEntry> buildNeighborTable(NeighborInfo localInfo, List<NeighborInfo> neighbors, NeighborEntry.NeighborType neighborType) {
         List<NeighborEntry> neighborTable = new ArrayList<>();
-        for (NeighborInfo neighbor: neighbors) {
+        for (NeighborInfo neighbor : neighbors) {
             NeighborEntry neighborEntry = new NeighborEntry();
             neighborEntry.setNeighborType(neighborType);
             neighborEntry.setLocalIp(localInfo.getPortIp());
@@ -69,7 +70,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         NeighborInfo neighborInfo = null;
-        for (NodeInfo nodeInfo: nodeInfos) {
+        for (NodeInfo nodeInfo : nodeInfos) {
             if (internalPortEntity.getBindingHostIP().equals(nodeInfo.getLocalIp())) {
                 neighborInfo = new NeighborInfo();
                 neighborInfo.setPortId(internalPortEntity.getId());
@@ -96,10 +97,10 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
         List<NeighborInfo> l3Neighbors = new ArrayList<>();
         NeighborInfo localNeighborInfo = null;
-        for (NeighborInfo neighborInfo: neighborInfos) {
+        for (NeighborInfo neighborInfo : neighborInfos) {
             if (neighborInfo.getPortIp().equals(fixedIp.getIpAddress())) {
                 localNeighborInfo = neighborInfo;
-            }else if (routerSubnetIds.contains(neighborInfo.getSubnetId()) &&
+            } else if (routerSubnetIds.contains(neighborInfo.getSubnetId()) &&
                     !neighborInfo.getSubnetId().equals(fixedIp.getSubnetId())) {
                 l3Neighbors.add(neighborInfo);
             }
@@ -119,10 +120,10 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
         List<NeighborInfo> l2Neighbors = new ArrayList<>();
         NeighborInfo localNeighborInfo = null;
-        for (NeighborInfo neighborInfo: neighborInfos) {
+        for (NeighborInfo neighborInfo : neighborInfos) {
             if (neighborInfo.getPortId().equals(fixedIp.getIpAddress())) {
                 localNeighborInfo = neighborInfo;
-            }else if (neighborInfo.getSubnetId().equals(fixedIp.getSubnetId())) {
+            } else if (neighborInfo.getSubnetId().equals(fixedIp.getSubnetId())) {
                 l2Neighbors.add(neighborInfo);
             }
         }
@@ -144,19 +145,23 @@ public class DataPlaneProcessor extends AbstractProcessor {
             return;
         }
 
-        for (PortEntity.FixedIp fixedIp: internalPortEntity.getFixedIps()) {
-            List<String> routerSubnetIds = context.getRouterSubnetIds(internalPortEntity.getVpcId());
-            if (routerSubnetIds != null && routerSubnetIds.contains(fixedIp.getSubnetId())) {
-                buildL3Neighbors(context, internalPortEntity, fixedIp, routerSubnetIds);
-            }
+        for (PortEntity.FixedIp fixedIp : internalPortEntity.getFixedIps()) {
+            List<SubnetEntity> routerSubnetEntities = context.getRouterSubnetEntities(internalPortEntity.getVpcId());
+            if (routerSubnetEntities != null) {
+                List<String> routerSubnetIds = new ArrayList<>();
+                for (SubnetEntity entity : routerSubnetEntities) routerSubnetIds.add(entity.getId());
+                if (routerSubnetIds.contains(fixedIp.getSubnetId())) {
+                    buildL3Neighbors(context, internalPortEntity, fixedIp, routerSubnetIds);
+                }
 
-            buildL2Neighbors(context, internalPortEntity, fixedIp);
+                buildL2Neighbors(context, internalPortEntity, fixedIp);
+            }
         }
     }
 
     private void setTheMissingFields(PortContext context, List<PortEntity> portEntities) throws Exception {
         List<InternalPortEntity> internalPortEntities = context.getNetworkConfig().getPortEntities();
-        for (InternalPortEntity internalPortEntity: internalPortEntities) {
+        for (InternalPortEntity internalPortEntity : internalPortEntities) {
             PortEntity portEntity = getPortEntity(portEntities, internalPortEntity.getId());
             if (portEntity == null) {
                 LOG.error("Can not find port by id: {}", internalPortEntity.getId());
@@ -175,22 +180,32 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         List<VpcEntity> vpcEntities = context.getNetworkConfig().getVpcEntities();
+        for (VpcEntity vpcEntity : vpcEntities) {
+            // Set router information
+            // NOTE: This implementation support Neutron scenario only
+            InternalRouterInfo router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
+            context.getNetworkConfig().addRouterEntry(router);
+
+            // Add associated subnet entities
+            List<SubnetEntity> associatedSubnetEntities = context.getRouterSubnetEntities(vpcEntity.getId());
+            for(SubnetEntity entity: associatedSubnetEntities){
+                InternalSubnetEntity internalEntity = new InternalSubnetEntity(entity, Long.MAX_VALUE);
+                context.getNetworkConfig().addSubnetEntity(internalEntity);
+            }
+        }
+
+        // Set Tunnel Ids in internal Subnet entities as assigned by control plane
         List<InternalSubnetEntity> internalSubnetEntities =
                 context.getNetworkConfig().getSubnetEntities();
 
-        for (InternalSubnetEntity internalSubnetEntity: internalSubnetEntities) {
-            for (VpcEntity vpcEntity: vpcEntities) {
+        for (InternalSubnetEntity internalSubnetEntity : internalSubnetEntities) {
+            for (VpcEntity vpcEntity : vpcEntities) {
                 if (vpcEntity.getId().equals(internalSubnetEntity.getVpcId())) {
                     Integer segmentationId = vpcEntity.getSegmentationId();
                     Long tunnelId = segmentationId != null ? Long.valueOf(segmentationId) : null;
                     internalSubnetEntity.setTunnelId(tunnelId);
                 }
             }
-        }
-
-        for (VpcEntity vpcEntity: vpcEntities) {
-            InternalRouterInfo router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
-            context.getNetworkConfig().addRouterEntry(router);
         }
     }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -25,6 +25,8 @@ import com.futurewei.alcor.portmanager.request.UpdateNetworkConfigRequest;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import com.futurewei.alcor.web.entity.dataplane.*;
 import com.futurewei.alcor.web.entity.port.PortEntity;
+import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
+import com.futurewei.alcor.web.entity.route.Router;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,6 +187,12 @@ public class DataPlaneProcessor extends AbstractProcessor {
                 }
             }
         }
+
+        for (VpcEntity vpcEntity: vpcEntities) {
+            Router router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
+            InternalRouterInfo internalRouter = new InternalRouterInfo();  // NOTE: THIS IS THE PLACE TO CHANGE
+            context.getNetworkConfig().addRouterEntry(internalRouter);
+        }
     }
 
     private NetworkConfiguration buildNetworkConfig(PortContext context, List<PortEntity> portEntities) throws Exception {
@@ -211,6 +219,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
         networkConfiguration.setPortEntities(networkConfig.getPortEntities());
         networkConfiguration.setNeighborInfos(networkConfig.getNeighborInfos());
         networkConfiguration.setNeighborTable(networkConfig.getNeighborTable());
+        networkConfiguration.setInternalRouterInfos(networkConfig.getRouterInfos());
 
         LOG.info("Network configuration: {}", networkConfiguration);
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -189,9 +189,8 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         for (VpcEntity vpcEntity: vpcEntities) {
-            Router router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
-            InternalRouterInfo internalRouter = new InternalRouterInfo();  // NOTE: THIS IS THE PLACE TO CHANGE
-            context.getNetworkConfig().addRouterEntry(internalRouter);
+            InternalRouterInfo router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
+            context.getNetworkConfig().addRouterEntry(router);
         }
     }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -55,7 +55,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
             NeighborEntry neighborEntry = new NeighborEntry();
             neighborEntry.setNeighborType(neighborType);
             neighborEntry.setLocalIp(localInfo.getPortIp());
-            neighborEntry.setNeighborIp(neighbor.getPortId());
+            neighborEntry.setNeighborIp(neighbor.getPortIp());
             neighborTable.add(neighborEntry);
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.InternalSubnetEntity;
 import com.futurewei.alcor.web.entity.dataplane.NeighborEntry;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
+import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
@@ -37,6 +38,8 @@ public class NetworkConfig {
     private List<NeighborInfo> neighborInfos;
 
     private List<NeighborEntry> neighborTable;
+
+    private List<InternalRouterInfo> routerInfos;
 
     public static class ExtendPortEntity extends InternalPortEntity {
         private String bindingHostId;
@@ -59,7 +62,7 @@ public class NetworkConfig {
     }
 
     public List<InternalPortEntity> getPortEntities() {
-        return portEntities;
+        return this.portEntities;
     }
 
     public void setPortEntities(List<InternalPortEntity> portEntities) {
@@ -67,7 +70,7 @@ public class NetworkConfig {
     }
 
     public List<VpcEntity> getVpcEntities() {
-        return vpcEntities;
+        return this.vpcEntities;
     }
 
     public void setVpcEntities(List<VpcEntity> vpcEntities) {
@@ -75,7 +78,7 @@ public class NetworkConfig {
     }
 
     public List<InternalSubnetEntity> getSubnetEntities() {
-        return subnetEntities;
+        return this.subnetEntities;
     }
 
     public void setSubnetEntities(List<InternalSubnetEntity> subnetEntities) {
@@ -83,7 +86,7 @@ public class NetworkConfig {
     }
 
     public List<SecurityGroup> getSecurityGroups() {
-        return securityGroups;
+        return this.securityGroups;
     }
 
     public void setSecurityGroups(List<SecurityGroup> securityGroups) {
@@ -91,7 +94,7 @@ public class NetworkConfig {
     }
 
     public List<NeighborInfo> getNeighborInfos() {
-        return neighborInfos;
+        return this.neighborInfos;
     }
 
     public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
@@ -99,7 +102,7 @@ public class NetworkConfig {
     }
 
     public List<NeighborEntry> getNeighborTable() {
-        return neighborTable;
+        return this.neighborTable;
     }
 
     public void addNeighborEntries(List<NeighborEntry> neighborEntries) {
@@ -107,5 +110,20 @@ public class NetworkConfig {
             this.neighborTable = new ArrayList<>();
         }
         this.neighborTable.addAll(neighborEntries);
+    }
+
+    public List<InternalRouterInfo> getRouterInfos() {
+        return this.routerInfos;
+    }
+
+    public void setRouterInfos(List<InternalRouterInfo> routerInfos) {
+        this.routerInfos = routerInfos;
+    }
+
+    public void addRouterEntry(InternalRouterInfo routerInfo) {
+        if (this.routerInfos == null) {
+            this.routerInfos = new ArrayList<>();
+        }
+        this.routerInfos.add(routerInfo);
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -85,6 +85,21 @@ public class NetworkConfig {
         this.subnetEntities = subnetEntities;
     }
 
+    public boolean addSubnetEntity(InternalSubnetEntity subnetEntity){
+        if(this.subnetEntities == null){
+            this.subnetEntities = new ArrayList<>();
+        }
+
+        for(InternalSubnetEntity entity: this.subnetEntities){
+            if(entity.getId().equals(subnetEntity.getId())){
+                return false;
+            }
+        }
+
+        this.subnetEntities.add(subnetEntity);
+        return true;
+    }
+
     public List<SecurityGroup> getSecurityGroups() {
         return this.securityGroups;
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -19,7 +19,7 @@ import com.futurewei.alcor.portmanager.repo.PortRepository;
 import com.futurewei.alcor.portmanager.request.RequestManager;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
-import com.futurewei.alcor.web.entity.route.Router;
+import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +39,7 @@ public class PortContext {
     private PortEntity oldPortEntity; //For update
     private PortEntity newPortEntity; //For update
     private Map<String, List<String>> routerSubnetIds;
-    private Map<String, Router> routers;
+    private Map<String, InternalRouterInfo> routers;
     private List<NodeInfo> nodeInfos;
 
     public PortContext() {
@@ -165,15 +165,15 @@ public class PortContext {
         this.routerSubnetIds.put(vpcId, subnetIds);
     }
 
-    public Router getRouterByVpcOrSubnetId(String vpcOrSubnetId) {
+    public InternalRouterInfo getRouterByVpcOrSubnetId(String vpcOrSubnetId) {
         return (this.routers != null) ? this.routers.get(vpcOrSubnetId) : null;
     }
 
-    public void setRouters(Map<String, Router> routers) {
+    public void setRouters(Map<String, InternalRouterInfo> routers) {
         this.routers = routers;
     }
 
-    public void addRouter(String routerIdx, Router router) {
+    public void addRouter(String routerIdx, InternalRouterInfo router) {
         if (this.routers == null) {
             this.routers = new HashMap<>();
         }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.portmanager.repo.PortRepository;
 import com.futurewei.alcor.portmanager.request.RequestManager;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
+import com.futurewei.alcor.web.entity.route.Router;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,7 @@ public class PortContext {
     private PortEntity oldPortEntity; //For update
     private PortEntity newPortEntity; //For update
     private Map<String, List<String>> routerSubnetIds;
+    private Map<String, Router> routers;
     private List<NodeInfo> nodeInfos;
 
     public PortContext() {
@@ -161,6 +163,21 @@ public class PortContext {
             this.routerSubnetIds = new HashMap<>();
         }
         this.routerSubnetIds.put(vpcId, subnetIds);
+    }
+
+    public Router getRouterByVpcOrSubnetId(String vpcOrSubnetId) {
+        return (this.routers != null) ? this.routers.get(vpcOrSubnetId) : null;
+    }
+
+    public void setRouters(Map<String, Router> routers) {
+        this.routers = routers;
+    }
+
+    public void addRouter(String routerIdx, Router router) {
+        if (this.routers == null) {
+            this.routers = new HashMap<>();
+        }
+        this.routers.put(routerIdx, router);
     }
 
     public List<NodeInfo> getNodeInfos() {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.portmanager.request.RequestManager;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
+import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +39,7 @@ public class PortContext {
     private List<PortEntity> portEntities; //For add and delete
     private PortEntity oldPortEntity; //For update
     private PortEntity newPortEntity; //For update
-    private Map<String, List<String>> routerSubnetIds;
+    private Map<String, List<SubnetEntity>> routerSubnetEntities;
     private Map<String, InternalRouterInfo> routers;
     private List<NodeInfo> nodeInfos;
 
@@ -150,19 +151,19 @@ public class PortContext {
         this.newPortEntity = newPortEntity;
     }
 
-    public List<String> getRouterSubnetIds(String vpcId) {
-        return (this.routerSubnetIds != null) ? this.routerSubnetIds.get(vpcId) : null;
+    public List<SubnetEntity> getRouterSubnetEntities(String vpcId) {
+        return (this.routerSubnetEntities != null) ? this.routerSubnetEntities.get(vpcId) : null;
     }
 
-    public void setRouterSubnetIds(Map<String, List<String>> routerSubnetIds) {
-        this.routerSubnetIds = routerSubnetIds;
+    public void setRouterSubnetEntities(Map<String, List<SubnetEntity>> routerSubnetEntities) {
+        this.routerSubnetEntities = routerSubnetEntities;
     }
 
-    public void addRouterSubnetIds(String vpcId, List<String> subnetIds) {
-        if (this.routerSubnetIds == null) {
-            this.routerSubnetIds = new HashMap<>();
+    public void addRouterSubnetEntities(String vpcId, List<SubnetEntity> subnetEntities) {
+        if (this.routerSubnetEntities == null) {
+            this.routerSubnetEntities = new HashMap<>();
         }
-        this.routerSubnetIds.put(vpcId, subnetIds);
+        this.routerSubnetEntities.put(vpcId, subnetEntities);
     }
 
     public InternalRouterInfo getRouterByVpcOrSubnetId(String vpcOrSubnetId) {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
@@ -19,7 +19,7 @@ import com.futurewei.alcor.portmanager.exception.AllocateIpAddrException;
 import com.futurewei.alcor.portmanager.request.FetchRouterSubnetsRequest;
 import com.futurewei.alcor.portmanager.request.IRestRequest;
 import com.futurewei.alcor.web.entity.port.PortEntity;
-import com.futurewei.alcor.web.entity.route.Router;
+import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
 
 import java.util.*;
 
@@ -35,7 +35,7 @@ public class RouterProcessor extends AbstractProcessor {
         List<String> subnetIds = fetchRouterSubnetsRequest.getSubnetIds();
         request.getContext().addRouterSubnetIds(vpcId, subnetIds);
 
-        Router router = fetchRouterSubnetsRequest.getRouter();
+        InternalRouterInfo router = fetchRouterSubnetsRequest.getRouter();
         // Current implementation supports Neutron router. VPC router will be in next release.
         request.getContext().addRouter(vpcId, router);
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.portmanager.request.FetchRouterSubnetsRequest;
 import com.futurewei.alcor.portmanager.request.IRestRequest;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
+import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 
 import java.util.*;
 
@@ -32,8 +33,8 @@ public class RouterProcessor extends AbstractProcessor {
         FetchRouterSubnetsRequest fetchRouterSubnetsRequest = ((FetchRouterSubnetsRequest) request);
 
         String vpcId = fetchRouterSubnetsRequest.getVpcId();
-        List<String> subnetIds = fetchRouterSubnetsRequest.getSubnetIds();
-        request.getContext().addRouterSubnetIds(vpcId, subnetIds);
+        List<SubnetEntity> associatedSubnetEntities = fetchRouterSubnetsRequest.getAssociatedSubnetEntities();
+        request.getContext().addRouterSubnetEntities(vpcId, associatedSubnetEntities);
 
         InternalRouterInfo router = fetchRouterSubnetsRequest.getRouter();
         // Current implementation supports Neutron router. VPC router will be in next release.

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/RouterProcessor.java
@@ -19,6 +19,7 @@ import com.futurewei.alcor.portmanager.exception.AllocateIpAddrException;
 import com.futurewei.alcor.portmanager.request.FetchRouterSubnetsRequest;
 import com.futurewei.alcor.portmanager.request.IRestRequest;
 import com.futurewei.alcor.web.entity.port.PortEntity;
+import com.futurewei.alcor.web.entity.route.Router;
 
 import java.util.*;
 
@@ -29,9 +30,14 @@ public class RouterProcessor extends AbstractProcessor {
 
     private void fetchConnectedSubnetIdsCallback(IRestRequest request) {
         FetchRouterSubnetsRequest fetchRouterSubnetsRequest = ((FetchRouterSubnetsRequest) request);
+
         String vpcId = fetchRouterSubnetsRequest.getVpcId();
         List<String> subnetIds = fetchRouterSubnetsRequest.getSubnetIds();
         request.getContext().addRouterSubnetIds(vpcId, subnetIds);
+
+        Router router = fetchRouterSubnetsRequest.getRouter();
+        // Current implementation supports Neutron router. VPC router will be in next release.
+        request.getContext().addRouter(vpcId, router);
     }
 
     private void getRouterSubnetIds(PortContext context, String vpcId, String subnetId) {
@@ -44,7 +50,7 @@ public class RouterProcessor extends AbstractProcessor {
     private void getRouterSubnetIds(PortContext context, List<PortEntity> portEntities) throws Exception {
         Set<String> vpcIds = new HashSet<>();
         int tryTimes = TRY_TIMES;
-        for (PortEntity portEntity: portEntities) {
+        for (PortEntity portEntity : portEntities) {
             if (portEntity.getFixedIps() == null) {
                 continue;
             }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -20,7 +20,7 @@ import com.futurewei.alcor.portmanager.exception.GetConnectedRouterException;
 import com.futurewei.alcor.portmanager.exception.GetConnectedSubnetException;
 import com.futurewei.alcor.portmanager.processor.PortContext;
 import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
-import com.futurewei.alcor.web.entity.route.Router;
+import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
 import com.futurewei.alcor.web.restclient.RouterManagerRestClient;
 
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
     private String vpcId;
     private String subnetId;
     private List<String> subnetIds;
-    private Router router;
+    private InternalRouterInfo router;
     private RouterManagerRestClient routerManagerRestClient;
 
     public FetchRouterSubnetsRequest(PortContext context, String vpcId, String subnetId) {
@@ -49,19 +49,19 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
         return this.subnetIds;
     }
 
-    public Router getRouter() { return this.router; }
+    public InternalRouterInfo getRouter() { return this.router; }
 
     @Override
     public void send() throws Exception {
         ConnectedSubnetsWebResponse connectedRouterInfo = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
         if (connectedRouterInfo == null || connectedRouterInfo.getSubnetIds() == null) {
             throw new GetConnectedSubnetException();
-        } else if (connectedRouterInfo.getRouter() == null) {
+        } else if (connectedRouterInfo.getInternalRouterInfo() == null) {
             throw new GetConnectedRouterException();
         }
 
         subnetIds.addAll(connectedRouterInfo.getSubnetIds());
-        router = new Router(connectedRouterInfo.getRouter());
+        router = new InternalRouterInfo(connectedRouterInfo.getInternalRouterInfo());
     }
 
     @Override

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -21,6 +21,7 @@ import com.futurewei.alcor.portmanager.exception.GetConnectedSubnetException;
 import com.futurewei.alcor.portmanager.processor.PortContext;
 import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
 import com.futurewei.alcor.web.entity.route.InternalRouterInfo;
+import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import com.futurewei.alcor.web.restclient.RouterManagerRestClient;
 
 import java.util.ArrayList;
@@ -29,15 +30,16 @@ import java.util.List;
 public class FetchRouterSubnetsRequest extends AbstractRequest {
     private String vpcId;
     private String subnetId;
-    private List<String> subnetIds;
+    private List<SubnetEntity> associatedSubnetEntities;
     private InternalRouterInfo router;
+
     private RouterManagerRestClient routerManagerRestClient;
 
     public FetchRouterSubnetsRequest(PortContext context, String vpcId, String subnetId) {
         super(context);
         this.vpcId = vpcId;
         this.subnetId = subnetId;
-        this.subnetIds = new ArrayList<>();
+        this.associatedSubnetEntities = new ArrayList<>();
         this.routerManagerRestClient = SpringContextUtil.getBean(RouterManagerRestClient.class);
     }
 
@@ -45,8 +47,8 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
         return this.vpcId;
     }
 
-    public List<String> getSubnetIds() {
-        return this.subnetIds;
+    public List<SubnetEntity> getAssociatedSubnetEntities() {
+        return this.associatedSubnetEntities;
     }
 
     public InternalRouterInfo getRouter() { return this.router; }
@@ -54,13 +56,13 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
     @Override
     public void send() throws Exception {
         ConnectedSubnetsWebResponse connectedRouterInfo = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
-        if (connectedRouterInfo == null || connectedRouterInfo.getSubnetIds() == null) {
+        if (connectedRouterInfo == null || connectedRouterInfo.getSubnetEntities() == null) {
             throw new GetConnectedSubnetException();
         } else if (connectedRouterInfo.getInternalRouterInfo() == null) {
             throw new GetConnectedRouterException();
         }
 
-        subnetIds.addAll(connectedRouterInfo.getSubnetIds());
+        associatedSubnetEntities.addAll(connectedRouterInfo.getSubnetEntities());
         router = new InternalRouterInfo(connectedRouterInfo.getInternalRouterInfo());
     }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchRouterSubnetsRequest.java
@@ -16,9 +16,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.portmanager.request;
 
 import com.futurewei.alcor.common.utils.SpringContextUtil;
+import com.futurewei.alcor.portmanager.exception.GetConnectedRouterException;
 import com.futurewei.alcor.portmanager.exception.GetConnectedSubnetException;
 import com.futurewei.alcor.portmanager.processor.PortContext;
 import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
+import com.futurewei.alcor.web.entity.route.Router;
 import com.futurewei.alcor.web.restclient.RouterManagerRestClient;
 
 import java.util.ArrayList;
@@ -28,6 +30,7 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
     private String vpcId;
     private String subnetId;
     private List<String> subnetIds;
+    private Router router;
     private RouterManagerRestClient routerManagerRestClient;
 
     public FetchRouterSubnetsRequest(PortContext context, String vpcId, String subnetId) {
@@ -39,21 +42,26 @@ public class FetchRouterSubnetsRequest extends AbstractRequest {
     }
 
     public String getVpcId() {
-        return vpcId;
+        return this.vpcId;
     }
 
     public List<String> getSubnetIds() {
-        return subnetIds;
+        return this.subnetIds;
     }
+
+    public Router getRouter() { return this.router; }
 
     @Override
     public void send() throws Exception {
-        ConnectedSubnetsWebResponse connectedSubnetIds = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
-        if (connectedSubnetIds == null || connectedSubnetIds.getSubnetIds() == null) {
+        ConnectedSubnetsWebResponse connectedRouterInfo = routerManagerRestClient.getRouterSubnets(context.getProjectId(), vpcId, subnetId);
+        if (connectedRouterInfo == null || connectedRouterInfo.getSubnetIds() == null) {
             throw new GetConnectedSubnetException();
+        } else if (connectedRouterInfo.getRouter() == null) {
+            throw new GetConnectedRouterException();
         }
 
-        subnetIds.addAll(connectedSubnetIds.getSubnetIds());
+        subnetIds.addAll(connectedRouterInfo.getSubnetIds());
+        router = new Router(connectedRouterInfo.getRouter());
     }
 
     @Override

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/implement/PortServiceImpl.java
@@ -36,6 +36,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
+/*
+NOTE: This is PM v1.0 implementation and has been deprecated
+      Please check com.futurewei.alcor.portmanager.service.PortServiceImpl for PM v2.0 implementation
+ */
+
 //@Service
 //@ComponentScan(value = "com.futurewei.alcor.common.utils")
 //@ComponentScan(value = "com.futurewei.alcor.web.restclient")
@@ -428,7 +433,7 @@ public class PortServiceImpl implements PortService {
 
                 //disassociate with elastic ip if exist
                 ElasticIpManagerProxy elasticIpManagerProxy = new ElasticIpManagerProxy(newPortEntity.getProjectId());
-                for (PortEntity.FixedIp delIp: delFixedIps) {
+                for (PortEntity.FixedIp delIp : delFixedIps) {
                     executor.runAsync(elasticIpManagerProxy::portIpDeleteEventProcess,
                             newPortEntity.getId(), delIp.getIpAddress());
                 }
@@ -775,7 +780,7 @@ public class PortServiceImpl implements PortService {
             return result;
         }
 
-        for (Map.Entry<String, PortEntity> entry: portEntityMap.entrySet()) {
+        for (Map.Entry<String, PortEntity> entry : portEntityMap.entrySet()) {
             PortWebJson portWebJson = new PortWebJson(entry.getValue());
             result.add(portWebJson);
         }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -103,8 +103,8 @@ public class NetworkConfigurationUtil {
                 PortNeighbors portNeighbors = (PortNeighbors) entity;
                 portNeighborsMap.put(portNeighbors.getVpcId(), portNeighbors);
             } else if (entity instanceof RouteEntity) {
-                // NOTE: Router implementation is supported in the new control path in PM
-                //       Please check com.futurewei.alcor.portmanager.processor for lasted implementation
+                // NOTE: Router implementation is supported in the new control path in PM v2.0 implementation
+                //       Please check com.futurewei.alcor.portmanager.service.PortServiceImpl for PM v2.0 implementation
             }
         }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/NetworkConfigurationUtil.java
@@ -102,6 +102,9 @@ public class NetworkConfigurationUtil {
             } else if (entity instanceof PortNeighbors) {
                 PortNeighbors portNeighbors = (PortNeighbors) entity;
                 portNeighborsMap.put(portNeighbors.getVpcId(), portNeighbors);
+            } else if (entity instanceof RouteEntity) {
+                // NOTE: Router implementation is supported in the new control path in PM
+                //       Please check com.futurewei.alcor.portmanager.processor for lasted implementation
             }
         }
 
@@ -127,6 +130,8 @@ public class NetworkConfigurationUtil {
             VpcEntity vpcEntity = vpcEntityMap.get(portEntity.getVpcId());
             if (vpcEntity == null) {
                 throw new VpcEntityNotFound();
+            } else if (vpcEntity.getSegmentationId() == null || vpcEntity.getSegmentationId() <= 0) {
+                throw new VpcTunnelIdInvalid(vpcEntity.getId(), vpcEntity.getSegmentationId());
             }
 
             if (!vpcUniqueIds.contains(portEntity.getVpcId())) {
@@ -143,8 +148,7 @@ public class NetworkConfigurationUtil {
                 }
 
                 if (!subnetUniqueIds.contains(subnetId)) {
-                    // FIXME ：subnetEntity.getVpcId().hashCode() need to be changed to segmentId
-                    Long tunnelId = getTunnelId(subnetEntity);
+                    Long tunnelId = vpcEntity.getSegmentationId().longValue();
                     InternalSubnetEntity internalSubnetEntity = new InternalSubnetEntity(subnetEntity, tunnelId);
                     networkConfigMessage.addSubnetEntity(internalSubnetEntity);
                     subnetUniqueIds.add(subnetId);
@@ -186,22 +190,22 @@ public class NetworkConfigurationUtil {
 
         return networkConfigMessage;
     }
-    
-    public static Long getTunnelId (SubnetEntity subnetEntity) {
-        if (subnetEntity.getTenantId() == null) {
-            return null;
-        }
 
-        return Long.valueOf(getHashCode(subnetEntity.getVpcId()));
-    }
+//    public static Long getTunnelId (SubnetEntity subnetEntity) {
+//        if (subnetEntity.getTenantId() == null) {
+//            return null;
+//        }
+//
+//        return Long.valueOf(getHashCode(subnetEntity.getVpcId()));
+//    }
 
-    public static int getHashCode (String vpcId) {
+    public static int getHashCode(String vpcId) {
         int hashcode = vpcId.hashCode();
         if (hashcode < 0) {
             hashcode = -hashcode;
         }
-        double num = (double)(4096 * 4096) / (double)Integer.MAX_VALUE;
-        hashcode = (int)(hashcode * num);
+        double num = (double) (4096 * 4096) / (double) Integer.MAX_VALUE;
+        hashcode = (int) (hashcode * num);
 
         return hashcode;
     }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
@@ -58,6 +58,8 @@ public class UnitTestConfig {
     public static String subnetId2 = "3d53801c-32ce-4e97-9572-bb966fe82b1";
     public static String rangeId = "3d53801c-32ce-4e97-9572-bb966f6ba29";
     public static String vpcCidr = "11.11.1.0/24";
+    public static String subnet1Cidr = "11.11.1.0/25";
+    public static String subnet2Cidr = "11.11.1.128/25";
     public static String ip1 = "11.11.11.100";
     public static String ip2 = "11.11.11.101";
     public static String ipv6Address = "2001:3CA1:310F:201A:121B:4231:2345:1010";

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
@@ -335,12 +335,14 @@ public class ResourceBuilder {
     }
 
     public static ConnectedSubnetsWebResponse buildRouterSubnets() {
-        List<String> subnetIds = new ArrayList<>();
-        subnetIds.add(UnitTestConfig.subnetId);
-        subnetIds.add(UnitTestConfig.subnetId2);
+        List<SubnetEntity> subnetEntities = new ArrayList<>();
+        SubnetEntity subnetEntity1 = new SubnetEntity(UnitTestConfig.projectId, UnitTestConfig.vpcId, UnitTestConfig.subnetId, "Subnet1", UnitTestConfig.subnet1Cidr);
+        SubnetEntity subnetEntity2 = new SubnetEntity(UnitTestConfig.projectId, UnitTestConfig.vpcId, UnitTestConfig.subnetId2, "Subnet2", UnitTestConfig.subnet2Cidr);
+        subnetEntities.add(subnetEntity1);
+        subnetEntities.add(subnetEntity1);
 
         InternalRouterInfo router = new InternalRouterInfo();
-        ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(router, subnetIds);
+        ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(router, subnetEntities);
         return routerSubnets;
     }
 }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/util/ResourceBuilder.java
@@ -33,10 +33,7 @@ import com.futurewei.alcor.web.entity.mac.MacStateBulkJson;
 import com.futurewei.alcor.web.entity.mac.MacStateJson;
 import com.futurewei.alcor.web.entity.port.PortEntity;
 import com.futurewei.alcor.web.entity.port.PortWebJson;
-import com.futurewei.alcor.web.entity.route.ConnectedSubnetsWebResponse;
-import com.futurewei.alcor.web.entity.route.RouteEntity;
-import com.futurewei.alcor.web.entity.route.RouteWebJson;
-import com.futurewei.alcor.web.entity.route.RoutesWebJson;
+import com.futurewei.alcor.web.entity.route.*;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupRule;
 import com.futurewei.alcor.web.entity.securitygroup.SecurityGroupJson;
@@ -341,7 +338,9 @@ public class ResourceBuilder {
         List<String> subnetIds = new ArrayList<>();
         subnetIds.add(UnitTestConfig.subnetId);
         subnetIds.add(UnitTestConfig.subnetId2);
-        ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(null, subnetIds);
+
+        InternalRouterInfo router = new InternalRouterInfo();
+        ConnectedSubnetsWebResponse routerSubnets = new ConnectedSubnetsWebResponse(router, subnetIds);
         return routerSubnets;
     }
 }

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/config/ConstantsConfig.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/config/ConstantsConfig.java
@@ -17,7 +17,7 @@ package com.futurewei.alcor.route.config;
 
 public class ConstantsConfig {
 
-    public static String formatVersion = "1";
-    public static String revisionNumber = "1";
-
+    public static String FORMAT_VERSION = "1";
+    public static String REVISION_NUMBER = "1";
+    public static String HOST_DVR_MAC = "fe:16:11:00:00:00";
 }

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/NeutronRouterServiceImpl.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/NeutronRouterServiceImpl.java
@@ -445,13 +445,13 @@ public class NeutronRouterServiceImpl implements NeutronRouterService {
         }
 
         String routeTableType = router.getNeutronRouteTable().getRouteTableType();
-        if (routeTableType.equals("neutron")) {
+        if (routeTableType.equals("neutron_router")) {
             boolean processedResult = this.ProcessNeutronRouterAndPopulateSubnetIds(projectId, router, subnetIds);
             if (!processedResult) {
                 logger.log(Level.WARNING, "Process failed for Neutron router | project id:" + projectId + "router id: " + router.getId());
                 return connectedSubnetsWebResponse;
             }
-        } else if (routeTableType.equals("vpc")) {
+        } else if (routeTableType.equals("vpc_router")) {
             // TODO: vpc route operation
             throw new UnsupportedOperationException();
         } else {
@@ -504,7 +504,7 @@ public class NeutronRouterServiceImpl implements NeutronRouterService {
         List<String> ports = router.getPorts();
 
         // check ports
-        if (ports == null || ports.size() <= 1) {
+        if (ports == null || ports.size() == 0) {
             return false;
         }
 

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/NetworkConfiguration.java
@@ -26,137 +26,136 @@ import java.util.List;
 @Data
 public class NetworkConfiguration {
 
-  private ResourceType rsType;
-  private OperationType opType;
+    private ResourceType rsType;
+    private OperationType opType;
 
-  @JsonProperty("ports_internal")
-  private List<InternalPortEntity> portEntities;
+    @JsonProperty("ports_internal")
+    private List<InternalPortEntity> portEntities;
 
-  @JsonProperty("vpcs_internal")
-  private List<VpcEntity> vpcs;
+    @JsonProperty("vpcs_internal")
+    private List<VpcEntity> vpcs;
 
-  @JsonProperty("subnets_internal")
-  private List<InternalSubnetEntity> subnets;
+    @JsonProperty("subnets_internal")
+    private List<InternalSubnetEntity> subnets;
 
-  @JsonProperty("security_groups_internal")
-  private List<SecurityGroup> securityGroups;
+    @JsonProperty("security_groups_internal")
+    private List<SecurityGroup> securityGroups;
 
-  @JsonProperty("neighbor_info")
-  private List<NeighborInfo> neighborInfos;
+    @JsonProperty("neighbor_info")
+    private List<NeighborInfo> neighborInfos;
 
-  @JsonProperty("neighbor_table")
-  private List<NeighborEntry> neighborTable;
+    @JsonProperty("neighbor_table")
+    private List<NeighborEntry> neighborTable;
 
-  @JsonProperty("routers_internal")
-  private List<InternalRouterInfo> internalRouterInfos;
+    @JsonProperty("routers_internal")
+    private List<InternalRouterInfo> internalRouterInfos;
 
-  @Override
-  public String toString() {
-    return "NetworkConfiguration{" + "rsType=" + rsType + ", opType=" + opType + ", portEntities=" + portEntities + ", vpcs=" + vpcs + ", subnets=" + subnets + ", securityGroups=" + securityGroups + ", neighborInfos=" + neighborInfos + ", neighborTable=" + neighborTable + ", routerTable=" + internalRouterInfos + '}';
-  }
-
-  public List<InternalRouterInfo> getInternalRouterInfos() {
-    return internalRouterInfos;
-  }
-
-  public void setInternalRouterInfos(List<InternalRouterInfo> internalRouterInfos) {
-    this.internalRouterInfos = internalRouterInfos;
-  }
-
-  public void addPortEntity(InternalPortEntity portEntity) {
-    if (this.portEntities == null) {
-      this.portEntities = new ArrayList<>();
+    @Override
+    public String toString() {
+        return "NetworkConfiguration{" + "rsType=" + rsType + ", opType=" + opType + ", portEntities=" + portEntities + ", vpcs=" + vpcs + ", subnets=" + subnets + ", securityGroups=" + securityGroups + ", neighborInfos=" + neighborInfos + ", neighborTable=" + neighborTable + ", routerTable=" + internalRouterInfos + '}';
     }
 
-    this.portEntities.add(portEntity);
-  }
-
-  public void addVpcEntity(VpcEntity vpcEntity) {
-    if (this.vpcs == null) {
-      this.vpcs = new ArrayList<>();
+    public List<InternalRouterInfo> getInternalRouterInfos() {
+        return internalRouterInfos;
     }
 
-    this.vpcs.add(vpcEntity);
-  }
-
-  public void addSubnetEntity(InternalSubnetEntity subnetEntity) {
-    if (this.subnets == null) {
-      this.subnets = new ArrayList<>();
+    public void setInternalRouterInfos(List<InternalRouterInfo> internalRouterInfos) {
+        this.internalRouterInfos = internalRouterInfos;
     }
 
-    this.subnets.add(subnetEntity);
-  }
+    public void addPortEntity(InternalPortEntity portEntity) {
+        if (this.portEntities == null) {
+            this.portEntities = new ArrayList<>();
+        }
 
-  public void addSecurityGroupEntity(SecurityGroup securityGroup) {
-    if (this.securityGroups == null) {
-      this.securityGroups = new ArrayList<>();
+        this.portEntities.add(portEntity);
     }
 
-    this.securityGroups.add(securityGroup);
-  }
+    public void addVpcEntity(VpcEntity vpcEntity) {
+        if (this.vpcs == null) {
+            this.vpcs = new ArrayList<>();
+        }
 
-  public ResourceType getRsType() {
-    return rsType;
-  }
+        this.vpcs.add(vpcEntity);
+    }
 
-  public void setRsType(ResourceType rsType) {
-    this.rsType = rsType;
-  }
+    public void addSubnetEntity(InternalSubnetEntity subnetEntity) {
+        if (this.subnets == null) {
+            this.subnets = new ArrayList<>();
+        }
 
-  public OperationType getOpType() {
-    return opType;
-  }
+        this.subnets.add(subnetEntity);
+    }
 
-  public void setOpType(OperationType opType) {
-    this.opType = opType;
-  }
+    public void addSecurityGroupEntity(SecurityGroup securityGroup) {
+        if (this.securityGroups == null) {
+            this.securityGroups = new ArrayList<>();
+        }
 
-  public List<InternalPortEntity> getPortEntities() {
-    return portEntities;
-  }
+        this.securityGroups.add(securityGroup);
+    }
 
-  public void setPortEntities(List<InternalPortEntity> portEntities) {
-    this.portEntities = portEntities;
-  }
+    public ResourceType getRsType() {
+        return rsType;
+    }
 
-  public List<VpcEntity> getVpcs() {
-    return vpcs;
-  }
+    public void setRsType(ResourceType rsType) {
+        this.rsType = rsType;
+    }
 
-  public void setVpcs(List<VpcEntity> vpcs) {
-    this.vpcs = vpcs;
-  }
+    public OperationType getOpType() {
+        return opType;
+    }
 
-  public List<InternalSubnetEntity> getSubnets() {
-    return subnets;
-  }
+    public void setOpType(OperationType opType) {
+        this.opType = opType;
+    }
 
-  public void setSubnets(List<InternalSubnetEntity> subnets) {
-    this.subnets = subnets;
-  }
+    public List<InternalPortEntity> getPortEntities() {
+        return portEntities;
+    }
 
-  public List<SecurityGroup> getSecurityGroups() {
-    return securityGroups;
-  }
+    public void setPortEntities(List<InternalPortEntity> portEntities) {
+        this.portEntities = portEntities;
+    }
 
-  public void setSecurityGroups(List<SecurityGroup> securityGroups) {
-    this.securityGroups = securityGroups;
-  }
+    public List<VpcEntity> getVpcs() {
+        return vpcs;
+    }
 
-  public List<NeighborInfo> getNeighborInfos() {
-    return neighborInfos;
-  }
+    public void setVpcs(List<VpcEntity> vpcs) {
+        this.vpcs = vpcs;
+    }
 
-  public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
-    this.neighborInfos = neighborInfos;
-  }
+    public List<InternalSubnetEntity> getSubnets() {
+        return subnets;
+    }
 
-  public List<NeighborEntry> getNeighborTable() {
-    return neighborTable;
-  }
+    public void setSubnets(List<InternalSubnetEntity> subnets) {
+        this.subnets = subnets;
+    }
 
-  public void setNeighborTable(List<NeighborEntry> neighborTable) {
-    this.neighborTable = neighborTable;
-  }
+    public List<SecurityGroup> getSecurityGroups() {
+        return securityGroups;
+    }
 
+    public void setSecurityGroups(List<SecurityGroup> securityGroups) {
+        this.securityGroups = securityGroups;
+    }
+
+    public List<NeighborInfo> getNeighborInfos() {
+        return neighborInfos;
+    }
+
+    public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
+        this.neighborInfos = neighborInfos;
+    }
+
+    public List<NeighborEntry> getNeighborTable() {
+        return neighborTable;
+    }
+
+    public void setNeighborTable(List<NeighborEntry> neighborTable) {
+        this.neighborTable = neighborTable;
+    }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/ConnectedSubnetsWebResponse.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/ConnectedSubnetsWebResponse.java
@@ -16,6 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.web.entity.route;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.futurewei.alcor.web.entity.subnet.SubnetEntity;
 import lombok.Data;
 
 import java.util.List;
@@ -27,12 +28,12 @@ public class ConnectedSubnetsWebResponse {
     private InternalRouterInfo internalRouterInfo;
 
     @JsonProperty("subnets")
-    private List<String> subnetIds;
+    private List<SubnetEntity> subnetEntities;
 
     public ConnectedSubnetsWebResponse () {}
 
-    public ConnectedSubnetsWebResponse(InternalRouterInfo internalRouterInfo, List<String> subnetIds) {
+    public ConnectedSubnetsWebResponse(InternalRouterInfo internalRouterInfo, List<SubnetEntity> subnetEntities) {
         this.internalRouterInfo = internalRouterInfo;
-        this.subnetIds = subnetIds;
+        this.subnetEntities = subnetEntities;
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/InternalRouterInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/InternalRouterInfo.java
@@ -34,10 +34,22 @@ public class InternalRouterInfo {
         this.configuration = configuration;
     }
 
-    public OperationType getOperationType() { return this.operation_type; }
-    public void setOperationType(OperationType operation_type) { this.operation_type = operation_type; }
+    public InternalRouterInfo(InternalRouterInfo routerInfo) {
+        this(routerInfo.getOperationType(), routerInfo.getRouterConfiguration());
+    }
 
-    public InternalRouterConfiguration getRouterConfiguration() { return this.configuration; }
+    public OperationType getOperationType() {
+        return this.operation_type;
+    }
+
+    public void setOperationType(OperationType operation_type) {
+        this.operation_type = operation_type;
+    }
+
+    public InternalRouterConfiguration getRouterConfiguration() {
+        return this.configuration;
+    }
+
     public void setRouterConfiguration(InternalRouterConfiguration configuration) {
         this.configuration = configuration;
     }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/Router.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/Router.java
@@ -68,7 +68,8 @@ public class Router extends CustomerResource {
     @JsonProperty("updated_at")
     private String updated_at;
 
-    public Router() {}
+    public Router() {
+    }
 
     public Router(String projectId, String Id, String name, String description, RouteTable neutronRouteTable) {
         super(projectId, Id, name, description);
@@ -80,7 +81,10 @@ public class Router extends CustomerResource {
         this.vpcRouteTable = vpcRouteTable;
     }
 
-    public Router(String projectId, String id, String name, String description, RouteTable neutronRouteTable, List<RouteTable> vpcRouteTable, String owner, List<String> ports, String tenantId, boolean adminStateUp, String status, String routerExtraAttributeId, String vpcDefaultRouteTableId) {
+    public Router(String projectId, String id, String name, String description,
+                  RouteTable neutronRouteTable, List<RouteTable> vpcRouteTable, String owner, List<String> ports,
+                  String tenantId, boolean adminStateUp, String status, String routerExtraAttributeId,
+                  String vpcDefaultRouteTableId) {
         super(projectId, id, name, description);
         this.neutronRouteTable = neutronRouteTable;
         this.vpcRouteTable = vpcRouteTable;
@@ -91,5 +95,12 @@ public class Router extends CustomerResource {
         this.status = status;
         this.routerExtraAttributeId = routerExtraAttributeId;
         this.vpcDefaultRouteTableId = vpcDefaultRouteTableId;
+    }
+
+    public Router(Router r) {
+        this(r.getProjectId(), r.getId(), r.getName(), r.getDescription(),
+                r.getNeutronRouteTable(), r.getVpcRouteTable(), r.getOwner(), r.getPorts(),
+                r.getTenantId(), true, r.getStatus(), r.getRouterExtraAttributeId(),
+                r.getVpcDefaultRouteTableId());
     }
 }


### PR DESCRIPTION
This PR proposes the following changes to Port Manager and Route Manager to enable L3 routing:
- PM starts using response from GetConnectedSubnet API from RM, and passing down associated router info (including routing table and routing rule)
- RM GetConnectedSubnet API refactor and issue fixes:
	- Change ConnectedSubnetsWebResponse to include a list of SubnetEntities, instead of SubnetIds so that PM could pass down all connected subnets to DPM
    - Router type fix (should be neutron_router, instead of neutron)
- PM issue fix:
    - Fix remote ip in neighbor table to be the ip address of neighbor port, instead of the neighbor port id.