### PR TITLE
Add NCM_URI and NCM_ID to NodeInfo

### DIFF
--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -20,6 +20,7 @@ package alcor.schema;
 
 option java_package = "com.futurewei.alcor.schema";
 
+import "common.proto";
 import "vpc.proto";
 import "subnet.proto";
 import "port.proto";
@@ -42,10 +43,19 @@ message GoalState {
     repeated GatewayState gateway_states = 9;
 }
 
+message ResourceIdType{
+    ResourceType type = 1;
+    string id = 2;
+}
+
+message HostResources{
+    repeated ResourceIdType resources = 1;
+}
+
 message GoalStateV2 {
     uint32 format_version = 1;
 
-    map<string /*host ip-ResourceType enum*/, string /*resource id*/> host_to_resource_id = 2;
+    map<string /*host ip*/, HostResources /*list of resources deployed to a target host*/> host_resources = 2;
     map<string /*resource id*/, VpcState> vpc_states = 3;
     map<string /*resource id*/, SubnetState> subnet_states = 4;
 

--- a/schema/proto3/router.proto
+++ b/schema/proto3/router.proto
@@ -39,7 +39,7 @@ message RouterConfiguration {
     message RoutingRuleExtraInfo{
         DestinationType destination_type = 1;
         string next_hop_mac = 2;
-        }
+    }
 
     message RoutingRule {
         OperationType operation_type = 1;

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/NodeService.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/NodeService.java
@@ -26,4 +26,7 @@ public interface NodeService {
     NodeInfo updateNodeInfo(String nodeId, NodeInfo nodeInfo) throws ParameterNullOrEmptyException, InvalidDataException, Exception;
 
     String deleteNodeInfo(String nodeId) throws ParameterNullOrEmptyException, Exception;
+
+    static String makeUpNcmUri(String hostIP, int localPort) { return "ncm/" + hostIP + "/" + String.valueOf(localPort); }
+    static String makeUpNcmId(String hostIP, int localPort) { return "ncm_" + hostIP + "_" + String.valueOf(localPort); }
 }

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.nodemanager.service.implement;
 
 import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.nodemanager.exception.InvalidDataException;
+import com.futurewei.alcor.nodemanager.service.NodeService;
 import com.futurewei.alcor.nodemanager.utils.NodeManagerConstant;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import org.json.simple.JSONArray;
@@ -97,8 +98,14 @@ public class NodeFileLoader {
         String unicastTopic = (String) nodeJson.get(NodeManagerConstant.UNICAST_TOPIC);
         String multicastTopic = (String) nodeJson.get(NodeManagerConstant.MULTICAST_TOPIC);
         String groupTopic = (String) nodeJson.get(NodeManagerConstant.GROUP_TOPIC);
+        String ncm_uri = (String)nodeJson.get(NodeManagerConstant.JSON_NCM_URI);
+        String ncm_id = (String)nodeJson.get(NodeManagerConstant.JSON_NCM_ID);
+        if (ncm_uri == null)
+            ncm_uri = NodeService.makeUpNcmUri(ip, NodeManagerConstant.GRPC_SERVER_PORT); // What does this port mean here?
+        if (ncm_id == null)
+            ncm_id = NodeService.makeUpNcmId(ip, NodeManagerConstant.GRPC_SERVER_PORT); // What does this port mean here?
         try {
-            node = new NodeInfo(id, id, ip, mac, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic);
+            node = new NodeInfo(id, id, ip, mac, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
             String message = "";
             if (node.validateIp(ip) == false)
                 message = NodeManagerConstant.NODE_EXCEPTION_IP_FORMAT_INVALID;

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/utils/NodeManagerConstant.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/utils/NodeManagerConstant.java
@@ -24,6 +24,8 @@ public class NodeManagerConstant {
     public static final String UNICAST_TOPIC = "unicast_topic";
     public static final String MULTICAST_TOPIC = "multicast_topic";
     public static final String GROUP_TOPIC = "group_topic";
+    public static final String JSON_NCM_URI = "ncm_uri";
+    public static final String JSON_NCM_ID = "ncm_id";
 
     //Exception Messages
     public static final String NODE_EXCEPTION_PARAMETER_NULL_EMPTY = "Parameter is null or empty";

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
@@ -149,7 +149,9 @@ public class NodeControllerTest extends MockIgniteServer {
         String strUnicastTopic = "unicast-topic-1";
         String strMulticastTopic = "multicast-topic-1";
         String strGroupTopic = "group-topic-1";
-        NodeInfo nodeInfo = new NodeInfo(strId, strName, strIp, strMac, strVeth, nServerPort, strUnicastTopic, strMulticastTopic, strGroupTopic);
+        String ncm_uri = NodeService.makeUpNcmUri(strIp, nServerPort);
+        String ncm_id = NodeService.makeUpNcmId(strIp, nServerPort);
+        NodeInfo nodeInfo = new NodeInfo(strId, strName, strIp, strMac, strVeth, nServerPort, strUnicastTopic, strMulticastTopic, strGroupTopic, ncm_uri, ncm_id);
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);
@@ -170,7 +172,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void test_createNodeInfo_invalidInput_ip() throws Exception {
         String ip = "10, 0, 0, 1";
-        NodeInfo nodeInfo = new NodeInfo("h01", "host1", ip, "AA-BB-CC-DD-EE-11", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
+        NodeInfo nodeInfo = new NodeInfo("h01", "host1", ip, "AA-BB-CC-DD-EE-11", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);
@@ -201,7 +203,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void updateNodeInfo_invalidInput() throws Exception {
         String ip = "10.0.0.2";
-        NodeInfo nodeInfo = new NodeInfo("h02", "host2", ip, "AA-BB-CC-DD-EE-22", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
+        NodeInfo nodeInfo = new NodeInfo("h02", "host2", ip, "AA-BB-CC-DD-EE-22", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);
@@ -243,7 +245,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void test_getNodeInfoByNodeId_invalidId() throws Exception {
         String ip = "10.0.0.3";
-        NodeInfo nodeInfo = new NodeInfo("h03", "host3", ip, "AA-BB-CC-03-03-03", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
+        NodeInfo nodeInfo = new NodeInfo("h03", "host3", ip, "AA-BB-CC-03-03-03", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
         String strNodeId = "       ";
         try {
             MvcResult result = this.mockMvc.perform(get("/nodes/" + strNodeId))

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
@@ -172,7 +172,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void test_createNodeInfo_invalidInput_ip() throws Exception {
         String ip = "10, 0, 0, 1";
-        NodeInfo nodeInfo = new NodeInfo("h01", "host1", ip, "AA-BB-CC-DD-EE-11", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
+        NodeInfo nodeInfo = new NodeInfo("h01", "host1", ip, "AA-BB-CC-DD-EE-11", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);
@@ -203,7 +203,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void updateNodeInfo_invalidInput() throws Exception {
         String ip = "10.0.0.2";
-        NodeInfo nodeInfo = new NodeInfo("h02", "host2", ip, "AA-BB-CC-DD-EE-22", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
+        NodeInfo nodeInfo = new NodeInfo("h02", "host2", ip, "AA-BB-CC-DD-EE-22", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);
@@ -245,7 +245,7 @@ public class NodeControllerTest extends MockIgniteServer {
     @Test
     public void test_getNodeInfoByNodeId_invalidId() throws Exception {
         String ip = "10.0.0.3";
-        NodeInfo nodeInfo = new NodeInfo("h03", "host3", ip, "AA-BB-CC-03-03-03", "unicast-topic-1", "multicast-topic-1", "group-topic-1", null, null);
+        NodeInfo nodeInfo = new NodeInfo("h03", "host3", ip, "AA-BB-CC-03-03-03", "unicast-topic-1", "multicast-topic-1", "group-topic-1");
         String strNodeId = "       ";
         try {
             MvcResult result = this.mockMvc.perform(get("/nodes/" + strNodeId))

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/NodeManagerProxy.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/NodeManagerProxy.java
@@ -78,7 +78,9 @@ public class NodeManagerProxy {
                 nodeInfos.get(0).getgRPCServerPort(),
                 nodeInfos.get(0).getUnicastTopic(),
                 nodeInfos.get(0).getMulticastTopic(),
-                nodeInfos.get(0).getGroupTopic()
+                nodeInfos.get(0).getGroupTopic(),
+                nodeInfos.get(0).getNcm_uri(),
+                nodeInfos.get(0).getNcm_id()
         );
 
         return new PortBindingHost(portEntity.getId(), node);

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
@@ -25,6 +25,8 @@ public class UnitTestConfig {
     public static String nodeUnicastTopic = "unicast-topic-1";
     public static String nodeMulticastTopic = "multicast-topic-1";
     public static String nodeGroupTopic = "group-topic-1";
+    public static String nodeNcmUri = "ncm/" + nodeLocalIp + "/" + String.valueOf(nodeGRPCServerPort);
+    public static String nodeNcmId = "ncm_" + nodeLocalIp + "_" + String.valueOf(nodeGRPCServerPort);
 
     public static String portId1 = "3d53801c-32ce-4e97-9572-bb966f4aa53e";
     public static String portId2 = "3d53801c-32ce-4e97-9572-bb966f4625ba";

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/controller/MockRestClientAndRepository.java
@@ -131,7 +131,9 @@ public class MockRestClientAndRepository {
                 UnitTestConfig.nodeGRPCServerPort,
                 UnitTestConfig.nodeUnicastTopic,
                 UnitTestConfig.nodeMulticastTopic,
-                UnitTestConfig.nodeGroupTopic
+                UnitTestConfig.nodeGroupTopic,
+                UnitTestConfig.nodeNcmUri,
+                UnitTestConfig.nodeNcmId
         );
         nodeInfos.add(nodeInfo);
         Mockito.when(nodeManagerRestClient.getNodeInfoByNodeName(anyString())).thenReturn(nodeInfos);

--- a/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
@@ -71,19 +71,19 @@ public class NodeInfo implements Serializable {
         this(nodeInfo.id, nodeInfo.name, nodeInfo.localIp, nodeInfo.macAddress, nodeInfo.veth, nodeInfo.gRPCServerPort, nodeInfo.hostDvrMac, nodeInfo.unicastTopic, nodeInfo.multicastTopic, nodeInfo.groupTopic, nodeInfo.ncm_uri, nodeInfo.ncm_id);
     }
 
-    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
-        this(id, name, localIp, macAddress, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
+    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic) {
+        this(id, name, localIp, macAddress, unicastTopic, multicastTopic, groupTopic);
         this.veth = veth;
         this.gRPCServerPort = gRPCServerPort;
     }
 
-    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
-        this(nodeId, nodeName, ipAddress, macAddress, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
+    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic) {
+        this(nodeId, nodeName, ipAddress, macAddress, unicastTopic, multicastTopic, groupTopic);
         this.veth = "";
         this.gRPCServerPort = gRPCServerPort;
     }
 
-    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, String unicastTopic, String multicastTopic, String groupTopic) {
         this.id = nodeId;
         this.name = nodeName;
         if (this.validateIp(ipAddress)) {
@@ -102,15 +102,27 @@ public class NodeInfo implements Serializable {
         this.unicastTopic = unicastTopic;
         this.multicastTopic = multicastTopic;
         this.groupTopic = groupTopic;
-        this.ncm_uri = ncm_uri;
-        this.ncm_id = ncm_id;
     }
 
-    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String host_dvr_mac, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
-        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
+    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String host_dvr_mac, String unicastTopic, String multicastTopic, String groupTopic) {
+        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic);
         this.hostDvrMac = host_dvr_mac;
     }
 
+    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String host_dvr_mac, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic);
+        this.hostDvrMac = host_dvr_mac;
+        this.ncm_uri = ncm_uri;
+        this.ncm_id = ncm_id;
+
+    }
+
+    public  NodeInfo(String id, String name, String localIp, String macAddress, String veth, int  gRPCServerPort,  String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic);
+        this.hostDvrMac = "";
+        this.ncm_uri = ncm_uri;
+        this.ncm_id = ncm_id;
+    }
     public boolean validateMac(String mac) {
         Pattern p = Pattern.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$");
         Matcher m = p.matcher(mac);

--- a/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
@@ -57,27 +57,33 @@ public class NodeInfo implements Serializable {
     @JsonProperty("group_topic")
     private String groupTopic;
 
+    @JsonProperty("ncm_uri")
+    private String ncm_uri;
+
+    @JsonProperty("ncm_id")
+    private String ncm_id;
+
     public NodeInfo() {
 
     }
 
     public NodeInfo(NodeInfo nodeInfo) {
-        this(nodeInfo.id, nodeInfo.name, nodeInfo.localIp, nodeInfo.macAddress, nodeInfo.veth, nodeInfo.gRPCServerPort, nodeInfo.hostDvrMac, nodeInfo.unicastTopic, nodeInfo.multicastTopic, nodeInfo.groupTopic);
+        this(nodeInfo.id, nodeInfo.name, nodeInfo.localIp, nodeInfo.macAddress, nodeInfo.veth, nodeInfo.gRPCServerPort, nodeInfo.hostDvrMac, nodeInfo.unicastTopic, nodeInfo.multicastTopic, nodeInfo.groupTopic, nodeInfo.ncm_uri, nodeInfo.ncm_id);
     }
 
-    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic) {
-        this(id, name, localIp, macAddress, unicastTopic, multicastTopic, groupTopic);
+    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+        this(id, name, localIp, macAddress, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
         this.veth = veth;
         this.gRPCServerPort = gRPCServerPort;
     }
 
-    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic) {
-        this(nodeId, nodeName, ipAddress, macAddress, unicastTopic, multicastTopic, groupTopic);
+    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+        this(nodeId, nodeName, ipAddress, macAddress, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
         this.veth = "";
         this.gRPCServerPort = gRPCServerPort;
     }
 
-    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, String unicastTopic, String multicastTopic, String groupTopic) {
+    public NodeInfo(String nodeId, String nodeName, String ipAddress, String macAddress, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
         this.id = nodeId;
         this.name = nodeName;
         if (this.validateIp(ipAddress)) {
@@ -96,10 +102,12 @@ public class NodeInfo implements Serializable {
         this.unicastTopic = unicastTopic;
         this.multicastTopic = multicastTopic;
         this.groupTopic = groupTopic;
+        this.ncm_uri = ncm_uri;
+        this.ncm_id = ncm_id;
     }
 
-    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String host_dvr_mac, String unicastTopic, String multicastTopic, String groupTopic) {
-        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic);
+    public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String host_dvr_mac, String unicastTopic, String multicastTopic, String groupTopic, String ncm_uri, String ncm_id) {
+        this(id, name, localIp, macAddress, veth, gRPCServerPort, unicastTopic, multicastTopic, groupTopic, ncm_uri, ncm_id);
         this.hostDvrMac = host_dvr_mac;
     }
 
@@ -186,4 +194,12 @@ public class NodeInfo implements Serializable {
     public String getGroupTopic() { return groupTopic; }
 
     public void setGroupTopic(String groupTopic) { this.groupTopic = groupTopic;  }
+
+    public String getNcmUri() { return ncm_uri; }
+
+    public void setNcmUri(String ncm_uri) { this.ncm_uri = ncm_uri; }
+
+    public String getNcmId() { return ncm_id; }
+
+    public void setNcmId(String ncm_id) { this.ncm_uri = ncm_id; }
 }


### PR DESCRIPTION
Orignally only ncm_uri was to be added but in a discussion with Liguang,
it became apparent that a "ncm_id" will be required and since adding it
elsewhere would require a join, it is added to NodeInfo.