### PR TITLE
[Contract] Add default_routing_table to Router Configuration

### DIFF
--- a/schema/proto3/auxiliarygateway.proto
+++ b/schema/proto3/auxiliarygateway.proto
@@ -27,9 +27,9 @@ enum AuxGatewayType {
 }
 
 message AuxGateway {
-    AuxGatewayType AuxGateway_type = 1;
+    AuxGatewayType aux_gateway_type = 1;
 
-    // if AuxGateway_type == NONE, then id = empty string 
+    // if aux_gateway_type == NONE, then id = empty string 
     string id = 2;
 
     message destination {
@@ -37,7 +37,7 @@ message AuxGateway {
         string mac_address = 2;
     }
 
-    // if AuxGateway_type == NONE, then destinations_size = 0 
+    // if aux_gateway_type == NONE, then destinations_size = 0 
     repeated destination destinations = 3;
 
     message zeta {

--- a/schema/proto3/router.proto
+++ b/schema/proto3/router.proto
@@ -52,12 +52,17 @@ message RouterConfiguration {
         RoutingRuleExtraInfo routing_rule_extra_info = 7;
     }
 
+    message DefaultRoutingTable {
+        repeated RoutingRule routing_rules = 1;
+    }
+    
     message SubnetRoutingTable {
         string subnet_id = 1;
         repeated RoutingRule routing_rules = 2;
     }
-
-    repeated SubnetRoutingTable subnet_routing_tables = 7;
+   
+    DefaultRoutingTable default_routing_table = 7;
+    repeated SubnetRoutingTable subnet_routing_tables = 8;
 }
 
 message RouterState {


### PR DESCRIPTION
This minor contract change includes:

1. added default_routing_table to router configuration - to support the current subnet manager and router design.
2. change from AuxGateway_type to aux_gateway_type in AuxGateway message - proto3 changes upper case field name to lower case during .proto file compile, so the change is to make this field explicitly to lower case and makes it pretty.