### PR TITLE
[Microservice] Move forward to DPM v2.0 APIs

### DIFF
--- a/kubernetes/services/port_manager.yaml
+++ b/kubernetes/services/port_manager.yaml
@@ -20,7 +20,7 @@ data:
     microservices.sg.service.url=http://sgmanager-service.default.svc.cluster.local:9008
     microservices.route.service.url=http://routemanager-service.default.svc.cluster.local:9003/routes
     microservices.node.service.url=http://nodemanager-service.default.svc.cluster.local:9007/nodes
-    microservices.dataplane.service.url=http://dataplanemanager-service.default.svc.cluster.local:9010/v4/port/
+    microservices.dataplane.service.url=http://dataplanemanager-service.default.svc.cluster.local:9010/network-configuration
     microservices.elasticip.service.url=http://eipmanager-service.default.svc.cluster.local:9011
 
     alcor.vif_type=ovs

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/cache/LocalCache.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/cache/LocalCache.java
@@ -8,4 +8,5 @@ public interface LocalCache {
     void updateSubnetPorts(NetworkConfiguration networkConfig) throws Exception;
     void deleteSubnetPorts(NetworkConfiguration networkConfig);
     InternalSubnetPorts getSubnetPorts(String subnetId) throws Exception;
+    void updateLocalCache(NetworkConfiguration networkConfig) throws Exception;
 }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/cache/LocalCacheImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/cache/LocalCacheImpl.java
@@ -15,8 +15,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.dataplane.cache;
 
-import com.futurewei.alcor.dataplane.client.grpc.DataPlaneClientImpl;
 import com.futurewei.alcor.dataplane.exception.SubnetEntityNotFound;
+import com.futurewei.alcor.schema.Common.OperationType;
 import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.InternalSubnetEntity;
 import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
@@ -116,5 +116,23 @@ public class LocalCacheImpl implements LocalCache {
     @Override
     public InternalSubnetPorts getSubnetPorts(String subnetId) throws Exception {
         return subnetPortsCache.getSubnetPorts(subnetId);
+    }
+
+    @Override
+    public void updateLocalCache(NetworkConfiguration networkConfig) throws Exception {
+        OperationType opType = networkConfig.getOpType();
+        switch (opType) {
+            case CREATE:
+                addSubnetPorts(networkConfig);
+                break;
+            case UPDATE:
+                updateSubnetPorts(networkConfig);
+                break;
+            case DELETE:
+                deleteSubnetPorts(networkConfig);
+                break;
+            default:
+                LOG.error("Update SubnetPorts failed: Unknown operation type");
+        }
     }
 }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/DataPlaneClient.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/DataPlaneClient.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 @Component
 public interface DataPlaneClient {
-    List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception;
-    List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates,
-                                  MulticastGoalState multicastGoalState) throws Exception;
+    List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception;
+    List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates,
+                                MulticastGoalState multicastGoalState) throws Exception;
 }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
@@ -57,13 +57,13 @@ public class DataPlaneClientImpl implements DataPlaneClient {
     }
 
     @Override
-    public List<String> createGoalStates(
+    public List<String> sendGoalStates(
             List<UnicastGoalState> unicastGoalStates) throws Exception {
-        return sendGoalStates(unicastGoalStates);
+        return doSendGoalStates(unicastGoalStates);
     }
 
     @Override
-    public List<String> createGoalStates(
+    public List<String> sendGoalStates(
             List<UnicastGoalState> unicastGoalStates, MulticastGoalState multicastGoalState) throws Exception {
         if (unicastGoalStates == null) {
             unicastGoalStates = new ArrayList<>();
@@ -82,13 +82,13 @@ public class DataPlaneClientImpl implements DataPlaneClient {
         }
 
         if (unicastGoalStates.size() > 0) {
-            return createGoalStates(unicastGoalStates);
+            return sendGoalStates(unicastGoalStates);
         }
 
         return null;
     }
 
-    private List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates) {
+    private List<String> doSendGoalStates(List<UnicastGoalState> unicastGoalStates) {
         List<Future<UnicastGoalState>>
                 futures = new ArrayList<>(unicastGoalStates.size());
 

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/kafka/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/kafka/DataPlaneClientImpl.java
@@ -27,12 +27,12 @@ import java.util.Map;
 public class DataPlaneClientImpl implements DataPlaneClient {
 
     @Override
-    public List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception {
+    public List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception {
         return null;
     }
 
     @Override
-    public List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates, MulticastGoalState multicastGoalState) throws Exception {
+    public List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates, MulticastGoalState multicastGoalState) throws Exception {
         return null;
     }
 }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/pulsar/DataPlaneClientImpl.java
@@ -118,7 +118,7 @@ public class DataPlaneClientImpl implements DataPlaneClient {
     }
 
     @Override
-    public List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception {
+    public List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates) throws Exception {
         List<String> failedHosts = new ArrayList<>();
 
         for (UnicastGoalState unicastGoalState: unicastGoalStates) {
@@ -156,10 +156,10 @@ public class DataPlaneClientImpl implements DataPlaneClient {
     }
 
     @Override
-    public List<String> createGoalStates(List<UnicastGoalState> unicastGoalStates, MulticastGoalState multicastGoalState) throws Exception {
+    public List<String> sendGoalStates(List<UnicastGoalState> unicastGoalStates, MulticastGoalState multicastGoalState) throws Exception {
         List<String> failedHosts = new ArrayList<>();
 
-        failedHosts.addAll(createGoalStates(unicastGoalStates));
+        failedHosts.addAll(sendGoalStates(unicastGoalStates));
         failedHosts.addAll(createGoalState(multicastGoalState));
 
         return failedHosts;

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DpmServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DpmServiceImpl.java
@@ -120,6 +120,19 @@ public class DpmServiceImpl implements DpmService {
         return dataPlaneClient.sendGoalStates(unicastGoalStates, multicastGoalState);
     }
 
+    /**
+     * This method processes the network configuration where the resource type is PORT.
+     * The NetworkConfiguration may contain multiple port entities, and these port
+     * entities may need to be sent to multiple hosts, Other configurations related to port
+     * also need to be processed, such as routing configuration and neighbor configuration.
+     * Here we build one UnicastGoalState for each host and put the information that it needs
+     * into it. If the same information needs to be sent to multiple host, in order to
+     * improve the transmission performance, only one MulticastGoalState is constructed and
+     * broadcast it to the all target  hosts.
+     * @param networkConfig The networkConfig may contain multiple port entities and related Configuration
+     * @return Hosts that failed to send GoalState
+     * @throws Exception Process exceptions and send exceptions
+     */
     private List<String> processPortConfiguration(NetworkConfiguration networkConfig) throws Exception {
         Map<String, List<InternalPortEntity>> grpcHostPortEntities = new HashMap<>();
         Map<String, List<InternalPortEntity>> pulsarHostPortEntities = new HashMap<>();
@@ -158,6 +171,14 @@ public class DpmServiceImpl implements DpmService {
         return statusList;
     }
 
+    /**
+     * This method get neighbor information from NetworkConfiguration, then build one
+     * UnicastGoalState for each host and fill in the neighbor information it needs,
+     * and finally send all UnicastGoalState to the relevant hosts.
+     * @param networkConfig Network configuration with neighbor configuration
+     * @return Hosts that failed to send GoalState
+     * @throws Exception Process exceptions and send exceptions
+     */
     private List<String> processNeighborConfiguration(NetworkConfiguration networkConfig) throws Exception {
         Map<String, NeighborInfo> neighborInfos = networkConfig.getNeighborInfos();
         Map<String, List<NeighborEntry>> neighborTable = networkConfig.getNeighborTable();
@@ -238,6 +259,16 @@ public class DpmServiceImpl implements DpmService {
         return null;
     }
 
+    /**
+     * This method get the subnet routing configuration from the NetworkConfiguration,
+     * then find the host information of all the virtual machines under the subnet from
+     * the local cache according to the subnet id, build one UnicastGoalState for each
+     * host and fill it with the routing information it needs, and finally send all the
+     * UnicastGoalState to the relevant hosts.
+     * @param networkConfig Network configuration with router configuration
+     * @return Hosts that failed to send GoalState
+     * @throws Exception Process exceptions and send exceptions
+     */
     private List<String> processRouterConfiguration(NetworkConfiguration networkConfig) throws Exception {
         List<InternalRouterInfo> internalRouterInfos = networkConfig.getInternalRouterInfos();
         if (internalRouterInfos == null) {

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/NeighborService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/NeighborService.java
@@ -31,7 +31,7 @@ import java.util.*;
 
 @Service
 public class NeighborService extends ResourceService {
-    public Neighbor.NeighborState buildNeighborState(NeighborEntry neighborEntry, NeighborInfo neighborInfo, Common.OperationType operationType) {
+    public Neighbor.NeighborState buildNeighborState(NeighborEntry.NeighborType type, NeighborInfo neighborInfo, Common.OperationType operationType) {
         Neighbor.NeighborConfiguration.Builder neighborConfigBuilder = Neighbor.NeighborConfiguration.newBuilder();
         neighborConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
         //neighborConfigBuilder.setId(); // TODO: We are going to need this per latest ACA change
@@ -39,7 +39,7 @@ public class NeighborService extends ResourceService {
         //neighborConfigBuilder.setName();
         neighborConfigBuilder.setMacAddress(neighborInfo.getPortMac());
         neighborConfigBuilder.setHostIpAddress(neighborInfo.getHostIp());
-        Neighbor.NeighborType neighborType = Neighbor.NeighborType.valueOf(neighborEntry.getNeighborType().getType());
+        Neighbor.NeighborType neighborType = Neighbor.NeighborType.valueOf(type.getType());
 
         //TODO:setNeighborHostDvrMac
         //neighborConfigBuilder.setNeighborHostDvrMac();
@@ -100,7 +100,7 @@ public class NeighborService extends ResourceService {
                     }
 
                     unicastGoalState.getGoalStateBuilder().addNeighborStates(buildNeighborState(
-                            neighborEntry, neighborInfo, networkConfig.getOpType()));
+                            neighborEntry.getNeighborType(), neighborInfo, networkConfig.getOpType()));
                 }
 
                 multicastNeighborEntries.addAll(neighborEntries);
@@ -123,7 +123,7 @@ public class NeighborService extends ResourceService {
 
             if (!neighborInfoSet.contains(neighborInfo1)) {
                 multicastGoalState.getGoalStateBuilder().addNeighborStates(buildNeighborState(
-                        neighborEntry, neighborInfo1, networkConfig.getOpType()));
+                        neighborEntry.getNeighborType(), neighborInfo1, networkConfig.getOpType()));
                 neighborInfoSet.add(neighborInfo1);
             }
         }

--- a/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/config/TestConfig.java
+++ b/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/config/TestConfig.java
@@ -40,7 +40,7 @@ public class TestConfig {
     public static String ip21 = "10.10.2.2";
     public static String ip22 = "10.10.2.3";
     public static String hostIp1 = "192.168.131.131";
-    public static String hostIp2 = "192.168.131.131";
+    public static String hostIp2 = "192.168.131.132";
     public static long tunnelId = 100;
     public static String mac1 = "00:01:6C:06:A6:29";
     public static String mac2 = "00:01:6C:06:A6:30";

--- a/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/controller/DpmTest.java
+++ b/services/data_plane_manager/src/test/java/com/futurewei/alcor/dataplane/controller/DpmTest.java
@@ -17,8 +17,8 @@ package com.futurewei.alcor.dataplane.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.futurewei.alcor.dataplane.client.DataPlaneClient;
+import com.futurewei.alcor.dataplane.client.grpc.DataPlaneClientImpl;
 import com.futurewei.alcor.dataplane.config.TestConfig;
-import com.futurewei.alcor.dataplane.constants.DPMAutoUnitTestConstant;
 import com.futurewei.alcor.schema.Common.OperationType;
 import com.futurewei.alcor.schema.Common.ResourceType;
 import com.futurewei.alcor.web.entity.dataplane.*;
@@ -75,7 +75,7 @@ public class DpmTest {
     private PulsarClient pulsarClient;
 
     @MockBean
-    private DataPlaneClient dataPlaneClient;
+    private DataPlaneClientImpl grpcDataPlaneClient;
 
     private List<VpcEntity> buildVpcEntities() {
         VpcEntity vpcEntity = new VpcEntity();
@@ -366,7 +366,29 @@ public class DpmTest {
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andDo(print());
+    }
 
+    private NetworkConfiguration buildNeighborConfiguration() {
+        NetworkConfiguration networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.setRsType(ResourceType.NEIGHBOR);
+        networkConfiguration.setOpType(OperationType.CREATE);
 
+        networkConfiguration.setNeighborInfos(buildNeighborInfos());
+        networkConfiguration.setNeighborTable(buildNeighborTable());
+
+        return networkConfiguration;
+    }
+
+    @Test
+    public void createNeighborConfigurationTest() throws Exception {
+        NetworkConfiguration networkConfiguration = buildNeighborConfiguration();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(networkConfiguration);
+
+        this.mockMvc.perform(MockMvcRequestBuilders.post(TestConfig.url)
+                .content(body)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andDo(print());
     }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NeighborProcessor.java
@@ -15,7 +15,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.processor;
 
-import com.futurewei.alcor.portmanager.entity.PortNeighbors;
 import com.futurewei.alcor.portmanager.request.FetchPortNeighborRequest;
 import com.futurewei.alcor.portmanager.request.IRestRequest;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
@@ -27,19 +26,15 @@ import java.util.stream.Collectors;
 @AfterProcessor(PortProcessor.class)
 public class NeighborProcessor extends AbstractProcessor {
     private void fetchPortNeighborCallback(IRestRequest request) {
-        List<PortNeighbors> portNeighborsList = ((FetchPortNeighborRequest) request).getPortNeighborsList();
-        if (portNeighborsList == null || portNeighborsList.size() == 0) {
+        Map<String, NeighborInfo> neighborInfoMap = ((FetchPortNeighborRequest) request).getNeighborInfos();
+        if (neighborInfoMap == null || neighborInfoMap.size() == 0) {
             return;
         }
 
-        List<NeighborInfo> neighborInfos = new ArrayList<>();
-        for (PortNeighbors portNeighbors: portNeighborsList) {
-            if (portNeighbors.getNeighbors() == null ||
-                    portNeighbors.getNeighbors().size() == 0) {
-                continue;
-            }
-
-            neighborInfos.addAll(portNeighbors.getNeighbors().values());
+        Map<String, NeighborInfo> neighborInfos = new HashMap<>();
+        for (Map.Entry<String, NeighborInfo> entry: neighborInfoMap.entrySet()) {
+            NeighborInfo neighborInfo = entry.getValue();
+            neighborInfos.put(neighborInfo.getPortIp(), neighborInfo);
         }
 
         NetworkConfig networkConfig = request.getContext().getNetworkConfig();

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/NetworkConfig.java
@@ -24,7 +24,9 @@ import com.futurewei.alcor.web.entity.securitygroup.SecurityGroup;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class NetworkConfig {
     private List<InternalPortEntity> portEntities;
@@ -35,9 +37,11 @@ public class NetworkConfig {
 
     private List<SecurityGroup> securityGroups;
 
-    private List<NeighborInfo> neighborInfos;
+    //Key: portIp, value: Neighbor information for port
+    private Map<String, NeighborInfo> neighborInfos;
 
-    private List<NeighborEntry> neighborTable;
+    //Key: portIp, value: All neighbor information for port
+    private Map<String, List<NeighborEntry>> neighborTable;
 
     private List<InternalRouterInfo> routerInfos;
 
@@ -108,23 +112,28 @@ public class NetworkConfig {
         this.securityGroups = securityGroups;
     }
 
-    public List<NeighborInfo> getNeighborInfos() {
+    public Map<String, NeighborInfo> getNeighborInfos() {
         return this.neighborInfos;
     }
 
-    public void setNeighborInfos(List<NeighborInfo> neighborInfos) {
+    public void setNeighborInfos(Map<String, NeighborInfo> neighborInfos) {
         this.neighborInfos = neighborInfos;
     }
 
-    public List<NeighborEntry> getNeighborTable() {
+    public Map<String, List<NeighborEntry>> getNeighborTable() {
         return this.neighborTable;
     }
 
-    public void addNeighborEntries(List<NeighborEntry> neighborEntries) {
+    public void addNeighborEntries(String portIp, List<NeighborEntry> neighborEntries) {
         if (this.neighborTable == null) {
-            this.neighborTable = new ArrayList<>();
+            this.neighborTable = new HashMap<>();
         }
-        this.neighborTable.addAll(neighborEntries);
+
+        if (!this.neighborTable.containsKey(portIp)) {
+            this.neighborTable.put(portIp, new ArrayList<>());
+        }
+
+        this.neighborTable.get(portIp).addAll(neighborEntries);
     }
 
     public List<InternalRouterInfo> getRouterInfos() {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/DataPlaneManagerProxy.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/DataPlaneManagerProxy.java
@@ -19,7 +19,7 @@ import com.futurewei.alcor.common.utils.SpringContextUtil;
 import com.futurewei.alcor.portmanager.rollback.CreateNetworkConfigRollback;
 import com.futurewei.alcor.portmanager.rollback.DeleteNetworkConfigRollback;
 import com.futurewei.alcor.portmanager.rollback.Rollback;
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 import java.util.Stack;
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/CreateNetworkConfigRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/CreateNetworkConfigRequest.java
@@ -17,7 +17,7 @@ package com.futurewei.alcor.portmanager.request;
 
 import com.futurewei.alcor.common.utils.SpringContextUtil;
 import com.futurewei.alcor.portmanager.processor.PortContext;
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/DeleteNetworkConfigRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/DeleteNetworkConfigRequest.java
@@ -17,7 +17,7 @@ package com.futurewei.alcor.portmanager.request;
 
 import com.futurewei.alcor.common.utils.SpringContextUtil;
 import com.futurewei.alcor.portmanager.processor.PortContext;
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchPortNeighborRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/FetchPortNeighborRequest.java
@@ -15,26 +15,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.request;
 
-import com.futurewei.alcor.portmanager.entity.PortNeighbors;
 import com.futurewei.alcor.portmanager.processor.PortContext;
 import com.futurewei.alcor.web.entity.dataplane.NeighborInfo;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class FetchPortNeighborRequest extends AbstractRequest {
     private List<String> vpcIds;
-    private List<PortNeighbors> portNeighborsList;
+    private Map<String, NeighborInfo> neighborInfos;
 
     public FetchPortNeighborRequest(PortContext context, List<String> vpcIds) {
         super(context);
         this.vpcIds = vpcIds;
-        this.portNeighborsList = new ArrayList<>();
+        this.neighborInfos = new HashMap<>();
     }
 
-    public List<PortNeighbors> getPortNeighborsList() {
-        return portNeighborsList;
+    public Map<String, NeighborInfo> getNeighborInfos() {
+        return neighborInfos;
     }
 
     @Override
@@ -42,8 +41,7 @@ public class FetchPortNeighborRequest extends AbstractRequest {
         for (String vpcId: vpcIds) {
             Map<String, NeighborInfo> neighbors = context.getPortRepository().getNeighbors(vpcId);
             if (neighbors != null && neighbors.size() > 0) {
-                PortNeighbors portNeighbors = new PortNeighbors(vpcId, neighbors);
-                portNeighborsList.add(portNeighbors);
+                neighborInfos.putAll(neighbors);
             }
         }
     }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/UpdateNetworkConfigRequest.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/request/UpdateNetworkConfigRequest.java
@@ -17,7 +17,7 @@ package com.futurewei.alcor.portmanager.request;
 
 import com.futurewei.alcor.common.utils.SpringContextUtil;
 import com.futurewei.alcor.portmanager.processor.PortContext;
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/CreateNetworkConfigRollback.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/CreateNetworkConfigRollback.java
@@ -15,7 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.rollback;
 
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 
 public class CreateNetworkConfigRollback extends NetworkConfigRollback {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/DeleteNetworkConfigRollback.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/DeleteNetworkConfigRollback.java
@@ -15,7 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.rollback;
 
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 
 public class DeleteNetworkConfigRollback extends NetworkConfigRollback {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/NetworkConfigRollback.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/NetworkConfigRollback.java
@@ -15,7 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.rollback;
 
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 
 import java.util.ArrayList;

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/UpdateNetworkConfigRollback.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/rollback/UpdateNetworkConfigRollback.java
@@ -15,7 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.portmanager.rollback;
 
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 import com.futurewei.alcor.web.restclient.DataPlaneManagerRestClient;
 
 public class UpdateNetworkConfigRollback extends NetworkConfigRollback {

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/service/PortServiceImpl.java
@@ -262,9 +262,9 @@ public class PortServiceImpl implements PortService {
             networkConfiguration.setRsType(Common.ResourceType.NEIGHBOR);
             String operationType = routerUpdateInfo.getOperationType();
             if (RouterUpdateInfo.OperationType.ADD.getType().equals(operationType)) {
-                networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_CREATE_UPDATE);
+                networkConfiguration.setOpType(Common.OperationType.CREATE);
             } else {
-                networkConfiguration.setOpType(Common.OperationType.NEIGHBOR_DELETE);
+                networkConfiguration.setOpType(Common.OperationType.DELETE);
             }
             networkConfiguration.setNeighborInfos(neighborInfos);
             networkConfiguration.setNeighborTable(neighborTable);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/util/RestParameterValidator.java
@@ -144,8 +144,8 @@ public class RestParameterValidator {
             throw new OperationTypeInvalid();
         }
 
-        if (routerUpdateInfo.getOldSubnetIds() == null) {
-            routerUpdateInfo.setOldSubnetIds(new ArrayList<>());
+        if (routerUpdateInfo.getGatewayPortIds() == null) {
+            routerUpdateInfo.setGatewayPortIds(new ArrayList<>());
         }
     }
 }

--- a/services/port_manager/src/main/resources/application.properties
+++ b/services/port_manager/src/main/resources/application.properties
@@ -8,7 +8,7 @@ microservices.ip.service.url=http://localhost:9004/ips
 microservices.mac.service.url=http://localhost:9005/macs
 microservices.sg.service.url=http://localhost:9008
 microservices.node.service.url=http://localhost:9007/nodes
-microservices.dataplane.service.url=http://localhost:9010/v4/port/
+microservices.dataplane.service.url=http://localhost:9010/network-configuration
 microservices.elasticip.service.url=http://localhost:9011
 
 #####Http Server#####

--- a/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/route/RouterUpdateInfo.java
@@ -29,8 +29,8 @@ public class RouterUpdateInfo {
     @JsonProperty("operation_type")
     private String operationType;
 
-    @JsonProperty("old_subnet_ids")
-    private List<String> oldSubnetIds;
+    @JsonProperty("gateway_port_ids")
+    private List<String> gatewayPortIds;
 
     public enum OperationType {
         ADD("add"),
@@ -55,11 +55,11 @@ public class RouterUpdateInfo {
 
     }
 
-    public RouterUpdateInfo(String vpcId, String subnetId, String operationType, List<String> oldSubnetIds) {
+    public RouterUpdateInfo(String vpcId, String subnetId, String operationType, List<String> gatewayPortIds) {
         this.vpcId = vpcId;
         this.subnetId = subnetId;
         this.operationType = operationType;
-        this.oldSubnetIds = oldSubnetIds;
+        this.gatewayPortIds = gatewayPortIds;
     }
 
     public String getVpcId() {
@@ -86,11 +86,11 @@ public class RouterUpdateInfo {
         this.operationType = operationType;
     }
 
-    public List<String> getOldSubnetIds() {
-        return oldSubnetIds;
+    public List<String> getGatewayPortIds() {
+        return gatewayPortIds;
     }
 
-    public void setOldSubnetIds(List<String> oldSubnetIds) {
-        this.oldSubnetIds = oldSubnetIds;
+    public void setGatewayPortIds(List<String> gatewayPortIds) {
+        this.gatewayPortIds = gatewayPortIds;
     }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/restclient/DataPlaneManagerRestClient.java
+++ b/web/src/main/java/com/futurewei/alcor/web/restclient/DataPlaneManagerRestClient.java
@@ -16,7 +16,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 package com.futurewei.alcor.web.restclient;
 
 import com.futurewei.alcor.common.stats.DurationStatistics;
-import com.futurewei.alcor.web.entity.dataplane.NetworkConfiguration;
+import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
1. PM uses the new APIs of DPM
2. Remove the usage of deprecating OperationType in PM
3. Refactor update-l3-neighbors API to accept a list of gateway port IDs
4. DPM handles the configuration information of neighbors