### PR TITLE
[Contract] Update Contract for DNS/Router, Resolve Discrepancy

### DIFF
--- a/schema/proto3/common.proto
+++ b/schema/proto3/common.proto
@@ -70,7 +70,7 @@ enum NetworkType {
     VXLAN_GPE = 4;
 }
 
-enum MessageType { 
+enum UpdateType { 
     DELTA = 0; // the default type
     FULL = 1;
 }

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -24,28 +24,15 @@ option java_outer_classname = "DHCP";
 import "common.proto";
 
 message DHCPConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    MessageType message_type = 4; // DELTA (default) or FULL
-    string subnet_id = 5;
-    string mac_address = 6;
-    string ipv4_address = 7;
-    string ipv6_address = 8;
-    string port_host_name = 9; // for local DNS response
-
-    message ExtraDhcpOption {
-        string name = 1;
-        string value = 2;
-    }
-
-    message DnsEntry {
-        string entry = 1;
-    }
-
-    repeated ExtraDhcpOption extra_dhcp_options = 10;
-    repeated DnsEntry dns_entry_list = 11;
+    string request_id = 2;
+    MessageType message_type = 3; // DELTA (default) or FULL
+    string subnet_id = 4;
+    string mac_address = 5;
+    string ipv4_address = 6;
+    string ipv6_address = 7;
+    string port_host_name = 8; // for local DNS response
 }
 
 message DHCPState {

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -27,7 +27,7 @@ message DHCPConfiguration {
     uint32 revision_number = 1;
 
     string request_id = 2;
-    MessageType message_type = 3; // DELTA (default) or FULL
+    UpdateType update_type = 3; // DELTA (default) or FULL
     string subnet_id = 4;
     string mac_address = 5;
     string ipv4_address = 6;

--- a/schema/proto3/neighbor.proto
+++ b/schema/proto3/neighbor.proto
@@ -29,17 +29,15 @@ enum NeighborType {
 }
 
 message NeighborConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType message_type = 5; // DELTA (default) or FULL
-    string project_id = 6;
-    string vpc_id = 7;
-    string name = 8;
-    string mac_address = 9;
-    string host_ip_address = 10;
+    string request_id = 2;
+    string id = 3;
+    MessageType message_type = 4; // DELTA (default) or FULL
+    string vpc_id = 5;
+    string name = 6;
+    string mac_address = 7;
+    string host_ip_address = 8;
 
     message FixedIp {
         NeighborType neighbor_type = 1;
@@ -52,8 +50,8 @@ message NeighborConfiguration {
         string mac_address = 2;
     }
 
-    repeated FixedIp fixed_ips = 11;
-    repeated AllowAddressPair allow_address_pairs = 12;
+    repeated FixedIp fixed_ips = 9;
+    repeated AllowAddressPair allow_address_pairs = 10;
 }
 
 message NeighborState {

--- a/schema/proto3/neighbor.proto
+++ b/schema/proto3/neighbor.proto
@@ -33,7 +33,7 @@ message NeighborConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType message_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     string vpc_id = 5;
     string name = 6;
     string mac_address = 7;

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -24,20 +24,17 @@ option java_outer_classname = "Port";
 import "common.proto";
 
 message PortConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType message_type = 5; // DELTA (default) or FULL
-    NetworkType network_type = 6; // to be removed, will use the one in subnet
-    string project_id = 7;
-    string vpc_id = 8;
-    string name = 9;
-    string device_id = 10;
-    string device_owner = 11;
-    string mac_address = 12;
-    bool admin_state_up = 13;
+    string request_id = 2;
+    string id = 3;
+    MessageType message_type = 4; // DELTA (default) or FULL
+    string vpc_id = 5;
+    string name = 6;
+    string device_id = 7;
+    string device_owner = 8;
+    string mac_address = 9;
+    bool admin_state_up = 10;
 
     message HostInfo {
         string ip_address = 1;
@@ -58,10 +55,10 @@ message PortConfiguration {
         string id = 1;
     }
 
-    HostInfo host_info = 14;
-    repeated FixedIp fixed_ips = 15;
-    repeated AllowAddressPair allow_address_pairs = 16;
-    repeated SecurityGroupId security_group_ids = 17;
+    HostInfo host_info = 11;
+    repeated FixedIp fixed_ips = 12;
+    repeated AllowAddressPair allow_address_pairs = 13;
+    repeated SecurityGroupId security_group_ids = 14;
 }
 
 message PortState {

--- a/schema/proto3/port.proto
+++ b/schema/proto3/port.proto
@@ -28,7 +28,7 @@ message PortConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType message_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     string vpc_id = 5;
     string name = 6;
     string device_id = 7;

--- a/schema/proto3/router.proto
+++ b/schema/proto3/router.proto
@@ -29,13 +29,12 @@ enum DestinationType {
 }
 
 message RouterConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType message_type = 5; // DELTA (default) or FULL
-    string host_dvr_mac_address = 6;
+    string request_id = 2;
+    string id = 3;
+    MessageType message_type = 4; // DELTA (default) or FULL
+    string host_dvr_mac_address = 5;
 
     message RoutingRuleExtraInfo{
         DestinationType destination_type = 1;
@@ -51,18 +50,13 @@ message RouterConfiguration {
         uint32 priority = 6;
         RoutingRuleExtraInfo routing_rule_extra_info = 7;
     }
-
-    message DefaultRoutingTable {
-        repeated RoutingRule routing_rules = 1;
-    }
     
     message SubnetRoutingTable {
         string subnet_id = 1;
         repeated RoutingRule routing_rules = 2;
     }
-   
-    DefaultRoutingTable default_routing_table = 7;
-    repeated SubnetRoutingTable subnet_routing_tables = 8;
+
+    repeated SubnetRoutingTable subnet_routing_tables = 6;
 }
 
 message RouterState {

--- a/schema/proto3/router.proto
+++ b/schema/proto3/router.proto
@@ -33,7 +33,7 @@ message RouterConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType message_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     string host_dvr_mac_address = 5;
 
     message RoutingRuleExtraInfo{

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -24,15 +24,13 @@ option java_outer_classname = "SecurityGroup";
 import "common.proto";
 
 message SecurityGroupConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType update_type = 5; // DELTA (default) or FULL
-    string project_id = 6;
-    string vpc_id = 7;
-    string name = 8;
+    string request_id = 2;
+    string id = 3;
+    MessageType update_type = 4; // DELTA (default) or FULL
+    string vpc_id = 5;
+    string name = 6;
 
     enum Direction {
         EGRESS = 0;
@@ -52,7 +50,7 @@ message SecurityGroupConfiguration {
         string remote_group_id = 10;
     }
 
-    repeated SecurityGroupRule security_group_rules = 9;
+    repeated SecurityGroupRule security_group_rules = 7;
 }
 
 message SecurityGroupState {

--- a/schema/proto3/securitygroup.proto
+++ b/schema/proto3/securitygroup.proto
@@ -28,7 +28,7 @@ message SecurityGroupConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType update_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     string vpc_id = 5;
     string name = 6;
 

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -28,7 +28,7 @@ message SubnetConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType message_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     NetworkType network_type = 5; // DEPRECATING: use the one in VPCConfiguration
     string vpc_id = 6;
     string name = 7;

--- a/schema/proto3/subnet.proto
+++ b/schema/proto3/subnet.proto
@@ -24,32 +24,41 @@ option java_outer_classname = "Subnet";
 import "common.proto";
 
 message SubnetConfiguration {
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType message_type = 5; // DELTA (default) or FULL
-    NetworkType network_type = 6; // DEPRECATING: use the one in VPCConfiguration
-    string project_id = 7;
-    string vpc_id = 8;
-    string name = 9;
-    string cidr = 10;
+    string request_id = 2;
+    string id = 3;
+    MessageType message_type = 4; // DELTA (default) or FULL
+    NetworkType network_type = 5; // DEPRECATING: use the one in VPCConfiguration
+    string vpc_id = 6;
+    string name = 7;
+    string cidr = 8;
 
     // TODO: change to uint32 but that would require change in DPM
     // DEPRECATING: use the tunnel_id in VPCConfiguration
-    uint64 tunnel_id = 11;
+    uint64 tunnel_id = 9;
 
     message Gateway {
         string ip_address = 1;
         string mac_address = 2;
     }
 
-    Gateway gateway = 12;
-    bool dhcp_enable = 13;
+    Gateway gateway = 10;
+    bool dhcp_enable = 11;
+
+    message ExtraDhcpOption {
+        string name = 1;
+        string value = 2;
+    }
+
+    message DnsEntry {
+        string entry = 1;
+    }
+
+    repeated ExtraDhcpOption extra_dhcp_options = 12;
+    repeated DnsEntry dns_entry_list = 13;
+
     string availability_zone = 14;
-    string primary_dns = 15;
-    string secondary_dns = 16;
 }
 
 message SubnetState {

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -25,24 +25,23 @@ import "common.proto";
 import "auxiliarygateway.proto";
 
 message VpcConfiguration {  
-    uint32 format_version = 1;
-    uint32 revision_number = 2;
+    uint32 revision_number = 1;
 
-    string request_id = 3;
-    string id = 4;
-    MessageType update_type = 5; // DELTA (default) or FULL
-    string project_id = 6;
-    string name = 7;
-    string cidr = 8;
-    uint32 tunnel_id = 9;
+    string request_id = 2;
+    string id = 3;
+    MessageType update_type = 4; // DELTA (default) or FULL
+    string project_id = 5;
+    string name = 6;
+    string cidr = 7;
+    uint32 tunnel_id = 8;
 
     message SubnetId {
         string id = 1;
     }
 
-    repeated SubnetId subnet_ids = 10;
+    repeated SubnetId subnet_ids = 9;
 
-    AuxGateway auxiliary_gateway = 11;
+    AuxGateway auxiliary_gateway = 10;
 }
 
 message VpcState {

--- a/schema/proto3/vpc.proto
+++ b/schema/proto3/vpc.proto
@@ -29,7 +29,7 @@ message VpcConfiguration {
 
     string request_id = 2;
     string id = 3;
-    MessageType update_type = 4; // DELTA (default) or FULL
+    UpdateType update_type = 4; // DELTA (default) or FULL
     string project_id = 5;
     string name = 6;
     string cidr = 7;

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/config/Config.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/config/Config.java
@@ -42,6 +42,9 @@ public class Config {
   @Value("${grpc.threads-pool-name: grpc-thread-pool}")
   public String grpThreadsName;
 
+  @Value("${protobuf.goal-state-message.version}")
+  public int goalStateMessageVersion;
+
   public static FileWriter TIME_STAMP_FILE;
   public static BufferedWriter TIME_STAMP_WRITER;
   public static String LOG_FILE_PATH = "timestamp.log";

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -192,7 +192,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
             }
 
             // TODO: need to set DNS based on latest contract
-            
+
             if (subnetEntity.getAvailabilityZone() != null) {
                 subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
             }
@@ -210,7 +210,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
             PortConfiguration.Builder portConfigBuilder = PortConfiguration.newBuilder();
             portConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             portConfigBuilder.setId(portEntity.getId());
-            portConfigBuilder.setMessageType(Common.MessageType.FULL);
+            portConfigBuilder.setUpdateType(Common.UpdateType.FULL);
             portConfigBuilder.setVpcId(portEntity.getVpcId());
 
             if (portEntity.getName() != null) {

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -101,7 +101,6 @@ public class DataPlaneServiceImpl implements DataPlaneService {
         for (PortState portState: portStates) {
             VpcEntity vpcEntity = getVpcEntity(networkConfig, portState.getConfiguration().getVpcId());
             VpcConfiguration.Builder vpcConfigBuilder = VpcConfiguration.newBuilder();
-            vpcConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
             vpcConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             vpcConfigBuilder.setId(vpcEntity.getId());
             vpcConfigBuilder.setProjectId(vpcEntity.getProjectId());
@@ -168,11 +167,9 @@ public class DataPlaneServiceImpl implements DataPlaneService {
 
         for (InternalSubnetEntity subnetEntity: subnetEntities) {
             SubnetConfiguration.Builder subnetConfigBuilder = SubnetConfiguration.newBuilder();
-            subnetConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
             subnetConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             subnetConfigBuilder.setId(subnetEntity.getId());
             subnetConfigBuilder.setNetworkType(NetworkType.VXLAN);
-            subnetConfigBuilder.setProjectId(subnetEntity.getProjectId());
             subnetConfigBuilder.setVpcId(subnetEntity.getVpcId());
             subnetConfigBuilder.setName(subnetEntity.getName());
             subnetConfigBuilder.setCidr(subnetEntity.getCidr());
@@ -191,14 +188,6 @@ public class DataPlaneServiceImpl implements DataPlaneService {
                 subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
             }
 
-            if (subnetEntity.getPrimaryDns() != null) {
-                subnetConfigBuilder.setPrimaryDns(subnetEntity.getPrimaryDns());
-            }
-
-            if (subnetEntity.getSecondaryDns() != null) {
-                subnetConfigBuilder.setSecondaryDns(subnetEntity.getSecondaryDns());
-            }
-
             SubnetState.Builder subnetStateBuilder = SubnetState.newBuilder();
             subnetStateBuilder.setOperationType(networkConfig.getOpType());
             subnetStateBuilder.setConfiguration(subnetConfigBuilder.build());
@@ -210,12 +199,9 @@ public class DataPlaneServiceImpl implements DataPlaneService {
                                 UnicastGoalState unicastGoalState) {
         for (InternalPortEntity portEntity: portEntities) {
             PortConfiguration.Builder portConfigBuilder = PortConfiguration.newBuilder();
-            portConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
             portConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             portConfigBuilder.setId(portEntity.getId());
             portConfigBuilder.setMessageType(Common.MessageType.FULL);
-            portConfigBuilder.setNetworkType(NetworkType.VXLAN);
-            portConfigBuilder.setProjectId(portEntity.getProjectId());
             portConfigBuilder.setVpcId(portEntity.getVpcId());
 
             if (portEntity.getName() != null) {
@@ -266,10 +252,8 @@ public class DataPlaneServiceImpl implements DataPlaneService {
 
     private NeighborState buildNeighborState(NeighborEntry neighborEntry, NeighborInfo neighborInfo, OperationType operationType) {
         NeighborConfiguration.Builder neighborConfigBuilder = NeighborConfiguration.newBuilder();
-        neighborConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
         neighborConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
-        //neighborConfigBuilder.setId();
-        //neighborConfigBuilder.setProjectId();
+        //neighborConfigBuilder.setId(); // !!!We are going to need this per latest ACA change!!!
         neighborConfigBuilder.setVpcId(neighborInfo.getVpcId());
         //neighborConfigBuilder.setName();
         neighborConfigBuilder.setMacAddress(neighborInfo.getPortMac());
@@ -400,10 +384,8 @@ public class DataPlaneServiceImpl implements DataPlaneService {
         for (String securityGroupId: securityGroupIds) {
             SecurityGroup securityGroup = getSecurityGroup(networkConfig, securityGroupId);
             SecurityGroupConfiguration.Builder securityGroupConfigBuilder = SecurityGroupConfiguration.newBuilder();
-            securityGroupConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
             securityGroupConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             securityGroupConfigBuilder.setId(securityGroup.getId());
-            securityGroupConfigBuilder.setProjectId(securityGroup.getProjectId());
             //securityGroupConfigBuilder.setVpcId();
             securityGroupConfigBuilder.setName(securityGroup.getName());
 
@@ -444,7 +426,6 @@ public class DataPlaneServiceImpl implements DataPlaneService {
             List<FixedIp> fixedIps = portState.getConfiguration().getFixedIpsList();
             for (FixedIp fixedIp: fixedIps) {
                 DHCPConfiguration.Builder dhcpConfigBuilder = DHCPConfiguration.newBuilder();
-                dhcpConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
                 dhcpConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
                 dhcpConfigBuilder.setMacAddress(macAddress);
                 dhcpConfigBuilder.setIpv4Address(fixedIp.getIpAddress());
@@ -596,7 +577,6 @@ public class DataPlaneServiceImpl implements DataPlaneService {
         int routerStatesCount = goalStateBuilder.getRouterStatesCount();
         if (routerStatesCount == 0) {
             RouterConfiguration.Builder routerConfigBuilder = RouterConfiguration.newBuilder();
-            routerConfigBuilder.setFormatVersion(FORMAT_REVISION_NUMBER);
             routerConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             String hostDvrMac = routerInfo.getRouterConfiguration().getHostDvrMac();
             if (hostDvrMac != null) {

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -253,7 +253,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
     private NeighborState buildNeighborState(NeighborEntry neighborEntry, NeighborInfo neighborInfo, OperationType operationType) {
         NeighborConfiguration.Builder neighborConfigBuilder = NeighborConfiguration.newBuilder();
         neighborConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
-        //neighborConfigBuilder.setId(); // !!!We are going to need this per latest ACA change!!!
+        //neighborConfigBuilder.setId(); // TODO: We are going to need this per latest ACA change
         neighborConfigBuilder.setVpcId(neighborInfo.getVpcId());
         //neighborConfigBuilder.setName();
         neighborConfigBuilder.setMacAddress(neighborInfo.getPortMac());

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -72,6 +72,7 @@ import java.util.stream.Collectors;
 
 @Service
 public class DataPlaneServiceImpl implements DataPlaneService {
+    private static final int GOAL_STATE_MESSAGE_FORMAT_VERSION = 101;
     private static final int FORMAT_REVISION_NUMBER = 1;
 
     @Autowired
@@ -487,6 +488,8 @@ public class DataPlaneServiceImpl implements DataPlaneService {
                                                    MulticastGoalState multicastGoalState) throws Exception {
         UnicastGoalState unicastGoalState = new UnicastGoalState();
         unicastGoalState.setHostIp(hostIp);
+
+        unicastGoalState.getGoalStateBuilder().setFormatVersion(GOAL_STATE_MESSAGE_FORMAT_VERSION);
 
         if (portEntities != null && portEntities.size() > 0) {
             buildPortState(networkConfig, portEntities, unicastGoalState);

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/ovs/DataPlaneServiceImpl.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.dataplane.service.ovs;
 
+import com.futurewei.alcor.dataplane.config.Config;
 import com.futurewei.alcor.common.enumClass.VpcRouteTarget;
 import com.futurewei.alcor.dataplane.client.DataPlaneClient;
 import com.futurewei.alcor.dataplane.entity.MulticastGoalState;
@@ -72,8 +73,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class DataPlaneServiceImpl implements DataPlaneService {
-    private static final int GOAL_STATE_MESSAGE_FORMAT_VERSION = 101;
+    private int goalStateMessageVersion;
     private static final int FORMAT_REVISION_NUMBER = 1;
+
+    @Autowired
+    private DataPlaneServiceImpl(Config globalConfig) {
+        this.goalStateMessageVersion = globalConfig.goalStateMessageVersion;
+    }
 
     @Autowired
     private DataPlaneClient dataPlaneClient;
@@ -185,6 +191,8 @@ public class DataPlaneServiceImpl implements DataPlaneService {
                 subnetConfigBuilder.setDhcpEnable(subnetEntity.getDhcpEnable());
             }
 
+            // TODO: need to set DNS based on latest contract
+            
             if (subnetEntity.getAvailabilityZone() != null) {
                 subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
             }
@@ -489,7 +497,7 @@ public class DataPlaneServiceImpl implements DataPlaneService {
         UnicastGoalState unicastGoalState = new UnicastGoalState();
         unicastGoalState.setHostIp(hostIp);
 
-        unicastGoalState.getGoalStateBuilder().setFormatVersion(GOAL_STATE_MESSAGE_FORMAT_VERSION);
+        unicastGoalState.getGoalStateBuilder().setFormatVersion(this.goalStateMessageVersion);
 
         if (portEntities != null && portEntities.size() > 0) {
             buildPortState(networkConfig, portEntities, unicastGoalState);

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateHelper.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateHelper.java
@@ -79,11 +79,9 @@ public class GoalStateHelper {
         Subnet.SubnetConfiguration.newBuilder()
             .setId(subnetEntity1.getId())
             .setVpcId(subnetEntity1.getVpcId())
-            .setProjectId(subnetEntity1.getProjectId())
             .setCidr(subnetEntity1.getCidr())
             .setTunnelId(subnetEntity1.getTunnelId())
             .setGateway(gateway)
-            .setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER)
             .build();
     Subnet.SubnetState subnetState =
         Subnet.SubnetState.newBuilder().setConfiguration(subnetConfiguration).buildPartial();
@@ -170,10 +168,8 @@ public class GoalStateHelper {
             .addFixedIps(fixedIp)
             .setHostIpAddress(ipHostIpMap.get(ip))
             .setMacAddress(ipMacMap.get(ip))
-            .setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER)
             .setRevisionNumber(Port.PortConfiguration.REVISION_NUMBER_FIELD_NUMBER)
             .setId(ipPortIdMap.get(ip))
-            .setProjectId(networkConfiguration.getVpcs().get(0).getProjectId())
             .setVpcId(networkConfiguration.getVpcs().get(0).getId())
             .build();
     Common.OperationType target = getOperationType(networkConfiguration.getOpType());

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Future;
 
 @Component
 public class GoalStateManager {
+  public static final int GOAL_STATE_MESSAGE_FORMAT_VERSION = 101;
   public static final int FORMAT_REVISION_NUMBER = 1;
   private final GoalStateHelper goalStateHelper = new GoalStateHelper();
   private final GoalStatePreparer DPMPreparer = new GoalStatePreparer();

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateTransformer.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateTransformer.java
@@ -149,7 +149,7 @@ public class GoalStateTransformer {
                     }
                     String name = portStateWithEverythingFilledNB.getName() == null ? "" : portStateWithEverythingFilledNB.getName();
 
-                    Port.PortConfiguration portConfiguration = Port.PortConfiguration.newBuilder().setName(name).setVpcId(portStateWithEverythingFilledNB.getVpcEntities().iterator().next().getId()).setAdminStateUp(true).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllFixedIps(fixedIps).setId(portStateWithEverythingFilledNB.getId()).setMessageTypeValue(Common.MessageType.FULL_VALUE).build();
+                    Port.PortConfiguration portConfiguration = Port.PortConfiguration.newBuilder().setName(name).setVpcId(portStateWithEverythingFilledNB.getVpcEntities().iterator().next().getId()).setAdminStateUp(true).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllFixedIps(fixedIps).setId(portStateWithEverythingFilledNB.getId()).setUpdateTypeValue(Common.UpdateType.FULL_VALUE).build();
 
                     final Port.PortState portStateSB = Port.PortState.newBuilder().setConfiguration(portConfiguration).setOperationType(Common.OperationType.CREATE).build();
 
@@ -277,7 +277,7 @@ public class GoalStateTransformer {
                         subnetRoutingTables2.add(subnetRoutingTable.toBuilder().addAllRoutingRules(routingRuleList).build());
                     }
 
-                    Router.RouterConfiguration routerConfiguration = Router.RouterConfiguration.newBuilder().setHostDvrMacAddress(internalRouterInfo.getRouterConfiguration().getHostDvrMac()).setId(internalRouterInfo.getRouterConfiguration().getId()).setMessageType(Common.MessageType.FULL).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllSubnetRoutingTables(subnetRoutingTables2).build();
+                    Router.RouterConfiguration routerConfiguration = Router.RouterConfiguration.newBuilder().setHostDvrMacAddress(internalRouterInfo.getRouterConfiguration().getHostDvrMac()).setId(internalRouterInfo.getRouterConfiguration().getId()).setUpdateType(Common.UpdateType.FULL).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllSubnetRoutingTables(subnetRoutingTables2).build();
                     Router.RouterState routerState = Router.RouterState.newBuilder().setConfiguration(routerConfiguration).build();
                     routerStateList.add(routerState);
                 }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateTransformer.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/utils/GoalStateTransformer.java
@@ -142,14 +142,14 @@ public class GoalStateTransformer {
                     for (PortEntity.FixedIp fixedIp : fixedIps1) {
                         fixedIps.add(Port.PortConfiguration.FixedIp.newBuilder().setSubnetId(fixedIp.getSubnetId()).setIpAddress(fixedIp.getIpAddress()).build());
                         if (portIdNeighborInfoMap.values().stream().filter(e -> e.getPortId().equals(ipPortIdMap.get(fixedIp.getIpAddress()))).count() == 0) {
-                            DHCP.DHCPConfiguration dhcpConfiguration = DHCP.DHCPConfiguration.newBuilder().setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER).setSubnetId(fixedIp.getSubnetId()).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setIpv4Address(fixedIp.getIpAddress()).build();
+                            DHCP.DHCPConfiguration dhcpConfiguration = DHCP.DHCPConfiguration.newBuilder().setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).setSubnetId(fixedIp.getSubnetId()).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setIpv4Address(fixedIp.getIpAddress()).build();
                             DHCP.DHCPState dhcpState = DHCP.DHCPState.newBuilder().setConfiguration(dhcpConfiguration).build();
                             dhcpStateList.add(dhcpState);
                         }
                     }
                     String name = portStateWithEverythingFilledNB.getName() == null ? "" : portStateWithEverythingFilledNB.getName();
 
-                    Port.PortConfiguration portConfiguration = Port.PortConfiguration.newBuilder().setName(name).setProjectId(portStateWithEverythingFilledNB.getProjectId()).setVpcId(portStateWithEverythingFilledNB.getVpcEntities().iterator().next().getId()).setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER).setAdminStateUp(true).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllFixedIps(fixedIps).setId(portStateWithEverythingFilledNB.getId()).setNetworkTypeValue(Common.NetworkType.VXLAN_VALUE).setMessageTypeValue(Common.MessageType.FULL_VALUE).build();
+                    Port.PortConfiguration portConfiguration = Port.PortConfiguration.newBuilder().setName(name).setVpcId(portStateWithEverythingFilledNB.getVpcEntities().iterator().next().getId()).setAdminStateUp(true).setMacAddress(portStateWithEverythingFilledNB.getMacAddress()).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllFixedIps(fixedIps).setId(portStateWithEverythingFilledNB.getId()).setMessageTypeValue(Common.MessageType.FULL_VALUE).build();
 
                     final Port.PortState portStateSB = Port.PortState.newBuilder().setConfiguration(portConfiguration).setOperationType(Common.OperationType.CREATE).build();
 
@@ -247,7 +247,7 @@ public class GoalStateTransformer {
                 goalStateManager.getGoalStateHelper().add2SubnetStates(networkConfiguration, subnetStateSet, subnetEntity1);
                 // lookup vpc entity
                 final VpcEntity vpcEntity = vpcMap.get(subnetEntity1.getVpcId());
-                Vpc.VpcConfiguration vpcConfiguration = Vpc.VpcConfiguration.newBuilder().setId(vpcEntity.getId()).setCidr(vpcEntity.getCidr()).setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).build();
+                Vpc.VpcConfiguration vpcConfiguration = Vpc.VpcConfiguration.newBuilder().setId(vpcEntity.getId()).setCidr(vpcEntity.getCidr()).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).build();
                 Vpc.VpcState vpcState = Vpc.VpcState.newBuilder().setConfiguration(vpcConfiguration).setOperationTypeValue(Common.OperationType.CREATE_VALUE).setOperationType(Common.OperationType.CREATE).build();
                 vpcStateSet.add(vpcState);
             }
@@ -277,7 +277,7 @@ public class GoalStateTransformer {
                         subnetRoutingTables2.add(subnetRoutingTable.toBuilder().addAllRoutingRules(routingRuleList).build());
                     }
 
-                    Router.RouterConfiguration routerConfiguration = Router.RouterConfiguration.newBuilder().setFormatVersion(GoalStateManager.FORMAT_REVISION_NUMBER).setHostDvrMacAddress(internalRouterInfo.getRouterConfiguration().getHostDvrMac()).setId(internalRouterInfo.getRouterConfiguration().getId()).setMessageType(Common.MessageType.FULL).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllSubnetRoutingTables(subnetRoutingTables2).build();
+                    Router.RouterConfiguration routerConfiguration = Router.RouterConfiguration.newBuilder().setHostDvrMacAddress(internalRouterInfo.getRouterConfiguration().getHostDvrMac()).setId(internalRouterInfo.getRouterConfiguration().getId()).setMessageType(Common.MessageType.FULL).setRevisionNumber(GoalStateManager.FORMAT_REVISION_NUMBER).addAllSubnetRoutingTables(subnetRoutingTables2).build();
                     Router.RouterState routerState = Router.RouterState.newBuilder().setConfiguration(routerConfiguration).build();
                     routerStateList.add(routerState);
                 }
@@ -285,7 +285,7 @@ public class GoalStateTransformer {
             // leave a dummy security group value since for now there is no impl for sg
             SecurityGroup.SecurityGroupConfiguration securityGroupConfiguration = SecurityGroup.SecurityGroupConfiguration.newBuilder().build();
             final SecurityGroup.SecurityGroupState securityGroupState = SecurityGroup.SecurityGroupState.newBuilder().setConfiguration(securityGroupConfiguration).build();
-            final Goalstate.GoalState goalState = Goalstate.GoalState.newBuilder().addAllPortStates(portStateHashSet).addAllNeighborStates(neighborStates.values()).addAllSubnetStates(subnetStateSet).addSecurityGroupStates(0, securityGroupState).addAllRouterStates(routerStateList).addAllDhcpStates(dhcpStateList).build();
+            final Goalstate.GoalState goalState = Goalstate.GoalState.newBuilder().setFormatVersion(GoalStateManager.GOAL_STATE_MESSAGE_FORMAT_VERSION).addAllPortStates(portStateHashSet).addAllNeighborStates(neighborStates.values()).addAllSubnetStates(subnetStateSet).addSecurityGroupStates(0, securityGroupState).addAllRouterStates(routerStateList).addAllDhcpStates(dhcpStateList).build();
             goalStateConcurrentHashMap.put(currentGroupHostIp, goalState);
         });
         GoalStateManager.LOG.log(Level.INFO, goalStateConcurrentHashMap.entrySet().toString());

--- a/services/data_plane_manager/src/main/resources/application.properties
+++ b/services/data_plane_manager/src/main/resources/application.properties
@@ -7,6 +7,10 @@ grpc.min-threads = 100
 grpc.max-threads = 200
 grpc.threads-pool-name = grpc-thread-pool
 
+#DPM v1 is statically using version 101
+#DPM v2 will start with version 102
+protobuf.goal-state-message.version = 102
+
 #####Logging configuration#####
 #logging.file.path=./
 #logging.file.name=data-plane-manager.log

--- a/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
+++ b/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
@@ -438,6 +438,8 @@ public class DataPlaneManagerUtil {
             gatewayBuilder.setMacAddress(subnetEntity.getGatewayMacAddress());
             subnetConfigBuilder.setGateway(gatewayBuilder.build());
             subnetConfigBuilder.setDhcpEnable(subnetEntity.getDhcpEnable());
+
+            // TODO: need to set DNS based on latest contract
             if (subnetEntity.getAvailabilityZone() != null) {
                 subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
             }

--- a/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
+++ b/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
@@ -424,10 +424,8 @@ public class DataPlaneManagerUtil {
 
         for (InternalSubnetEntity subnetEntity: subnets) {
             Subnet.SubnetConfiguration.Builder subnetConfigBuilder = Subnet.SubnetConfiguration.newBuilder();
-            subnetConfigBuilder.setFormatVersion(DPMAutoUnitTestConstant.formatVersion);
             subnetConfigBuilder.setId(subnetEntity.getId());
             subnetConfigBuilder.setNetworkType(Common.NetworkType.VXLAN);
-            subnetConfigBuilder.setProjectId(subnetEntity.getProjectId());
             subnetConfigBuilder.setVpcId(subnetEntity.getVpcId());
             if (subnetEntity.getName() != null) {
                 subnetConfigBuilder.setName(subnetEntity.getName());
@@ -442,13 +440,6 @@ public class DataPlaneManagerUtil {
             subnetConfigBuilder.setDhcpEnable(subnetEntity.getDhcpEnable());
             if (subnetEntity.getAvailabilityZone() != null) {
                 subnetConfigBuilder.setAvailabilityZone(subnetEntity.getAvailabilityZone());
-            }
-            if (subnetEntity.getPrimaryDns() != null) {
-                subnetConfigBuilder.setPrimaryDns(subnetEntity.getPrimaryDns());
-            }
-
-            if (subnetEntity.getSecondaryDns() != null) {
-                subnetConfigBuilder.setSecondaryDns(subnetEntity.getSecondaryDns());
             }
             Subnet.SubnetState.Builder subnetStateBuilder = Subnet.SubnetState.newBuilder();
             subnetStateBuilder.setOperationType(com.futurewei.alcor.schema.Common.OperationType.INFO);
@@ -466,12 +457,9 @@ public class DataPlaneManagerUtil {
     private void buildPortState(NetworkConfiguration networkConfig, List<InternalPortEntity> portEntities, Goalstate.GoalState.Builder goalStateBuilder) {
         for (InternalPortEntity portEntity: portEntities) {
             Port.PortConfiguration.Builder portConfigBuilder = Port.PortConfiguration.newBuilder();
-            portConfigBuilder.setFormatVersion(DPMAutoUnitTestConstant.formatVersion);
             portConfigBuilder.setRevisionNumber(DPMAutoUnitTestConstant.revisionNumber);
             portConfigBuilder.setId(portEntity.getId());
             portConfigBuilder.setMessageType(Common.MessageType.FULL);
-            portConfigBuilder.setNetworkType(Common.NetworkType.VXLAN);
-            portConfigBuilder.setProjectId(portEntity.getProjectId());
             portConfigBuilder.setVpcId(portEntity.getVpcId());
             portConfigBuilder.setName(portEntity.getName());
             portConfigBuilder.setMacAddress(portEntity.getMacAddress());
@@ -640,8 +628,6 @@ public class DataPlaneManagerUtil {
                 neighborType = Neighbor.NeighborType.valueOf(neighborTypeStr);
             }
             //neighborConfigBuilder.setNeighborType(neighborType);
-            neighborConfigBuilder.setProjectId(DPMAutoUnitTestConstant.projectId);
-            neighborConfigBuilder.setFormatVersion(DPMAutoUnitTestConstant.formatVersion);
             neighborConfigBuilder.setRevisionNumber(DPMAutoUnitTestConstant.revisionNumber2);
             neighborConfigBuilder.setVpcId(neighborInfo.getVpcId());
             //neighborConfigBuilder.setName();
@@ -715,7 +701,6 @@ public class DataPlaneManagerUtil {
         for (String securityGroupId: securityGroupIds) {
             SecurityGroup securityGroup = getSecurityGroup(networkConfig, securityGroupId);
             securityGroupConfigBuilder.setId(securityGroup.getId());
-            securityGroupConfigBuilder.setProjectId(securityGroup.getProjectId());
             //securityGroupConfigBuilder.setVpcId();
             securityGroupConfigBuilder.setName(securityGroup.getName());
 
@@ -768,7 +753,6 @@ public class DataPlaneManagerUtil {
             DHCP.DHCPConfiguration.Builder dhcpConfigBuilder = DHCP.DHCPConfiguration.newBuilder();
             dhcpConfigBuilder.setMacAddress(macAddress);
             dhcpConfigBuilder.setIpv4Address(fixedIps.get(0).getIpAddress());
-            dhcpConfigBuilder.setFormatVersion(DPMAutoUnitTestConstant.formatVersion);
             dhcpConfigBuilder.setRevisionNumber(DPMAutoUnitTestConstant.revisionNumber);
             dhcpConfigBuilder.setSubnetId(fixedIps.get(0).getSubnetId());
             //TODO: support ipv6
@@ -808,7 +792,6 @@ public class DataPlaneManagerUtil {
             if (configuration == null) {
                 continue;
             }
-            routerConfigBuilder.setFormatVersion(DPMAutoUnitTestConstant.formatVersion);
             routerConfigBuilder.setRevisionNumber(DPMAutoUnitTestConstant.revisionNumber);
             if (configuration.getRequestId() != null) {
                 routerConfigBuilder.setRequestId(configuration.getRequestId());

--- a/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
+++ b/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/utils/DataPlaneManagerUtil.java
@@ -461,7 +461,7 @@ public class DataPlaneManagerUtil {
             Port.PortConfiguration.Builder portConfigBuilder = Port.PortConfiguration.newBuilder();
             portConfigBuilder.setRevisionNumber(DPMAutoUnitTestConstant.revisionNumber);
             portConfigBuilder.setId(portEntity.getId());
-            portConfigBuilder.setMessageType(Common.MessageType.FULL);
+            portConfigBuilder.setUpdateType(Common.UpdateType.FULL);
             portConfigBuilder.setVpcId(portEntity.getVpcId());
             portConfigBuilder.setName(portEntity.getName());
             portConfigBuilder.setMacAddress(portEntity.getMacAddress());
@@ -799,7 +799,7 @@ public class DataPlaneManagerUtil {
                 routerConfigBuilder.setRequestId(configuration.getRequestId());
             }
             routerConfigBuilder.setId(configuration.getId());
-            routerConfigBuilder.setMessageType(Common.MessageType.FULL);
+            routerConfigBuilder.setUpdateType(Common.UpdateType.FULL);
             routerConfigBuilder.setHostDvrMacAddress(configuration.getHostDvrMac());
 
             List<InternalSubnetRoutingTable> subnetRoutingTables = configuration.getSubnetRoutingTables();


### PR DESCRIPTION
This is a contract update which includes the below changes:

1. Updated dns entry and extra dhcp options in subnet.proto, remove the ones in dhcp.proto to avoid duplication
1. Removed default_routing_table in router.proto
1. Removed DPM code to populate network_type from port.proto per number 3 in #386
1. Don't populate format_version and remove that field for all top level resources per number 4 in #386
1. Don't populate project_id and remove that field for all top level resources except vpc
 per number 5 in #386
1. Changed from MessageType to UpdateType for all resources per number 6 in #386