### PR TITLE
[API GW] Customize HTTP header config to Unblock Performance Test

### DIFF
--- a/kubernetes/services/api-gateway.yaml
+++ b/kubernetes/services/api-gateway.yaml
@@ -4,19 +4,22 @@ metadata:
   name: api-configmap
 data:
   application.properties: |
-    ignite.thin.client.enable=true
     spring.application.name=alcor-api-gateway
+    spring.sleuth.sampler.probability=1.0
+    spring.sleuth.web.skipPattern=(^health.*)
+    server.max-header-size=65536
+
+    management.endpoints.web.exposure.include=health,prometheus
     logging.level.org.springframework.web=DEBUG
     logging.level.org.springframework.cloud=DEBUG
     logging.level.com.github.tomakehurst.wiremock=TRACE
-    management.endpoints.web.exposure.include=health,prometheus
-    spring.sleuth.sampler.probability=1.0
-    spring.sleuth.web.skipPattern=(^health.*)
+    logging.level.root=DEBUG
+
+    ignite.thin.client.enable=true
     ignite.host=ignite-alcor-service.ignite-alcor.svc.cluster.local
     ignite.port=10800
     #ignite.key-store-path=keystore.jks
     #ignite.key-store-password=123456
-    
     #ignite.trust-store-path=truststore.jks
     #ignite.trust-store-password=123456
 
@@ -27,6 +30,7 @@ data:
     microservices.route.service.url=http://routemanager-service.default.svc.cluster.local:9003/
     microservices.quota.service.url = http://quotamanager-service.default.svc.cluster.local:9012/
     microservices.elasticip.service.url=http://eipmanager-service.default.svc.cluster.local:9011/
+    neutron.url_prefix=/v2.0
 
     keystone.enable=true
     keystone.project_domain_name=Default
@@ -38,9 +42,6 @@ data:
     keystone.password=alcor_pass
     keystone.auth_type=password
     keystone.auth_url=http://192.168.10.10:5000/v3
-    neutron.url_prefix=/v2.0
-    logging.level.root=DEBUG
-
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/services/api-gateway.yaml
+++ b/kubernetes/services/api-gateway.yaml
@@ -7,7 +7,8 @@ data:
     spring.application.name=alcor-api-gateway
     spring.sleuth.sampler.probability=1.0
     spring.sleuth.web.skipPattern=(^health.*)
-    server.max-header-size=65536
+    server.max-header-size=16384
+    server.max-initial-line-length=65536
 
     management.endpoints.web.exposure.include=health,prometheus
     logging.level.org.springframework.web=DEBUG

--- a/kubernetes/services/api-gateway.yaml
+++ b/kubernetes/services/api-gateway.yaml
@@ -7,7 +7,7 @@ data:
     spring.application.name=alcor-api-gateway
     spring.sleuth.sampler.probability=1.0
     spring.sleuth.web.skipPattern=(^health.*)
-    server.max-header-size=16384
+    server.max-http-header-size=16384
     server.max-initial-line-length=65536
 
     management.endpoints.web.exposure.include=health,prometheus

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory> {
 
-    // The default value is 8192 (8K) but may result in 413 when header is too lager.
+    // The default value is 8192 (8K) but may result in 413 when header is too large.
     // Enlarge the header size to 65536 (64K) which is enough for most cases.
     @Value("${server.max-header-size:65536}")
     private int maxHeaderSize;

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
@@ -8,13 +8,22 @@ import org.springframework.stereotype.Component;
 @Component
 public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory> {
 
-    // The default value is 8192 (8K) but may result in 413 when header is too large.
-    // Enlarge the header size to 65536 (64K) which is enough for most cases.
-    @Value("${server.max-header-size:65536}")
+    // In HttpRequestDecoderSpec, the default value of max header size is 8,192 bytes (8KB)
+    // but may result in 413 when header is too large.
+    // Make the header size configurable
+    @Value("${server.max-header-size:16384}")
     private int maxHeaderSize;
+
+    // In HttpRequestDecoderSpec, the default value of initial line length is 4096 bytes (4KB)
+    // but may result in 413 when header is too large.
+    // Make the line length configurable
+    @Value("${server.initial-line-length: 65536}")
+    private int maxInitialLineLength;
 
     public void customize(NettyReactiveWebServerFactory factory) {
         factory.addServerCustomizers(server ->
                 server.httpRequestDecoder(decoder -> decoder.maxHeaderSize(maxHeaderSize)));
+        factory.addServerCustomizers(server ->
+                server.httpRequestDecoder(decoder -> decoder.maxInitialLineLength(maxInitialLineLength)));
     }
 }

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
@@ -11,8 +11,8 @@ public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyR
     // In HttpRequestDecoderSpec, the default value of max header size is 8,192 bytes (8KB)
     // but may result in 413 when header is too large.
     // Make the header size configurable
-    @Value("${server.max-header-size:16384}")
-    private int maxHeaderSize;
+    @Value("${server.max-http-header-size:16384}")
+    private int maxHttpHeaderSize;
 
     // In HttpRequestDecoderSpec, the default value of initial line length is 4096 bytes (4KB)
     // but may result in 413 when header is too large.
@@ -22,7 +22,7 @@ public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyR
 
     public void customize(NettyReactiveWebServerFactory factory) {
         factory.addServerCustomizers(server ->
-                server.httpRequestDecoder(decoder -> decoder.maxHeaderSize(maxHeaderSize)));
+                server.httpRequestDecoder(decoder -> decoder.maxHeaderSize(maxHttpHeaderSize)));
         factory.addServerCustomizers(server ->
                 server.httpRequestDecoder(decoder -> decoder.maxInitialLineLength(maxInitialLineLength)));
     }

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
@@ -1,0 +1,20 @@
+package com.futurewei.alcor.apigateway.admin;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory> {
+
+    // The default value is 8192 (8K) but may result in 413 when header is too lager.
+    // Enlarge the header size to 16384 (16K) which is enough for most cases.
+    @Value("${server.max-header-size:65536}")
+    private int maxHeaderSize;
+
+    public void customize(NettyReactiveWebServerFactory factory) {
+        factory.addServerCustomizers(server ->
+                server.httpRequestDecoder(decoder -> decoder.maxHeaderSize(maxHeaderSize)));
+    }
+}

--- a/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
+++ b/services/api_gateway/src/main/java/com/futurewei/alcor/apigateway/admin/WebServerConfiguration.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class WebServerConfiguration implements WebServerFactoryCustomizer<NettyReactiveWebServerFactory> {
 
     // The default value is 8192 (8K) but may result in 413 when header is too lager.
-    // Enlarge the header size to 16384 (16K) which is enough for most cases.
+    // Enlarge the header size to 65536 (64K) which is enough for most cases.
     @Value("${server.max-header-size:65536}")
     private int maxHeaderSize;
 

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -42,10 +42,12 @@ ignite.thin.client.enable=true
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.cloud=DEBUG
 logging.level.com.github.tomakehurst.wiremock=TRACE
+logging.level.root=INFO
 
 #####Misc#####
 management.endpoints.web.exposure.include=health,prometheus
 
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^health.*)
-server.max-header-size=65536
+server.max-header-size=16384
+server.max-initial-line-length=65536

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -48,3 +48,4 @@ management.endpoints.web.exposure.include=health,prometheus
 
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^health.*)
+server.max-header-size=65536

--- a/services/api_gateway/src/main/resources/application.properties
+++ b/services/api_gateway/src/main/resources/application.properties
@@ -49,5 +49,5 @@ management.endpoints.web.exposure.include=health,prometheus
 
 spring.sleuth.sampler.probability=1.0
 spring.sleuth.web.skipPattern=(^health.*)
-server.max-header-size=16384
+server.max-http-header-size=16384
 server.max-initial-line-length=65536


### PR DESCRIPTION
__Context__

In current API GW, the default value of HTTP header size and initial line length is 8192 bytes and 4096 bytes, respectively. But they may result in 413 in one of performance testing scenario when Nova server may query hundreds of device ids. 

__Proposed Solution__
This PR add two new settings for HTTP header size and initial line length, and enlarge the default value of header size and initial line length to 16KB and 64KB, respectively, which is enough for most cases.