### PR TITLE
[DPM] Revert change back to PUT for createNetworkConfiguration

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DpmController.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DpmController.java
@@ -45,7 +45,7 @@ public class DpmController {
         return dpmService.createNetworkConfiguration(networkConfiguration);
     }
 
-    @PostMapping({"/network-configuration", "v4/network-configuration"})
+    @PutMapping({"/network-configuration", "v4/network-configuration"})
     @DurationStatistics
     public InternalDPMResultList updateNetworkConfiguration(@RequestBody NetworkConfiguration networkConfiguration) throws Exception {
         checkNetworkConfiguration(networkConfiguration);


### PR DESCRIPTION
The PR from @songxiaoyan PR#549 will break DPM.
This PR reverts the change for createNetworkConfiguration from POST to PUT.