### PR TITLE
[Contract] Support Port Delete and Preliminary Support of Zeta GW

### DIFF
--- a/schema/proto3/auxiliarygateway.proto
+++ b/schema/proto3/auxiliarygateway.proto
@@ -21,24 +21,31 @@ package alcor.schema;
 option java_package = "com.futurewei.alcor.schema";
 option java_outer_classname = "AuxiliaryGateway";
 
+enum AuxGatewayType {
+    NONE = 0;
+    ZETA = 1;
+}
 
 message AuxGateway {
-    // default value of empty string means no auxiliary gateway supported
-    string id = 1;
+    AuxGatewayType AuxGateway_type = 1;
+
+    // if AuxGateway_type == NONE, then id = empty string 
+    string id = 2;
 
     message destination {
         string ip_address = 1;
         string mac_address = 2;
     }
 
-    // default destinations_size of 0 means no auxiliary gateway supported
-    repeated destination destinations = 2;
+    // if AuxGateway_type == NONE, then destinations_size = 0 
+    repeated destination destinations = 3;
 
     message zeta {
-        uint32 port_inband_operation = 1; // port for in-band operation, TBD: why called in-band?
+        // port for in-band (same NIC channel) operation
+        uint32 port_inband_operation = 1;
     }
 
     oneof extra_info {
-        zeta zeta_info = 3;
+        zeta zeta_info = 4;
     }
 }

--- a/schema/proto3/auxiliarygateway.proto
+++ b/schema/proto3/auxiliarygateway.proto
@@ -19,33 +19,27 @@ syntax = "proto3";
 package alcor.schema;
 
 option java_package = "com.futurewei.alcor.schema";
-option java_outer_classname = "Vpc";
+option java_outer_classname = "AuxiliaryGateway";
 
-import "common.proto";
-import "auxiliarygateway.proto";
 
-message VpcConfiguration {  
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+message AuxGateway {
+    // default value of empty string means no auxiliary gateway supported
+    string id = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType update_type = 5; // DELTA (default) or FULL
-    string project_id = 6;
-    string name = 7;
-    string cidr = 8;
-    uint32 tunnel_id = 9;
-
-    message SubnetId {
-        string id = 1;
+    message destination {
+        string ip_address = 1;
+        string mac_address = 2;
     }
 
-    repeated SubnetId subnet_ids = 10;
+    // default destinations_size of 0 means no auxiliary gateway supported
+    repeated destination destinations = 2;
 
-    AuxGateway auxiliary_gateway = 11;
-}
+    message zeta {
+    // default value of 0 means no auxiliary gateway supported
+    uint32 port_inband_operation = 1; // port for in-band operation, TBD: why called in-band?
+    }
 
-message VpcState {
-    OperationType operation_type = 1;
-    VpcConfiguration configuration = 2;
+    oneof extra_info {
+        zeta zeta_info = 3;
+    }
 }

--- a/schema/proto3/auxiliarygateway.proto
+++ b/schema/proto3/auxiliarygateway.proto
@@ -35,8 +35,7 @@ message AuxGateway {
     repeated destination destinations = 2;
 
     message zeta {
-    // default value of 0 means no auxiliary gateway supported
-    uint32 port_inband_operation = 1; // port for in-band operation, TBD: why called in-band?
+        uint32 port_inband_operation = 1; // port for in-band operation, TBD: why called in-band?
     }
 
     oneof extra_info {

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -34,8 +34,10 @@ message PortConfiguration {
     string project_id = 7;
     string vpc_id = 8;
     string name = 9;
-    string mac_address = 10;
-    bool admin_state_up = 11;
+    string device_id = 10;
+    string device_owner = 11;
+    string mac_address = 12;
+    bool admin_state_up = 13;
 
     message HostInfo {
         string ip_address = 1;
@@ -56,10 +58,10 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 12;
-    repeated FixedIp fixed_ips = 13;
-    repeated AllowAddressPair allow_address_pairs = 14;
-    repeated SecurityGroupId security_group_ids = 15;
+    HostInfo host_info = 14;
+    repeated FixedIp fixed_ips = 15;
+    repeated AllowAddressPair allow_address_pairs = 16;
+    repeated SecurityGroupId security_group_ids = 17;
 }
 
 message PortState {

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -29,7 +29,7 @@ message SecurityGroupConfiguration {
 
     string request_id = 3;
     string id = 4;
-    MessageType message_type = 5; // DELTA (default) or FULL
+    MessageType update_type = 5; // DELTA (default) or FULL
     string project_id = 6;
     string vpc_id = 7;
     string name = 8;

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -30,13 +30,14 @@ message SubnetConfiguration {
     string request_id = 3;
     string id = 4;
     MessageType message_type = 5; // DELTA (default) or FULL
-    NetworkType network_type = 6;
+    NetworkType network_type = 6; // DEPRECATING: use the one in VPCConfiguration
     string project_id = 7;
     string vpc_id = 8;
     string name = 9;
     string cidr = 10;
 
     // TODO: change to uint32 but that would require change in DPM
+    // DEPRECATING: use the tunnel_id in VPCConfiguration
     uint64 tunnel_id = 11;
 
     message Gateway {
@@ -49,23 +50,6 @@ message SubnetConfiguration {
     string availability_zone = 14;
     string primary_dns = 15;
     string secondary_dns = 16;
-
-    // default value of empty string means not zeta supported
-    // for zeta supported subnet, expect it to be non empty string
-    string zgc_id = 17; // Zeta Gateway Cluster ID
-
-    // default value of 0 means not zeta supported
-    // for zeta supported subnet, expect zeta_port_ibo > 0
-    uint32 zeta_port_ibo = 18; // port for Zeta In-Band Operation
-
-    message ZetaGateway {
-        string ip_address = 1;
-        string mac_address = 2;
-    }
-
-    // default zeta_gateways_size of 0 means not zeta supported
-    // for zeta supported subnet, expect zeta_gateways_size > 0
-    repeated ZetaGateway zeta_gateways = 19;
 }
 
 message SubnetState {

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -40,8 +40,8 @@ message SubnetConfiguration {
     uint64 tunnel_id = 11;
 
     message Gateway {
-        string ip_address = 3;
-        string mac_address = 4;
+        string ip_address = 1;
+        string mac_address = 2;
     }
 
     Gateway gateway = 12;
@@ -49,6 +49,19 @@ message SubnetConfiguration {
     string availability_zone = 14;
     string primary_dns = 15;
     string secondary_dns = 16;
+
+    // default value of 0 means it is not zeta supported
+    // non zero means zeta supported for this subnet,
+    uint32 zeta_port_ibo = 17;
+
+    message ZetaGateway {
+        string ip_address = 1;
+        string mac_address = 2;
+    }
+
+    // if zeta supported, expect zeta_gateways_size > 0
+    // else zeta_gateways_size == 0
+    repeated ZetaGateway zeta_gateways = 18;
 }
 
 message SubnetState {

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -50,18 +50,22 @@ message SubnetConfiguration {
     string primary_dns = 15;
     string secondary_dns = 16;
 
-    // default value of 0 means it is not zeta supported
-    // for zeta supported subnet, set zeta_port_ibo > 0
-    uint32 zeta_port_ibo = 17;
+    // default value of empty string means not zeta supported
+    // for zeta supported subnet, expect it to be non empty string
+    string zgc_id = 17; // Zeta Gateway Cluster ID
+
+    // default value of 0 means not zeta supported
+    // for zeta supported subnet, expect zeta_port_ibo > 0
+    uint32 zeta_port_ibo = 18; // port for Zeta In-Band Operation
 
     message ZetaGateway {
         string ip_address = 1;
         string mac_address = 2;
     }
 
-    // default zeta_gateways_size of 0 means it is not zeta supported
+    // default zeta_gateways_size of 0 means not zeta supported
     // for zeta supported subnet, expect zeta_gateways_size > 0
-    repeated ZetaGateway zeta_gateways = 18;
+    repeated ZetaGateway zeta_gateways = 19;
 }
 
 message SubnetState {

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -51,7 +51,7 @@ message SubnetConfiguration {
     string secondary_dns = 16;
 
     // default value of 0 means it is not zeta supported
-    // non zero means zeta supported for this subnet,
+    // for zeta supported subnet, set zeta_port_ibo > 0
     uint32 zeta_port_ibo = 17;
 
     message ZetaGateway {
@@ -59,8 +59,8 @@ message SubnetConfiguration {
         string mac_address = 2;
     }
 
-    // if zeta supported, expect zeta_gateways_size > 0
-    // else zeta_gateways_size == 0
+    // default zeta_gateways_size of 0 means it is not zeta supported
+    // for zeta supported subnet, expect zeta_gateways_size > 0
     repeated ZetaGateway zeta_gateways = 18;
 }
 

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -91,7 +91,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
             vpcConfigBuilder.setProjectId(vpcEntity.getProjectId());
             vpcConfigBuilder.setName(vpcEntity.getName());
             vpcConfigBuilder.setCidr(vpcEntity.getCidr());
-            vpcConfigBuilder.setTunnelId(Long.parseLong(vpcEntity.getSegmentationId() + ""));
+            vpcConfigBuilder.setTunnelId(Integer.parseInt(vpcEntity.getSegmentationId() + ""));
 
             networkConfig.getSubnets().stream()
                     .filter(s -> s.getVpcId().equals(vpcEntity.getId()))

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImplNew.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImplNew.java
@@ -88,7 +88,7 @@ public class DataPlaneServiceImplNew implements DataPlaneServiceNew {
             vpcConfigBuilder.setProjectId(vpcEntity.getProjectId());
             vpcConfigBuilder.setName(vpcEntity.getName());
             vpcConfigBuilder.setCidr(vpcEntity.getCidr());
-            vpcConfigBuilder.setTunnelId(Long.parseLong(vpcEntity.getSegmentationId() + ""));
+            vpcConfigBuilder.setTunnelId(Integer.parseInt(vpcEntity.getSegmentationId() + ""));
 
             networkConfig.getSubnets().stream()
                     .filter(s -> s.getVpcId().equals(vpcEntity.getId()))


### PR DESCRIPTION
The contract change provides support for port delete and adds preliminary Zeta support. The change includes:

1. added auxiliarygateway.proto to support generic gateways
1. made AuxGateway generic for all gateways and use "oneof" to store extra info on specific implementation (e.g. zeta).
1. added device_id and device_owner in proto.proto to support port delete scenario
1. added auxiliary_gateway at vpc.proto
1. fix compiler error in DPM because vpc tunnel ID is changed to uint