### PR TITLE
[Data Plane Mgr] Add device id and owner in PortService

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/PortService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/PortService.java
@@ -39,6 +39,9 @@ public class PortService extends ResourceService {
                 portConfigBuilder.setName(portEntity.getName());
             }
 
+            portConfigBuilder.setDeviceId(portEntity.getDeviceId());
+            portConfigBuilder.setDeviceOwner(portEntity.getDeviceOwner());
+
             portConfigBuilder.setMacAddress(portEntity.getMacAddress());
             boolean adminState = portEntity.getAdminStateUp() == null ? false : portEntity.getAdminStateUp();
             portConfigBuilder.setAdminStateUp(adminState);


### PR DESCRIPTION
This PR fixes two missing fields in PortService at DPM so that we could support port creation and port deletion. 

Tracking issue: #103 