### PR TITLE
[Hotfix] Fix Issue that gRPC Client and Pulsar Client Can't Coexist

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/DataPlaneManager.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/DataPlaneManager.java
@@ -17,7 +17,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.dataplane;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -26,7 +25,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @SpringBootApplication
-@EnableAutoConfiguration
 @EnableAsync
 public class DataPlaneManager {
 

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
@@ -37,7 +37,7 @@ import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 //@Component
-@Service("grpc")
+@Service("grpcDataPlaneClient")
 public class DataPlaneClientImpl implements DataPlaneClient {
     private static final Logger LOG = LoggerFactory.getLogger(DataPlaneClientImpl.class);
 

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 //@Component
-@Service("pulsar")
+@Service("pulsarDataPlaneClient")
 public class DataPlaneClientImpl implements DataPlaneClient {
     private static final Logger LOG = LoggerFactory.getLogger(DataPlaneClientImpl.class);
 


### PR DESCRIPTION
By design, Data-plane Manager should allow multiple data plane clients coexist so that we could enable gRPC fast path and MQ scaling path simultaneously. This PR fixes the issue that DPM can't start (commit a893709) when two types of clients were enabled at the same time.
