### PR TITLE
[Schema] Add Id field in DHCP state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ ignite/
 
 # mac system file
 .DS_Store
+
+# vs code files
+*.classpath
+*.project
+*.prefs
+*.factorypath

--- a/schema/proto3/dhcp.proto
+++ b/schema/proto3/dhcp.proto
@@ -27,12 +27,13 @@ message DHCPConfiguration {
     uint32 revision_number = 1;
 
     string request_id = 2;
-    UpdateType update_type = 3; // DELTA (default) or FULL
-    string subnet_id = 4;
-    string mac_address = 5;
-    string ipv4_address = 6;
-    string ipv6_address = 7;
-    string port_host_name = 8; // for local DNS response
+    string id = 3;
+    UpdateType update_type = 4; // DELTA (default) or FULL
+    string subnet_id = 5;
+    string mac_address = 6;
+    string ipv4_address = 7;
+    string ipv6_address = 8;
+    string port_host_name = 9; // for local DNS response
 }
 
 message DHCPState {


### PR DESCRIPTION
This PR addes a field, `string id = 3;`, to dhcp.proto. 

It has been tested and the unit tests passed. Please refer to the following screenshot.

![image](https://user-images.githubusercontent.com/32083634/110050716-59d15200-7d09-11eb-824e-68e0e2641639.png)
