### PR TITLE
[Data-Plane Mgr] Fix missing subnet entity in multicast GoalState

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/client/grpc/DataPlaneClientImpl.java
@@ -96,6 +96,7 @@ public class DataPlaneClientImpl implements DataPlaneClient {
             Future<UnicastGoalState> future =
                     executor.submit(() -> {
                 try {
+                    LOG.debug(unicastGoalState.getGoalState().toString());
                     sendGoalState(unicastGoalState);
                 } catch (InterruptedException e) {
                     e.printStackTrace();

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DpmServiceImpl.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DpmServiceImpl.java
@@ -108,7 +108,7 @@ public class DpmServiceImpl implements DpmService {
         }
 
         vpcService.buildVpcStates(networkConfig, unicastGoalState);
-        subnetService.buildSubnetStates(networkConfig, unicastGoalState);
+        subnetService.buildSubnetStates(networkConfig, unicastGoalState, multicastGoalState);
         neighborService.buildNeighborStates(networkConfig, hostIp, unicastGoalState, multicastGoalState);
         securityGroupService.buildSecurityGroupStates(networkConfig, unicastGoalState);
         dhcpService.buildDhcpStates(networkConfig, unicastGoalState);

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/SubnetService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/SubnetService.java
@@ -15,6 +15,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 package com.futurewei.alcor.dataplane.service.impl;
 
+import com.futurewei.alcor.dataplane.entity.MulticastGoalState;
 import com.futurewei.alcor.dataplane.entity.UnicastGoalState;
 import com.futurewei.alcor.dataplane.exception.SubnetEntityNotFound;
 import com.futurewei.alcor.schema.Common;
@@ -44,7 +45,7 @@ public class SubnetService extends ResourceService {
         return result;
     }
 
-    public void buildSubnetStates(NetworkConfiguration networkConfig, UnicastGoalState unicastGoalState) throws Exception {
+    public void buildSubnetStates(NetworkConfiguration networkConfig, UnicastGoalState unicastGoalState, MulticastGoalState multicastGoalState) throws Exception {
         List<Port.PortState> portStates = unicastGoalState.getGoalStateBuilder().getPortStatesList();
         if (portStates == null || portStates.size() == 0) {
             return;
@@ -88,6 +89,7 @@ public class SubnetService extends ResourceService {
             subnetStateBuilder.setOperationType(Common.OperationType.INFO);
             subnetStateBuilder.setConfiguration(subnetConfigBuilder.build());
             unicastGoalState.getGoalStateBuilder().addSubnetStates(subnetStateBuilder.build());
+            multicastGoalState.getGoalStateBuilder().addSubnetStates(subnetStateBuilder.build());
         }
     }
 }


### PR DESCRIPTION
__Bug Description__

Each port creation generates one unicast GS and one multicast GS. In current implementation, multicast GS only includes neighbor states while lacks of corresponding subnet states. This causes ACA failure to look up neighbor.

This PR proposes a simple fix to add those missing subnet entities, and enable debug-level logging to show GS detail before sending it to ACA.