### PR TITLE
[Schema] Support multiple same-type resources per host

### DIFF
--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -45,7 +45,16 @@ message GoalState {
 message GoalStateV2 {
     uint32 format_version = 1;
 
-    map<string /*host ip-ResourceType enum*/, string /*resource id*/> host_to_resource_id = 2;
+    message ResourceIdType{
+        ResourceType type = 1;
+        string id = 2;
+    }
+
+    message HostResources{
+        repeated ResourceIdType resources = 1;
+    }
+
+    map<string /*host ip*/, HostResources /*list of resources deployed to a target host*/> host_resources = 2;
     map<string /*resource id*/, VpcState> vpc_states = 3;
     map<string /*resource id*/, SubnetState> subnet_states = 4;
 

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -43,17 +43,17 @@ message GoalState {
     repeated GatewayState gateway_states = 9;
 }
 
+message ResourceIdType{
+    ResourceType type = 1;
+    string id = 2;
+}
+
+message HostResources{
+    repeated ResourceIdType resources = 1;
+}
+
 message GoalStateV2 {
     uint32 format_version = 1;
-
-    message ResourceIdType{
-        ResourceType type = 1;
-        string id = 2;
-    }
-
-    message HostResources{
-        repeated ResourceIdType resources = 1;
-    }
 
     map<string /*host ip*/, HostResources /*list of resources deployed to a target host*/> host_resources = 2;
     map<string /*resource id*/, VpcState> vpc_states = 3;

--- a/schema/proto3/goalstate.proto
+++ b/schema/proto3/goalstate.proto
@@ -20,6 +20,7 @@ package alcor.schema;
 
 option java_package = "com.futurewei.alcor.schema";
 
+import "common.proto";
 import "vpc.proto";
 import "subnet.proto";
 import "port.proto";

--- a/schema/proto3/router.proto
+++ b/schema/proto3/router.proto
@@ -39,7 +39,7 @@ message RouterConfiguration {
     message RoutingRuleExtraInfo{
         DestinationType destination_type = 1;
         string next_hop_mac = 2;
-        }
+    }
 
     message RoutingRule {
         OperationType operation_type = 1;


### PR DESCRIPTION
This PR provides a simple update of GoalState V2 schema to support multiple same-type resources per host.