### PR TITLE
[Node Metadata Mgr] Add NCM Id field to NodeInfo

### DIFF
--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/NodeService.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/NodeService.java
@@ -26,4 +26,8 @@ public interface NodeService {
     NodeInfo updateNodeInfo(String nodeId, NodeInfo nodeInfo) throws ParameterNullOrEmptyException, InvalidDataException, Exception;
 
     String deleteNodeInfo(String nodeId) throws ParameterNullOrEmptyException, Exception;
+ 
+    // TEMP: URI will be provided by the Admin but these are for testing purpose.
+    static String makeUpNcmId(String hostIP, int localPort) { return "ncm_" + hostIP + "_" + String.valueOf(localPort); }
+    static String makeUpNcmUri(String hostIP, int localPort) { return "ncm/" + hostIP + "/" + String.valueOf(localPort); }
 }

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeFileLoader.java
@@ -18,6 +18,7 @@ package com.futurewei.alcor.nodemanager.service.implement;
 
 import com.futurewei.alcor.common.stats.DurationStatistics;
 import com.futurewei.alcor.nodemanager.exception.InvalidDataException;
+import com.futurewei.alcor.nodemanager.service.NodeService;
 import com.futurewei.alcor.nodemanager.utils.NodeManagerConstant;
 import com.futurewei.alcor.web.entity.node.NodeInfo;
 import org.json.simple.JSONArray;
@@ -112,6 +113,10 @@ public class NodeFileLoader {
                 logger.error(strMethodName+NodeManagerConstant.NODE_EXCEPTION_IP_FORMAT_INVALID);
                 throw new InvalidDataException(NodeManagerConstant.NODE_EXCEPTION_IP_FORMAT_INVALID);
             }
+            String ncm_id = (String)nodeJson.get(NodeManagerConstant.JSON_NCM_ID);
+            if (ncm_id == null)
+                ncm_id = NodeService.makeUpNcmId(ip, NodeManagerConstant.GRPC_SERVER_PORT);
+            node.setNcmId(ncm_id);
         } catch (Exception e) {
             logger.error(strMethodName+e.getMessage());
             throw e;

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/utils/NodeManagerConstant.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/utils/NodeManagerConstant.java
@@ -24,6 +24,8 @@ public class NodeManagerConstant {
     public static final String UNICAST_TOPIC = "unicast_topic";
     public static final String MULTICAST_TOPIC = "multicast_topic";
     public static final String GROUP_TOPIC = "group_topic";
+    public static final String JSON_NCM_ID = "ncm_id";
+    public static final String JSON_NCM_URI = "ncm_uri";
 
     //Exception Messages
     public static final String NODE_EXCEPTION_PARAMETER_NULL_EMPTY = "Parameter is null or empty";

--- a/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
+++ b/services/node_manager/src/test/java/com/futurewei/alcor/nodemanager/controller/NodeControllerTest.java
@@ -150,6 +150,8 @@ public class NodeControllerTest extends MockIgniteServer {
         String strMulticastTopic = "multicast-topic-1";
         String strGroupTopic = "group-topic-1";
         NodeInfo nodeInfo = new NodeInfo(strId, strName, strIp, strMac, strVeth, nServerPort, strUnicastTopic, strMulticastTopic, strGroupTopic);
+        String ncm_id = NodeService.makeUpNcmId(strIp, nServerPort);
+        nodeInfo.setNcmId(ncm_id);
         NodeInfoJson nodeInfoJson = new NodeInfoJson(nodeInfo);
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(nodeInfoJson);

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/NodeManagerProxy.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/proxy/NodeManagerProxy.java
@@ -80,6 +80,7 @@ public class NodeManagerProxy {
                 nodeInfos.get(0).getMulticastTopic(),
                 nodeInfos.get(0).getGroupTopic()
         );
+        node.setNcmId(nodeInfos.get(0).getNcmId());
 
         return new PortBindingHost(portEntity.getId(), node);
     }

--- a/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
+++ b/services/port_manager/src/test/java/com/futurewei/alcor/portmanager/config/UnitTestConfig.java
@@ -25,6 +25,7 @@ public class UnitTestConfig {
     public static String nodeUnicastTopic = "unicast-topic-1";
     public static String nodeMulticastTopic = "multicast-topic-1";
     public static String nodeGroupTopic = "group-topic-1";
+    public static String nodeNcmId = "ncm_10_213_43_161_0";
 
     public static String portId1 = "3d53801c-32ce-4e97-9572-bb966f4aa53e";
     public static String portId2 = "3d53801c-32ce-4e97-9572-bb966f4625ba";

--- a/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
@@ -57,7 +57,8 @@ public class NodeInfo implements Serializable {
     @JsonProperty("group_topic")
     private String groupTopic;
 
-    // add ncm here
+    @JsonProperty("ncm_id")
+    private String ncm_id;
 
     public NodeInfo() {
 
@@ -65,6 +66,7 @@ public class NodeInfo implements Serializable {
 
     public NodeInfo(NodeInfo nodeInfo) {
         this(nodeInfo.id, nodeInfo.name, nodeInfo.localIp, nodeInfo.macAddress, nodeInfo.veth, nodeInfo.gRPCServerPort, nodeInfo.hostDvrMac, nodeInfo.unicastTopic, nodeInfo.multicastTopic, nodeInfo.groupTopic);
+        this.ncm_id = nodeInfo.ncm_id;
     }
 
     public NodeInfo(String id, String name, String localIp, String macAddress, String veth, int gRPCServerPort, String unicastTopic, String multicastTopic, String groupTopic) {
@@ -188,4 +190,8 @@ public class NodeInfo implements Serializable {
     public String getGroupTopic() { return groupTopic; }
 
     public void setGroupTopic(String groupTopic) { this.groupTopic = groupTopic;  }
+
+    public String getNcmId() { return ncm_id; }
+
+    public void setNcmId(String ncm_id) { this.ncm_id = ncm_id; }
 }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/node/NodeInfo.java
@@ -57,6 +57,8 @@ public class NodeInfo implements Serializable {
     @JsonProperty("group_topic")
     private String groupTopic;
 
+    // add ncm here
+
     public NodeInfo() {
 
     }


### PR DESCRIPTION
NMM changes - part 1
* Add ncm_id to NodeInfo.
* Use setNcmId method to set the ncm_id after creating NodeInfo because
otherwise calls to overloaded constructors are resolving to incorrect
ones, or resulting in errors such as constructor is already defined, or
can't resolve constructor.
