### PR TITLE
[Port Mgr] Fix L3 Routing Issues for Unassociated Subnets

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -121,7 +121,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
         List<NeighborInfo> l2Neighbors = new ArrayList<>();
         NeighborInfo localNeighborInfo = null;
         for (NeighborInfo neighborInfo : neighborInfos) {
-            if (neighborInfo.getPortId().equals(fixedIp.getIpAddress())) {
+            if (neighborInfo.getPortIp().equals(fixedIp.getIpAddress())) {
                 localNeighborInfo = neighborInfo;
             } else if (neighborInfo.getSubnetId().equals(fixedIp.getSubnetId())) {
                 l2Neighbors.add(neighborInfo);
@@ -146,16 +146,17 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         for (PortEntity.FixedIp fixedIp : internalPortEntity.getFixedIps()) {
+
             List<SubnetEntity> routerSubnetEntities = context.getRouterSubnetEntities(internalPortEntity.getVpcId());
-            if (routerSubnetEntities != null) {
+            if (routerSubnetEntities != null && routerSubnetEntities.size() > 0) {
                 List<String> routerSubnetIds = new ArrayList<>();
                 for (SubnetEntity entity : routerSubnetEntities) routerSubnetIds.add(entity.getId());
                 if (routerSubnetIds.contains(fixedIp.getSubnetId())) {
                     buildL3Neighbors(context, internalPortEntity, fixedIp, routerSubnetIds);
                 }
-
-                buildL2Neighbors(context, internalPortEntity, fixedIp);
             }
+
+            buildL2Neighbors(context, internalPortEntity, fixedIp);
         }
     }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -181,14 +181,16 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
         List<VpcEntity> vpcEntities = context.getNetworkConfig().getVpcEntities();
         for (VpcEntity vpcEntity : vpcEntities) {
+            InternalRouterInfo router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
+            if (router == null || router.getRouterConfiguration() == null) continue;
+
             // Set router information
             // NOTE: This implementation support Neutron scenario only
-            InternalRouterInfo router = context.getRouterByVpcOrSubnetId(vpcEntity.getId());
             context.getNetworkConfig().addRouterEntry(router);
 
             // Add associated subnet entities
             List<SubnetEntity> associatedSubnetEntities = context.getRouterSubnetEntities(vpcEntity.getId());
-            for(SubnetEntity entity: associatedSubnetEntities){
+            for (SubnetEntity entity : associatedSubnetEntities) {
                 InternalSubnetEntity internalEntity = new InternalSubnetEntity(entity, Long.MAX_VALUE);
                 context.getNetworkConfig().addSubnetEntity(internalEntity);
             }


### PR DESCRIPTION
This PR fixes two issues for L3 routing in PM
- Issue 1: Empty router may be passed down when subnet is not associated to a router
- Issue 2: In the scenario of mixing subnets with and without association to the router, PM may recognize the new port as a neighbor and put itself in the neighbor table
