### PR TITLE
[Build Tool] Add Script to Build Docker Image for Services

### DIFF
--- a/kubernetes/services/only-build-docker.sh
+++ b/kubernetes/services/only-build-docker.sh
@@ -1,0 +1,9 @@
+cd ../../services
+  for d in *;
+  do
+      echo "Build service -  $d"
+      cd $d
+      docker build -t $d:v1.0 .
+      cd ..
+      echo "Build service -  $d completed"
+  done


### PR DESCRIPTION
This PR is to simplify the legacy build process by removing useless build step when you want to build the docker image with not all code change needed.
To run it , simply run sh only-build-docker.sh