### PR TITLE
[Network Config Mgr] Add NodeInfo APIs

### DIFF
--- a/scripts/json/updateNode.json
+++ b/scripts/json/updateNode.json
@@ -1,0 +1,11 @@
+{
+  "host_info": {
+    "node_id" : "9192a4d4-ffff-4ece-b3f0-8d36e3d85002",
+    "local_ip": "10.213.43.161",
+    "mac_address": "90:17:ac:c1:34:64",
+    "node_name": "node2",
+    "server_port": 8080,
+    "veth": "eth0",
+    "host_dvr_mac": "74-70-FD-73-09-07"
+  }
+}

--- a/scripts/test/ncmtest.sh
+++ b/scripts/test/ncmtest.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+# Expect to fail
+echo "DELETE Existing node"
+curl -X DELETE -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+echo "GET from empty cache"
+curl -X GET -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+echo "POST, new node"
+curl -X POST -H "Content-Type: application/json" --data @../json/createNode.json http://localhost:9014/nodes
+echo "GET it back"
+curl -X GET -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+echo "DELETE again node"
+curl -X DELETE -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+
+# Expect to fail
+echo "GET All from empty cache"
+curl -X GET -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+echo "POST, again"
+curl -X POST -H "Content-Type: application/json" --data @../json/createNode.json http://localhost:9014/nodes
+echo "GET it back"
+curl -X GET -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002
+echo "Update it"
+curl -X PUT -H "Content-Type: application/json" --data @../json/updateNode.json http://localhost:9014/nodes
+echo "host_dvr_mac should not be null"
+curl -X GET -H "Content-Type: application/json" http://localhost:9014/nodes/9192a4d4-ffff-4ece-b3f0-8d36e3d85002

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/cache/NodeInfoCache.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/cache/NodeInfoCache.java
@@ -1,0 +1,66 @@
+package com.futurewei.alcor.netwconfigmanager.cache;
+
+import com.futurewei.alcor.common.db.CacheFactory;
+import com.futurewei.alcor.common.db.ICache;
+import com.futurewei.alcor.common.db.repo.ICacheRepository;
+import com.futurewei.alcor.common.logging.Logger;
+import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
+import com.futurewei.alcor.common.utils.SpringContextUtil;
+import com.futurewei.alcor.web.entity.node.NodeInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+/**
+ * NodeInfo maintained by NCM. Validation is not necessary since NMM/DPM will have
+ * already done all the validation
+ */
+@Repository
+@ComponentScan(value = "com.futurewei.alcor.common.db")
+public class NodeInfoCache {
+    private ICache<String, NodeInfo> nodeInfoCache;
+    private static final Logger LOG = LoggerFactory.getLogger();
+
+    @Autowired
+    public NodeInfoCache(CacheFactory cacheFactory) {
+        nodeInfoCache = cacheFactory.getCache(NodeInfo.class);
+    }
+
+    @DurationStatistics
+    public NodeInfo getNodeInfo(String nodeId) throws Exception {
+        NodeInfo nodeInfo = nodeInfoCache.get(nodeId);
+
+        return nodeInfo;
+    }
+
+
+    @DurationStatistics
+    public void addNodeInfo(NodeInfo nodeInfo) throws Exception {
+        nodeInfoCache.put(nodeInfo.getId(), nodeInfo);
+    }
+
+    @DurationStatistics
+    public void addNodeInfoBulk(List<NodeInfo> nodeInfos) throws Exception {
+        Map<String, NodeInfo> nodeInfoMap = nodeInfos.stream().collect(Collectors.toMap(NodeInfo::getId, Function.identity()));
+        nodeInfoCache.putAll(nodeInfoMap);
+    }
+
+    @DurationStatistics
+    public void updateNodeInfo(NodeInfo nodeInfo) throws Exception {
+        nodeInfoCache.put(nodeInfo.getId(), nodeInfo);
+    }
+
+    @DurationStatistics
+    public void deleteNodeInfo(String nodeId) throws Exception {
+        nodeInfoCache.remove(nodeId);
+    }
+}

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/controller/NetworkConfigController.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/controller/NetworkConfigController.java
@@ -1,4 +1,112 @@
 package com.futurewei.alcor.netwconfigmanager.controller;
 
+import com.futurewei.alcor.common.exception.ParameterNullOrEmptyException;
+import com.futurewei.alcor.common.logging.Logger;
+import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.common.stats.DurationStatistics;
+import com.futurewei.alcor.common.utils.RestPreconditionsUtil;
+import com.futurewei.alcor.netwconfigmanager.service.NodeService;
+import com.futurewei.alcor.netwconfigmanager.util.Constants;
+import com.futurewei.alcor.web.entity.node.BulkNodeInfoJson;
+import com.futurewei.alcor.web.entity.node.NodeInfo;
+import com.futurewei.alcor.web.entity.node.NodeInfoJson;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+import java.util.List;
+import java.util.logging.Level;
+
+@RestController
+@ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class NetworkConfigController {
+    private static final Logger LOG = LoggerFactory.getLogger();
+
+    @Autowired
+    private NodeService nodeService;
+    @Autowired
+    private HttpServletRequest request;
+    @RequestMapping(
+        method = POST,
+        value = {"/nodes", "/v4/nodes"})
+    @ResponseStatus(HttpStatus.CREATED)
+    @DurationStatistics
+    public void createNodeInfo(@RequestBody NodeInfoJson nodeInfoJson) throws Exception {
+        try {
+            NodeInfo nodeInfo = nodeInfoJson.getNodeInfo();
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(nodeInfo);
+            nodeService.createNodeInfo(nodeInfoJson);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE,e.getMessage());
+            throw e;
+        }
+    }
+
+    @RequestMapping(
+        method = POST,
+        value = {"/nodes/bulk", "/v4/nodes/bulk"})
+    @DurationStatistics
+    public void createNodesInfoBulk(@RequestBody BulkNodeInfoJson bulkNodeInfoJson) throws Exception {
+        if (bulkNodeInfoJson == null) {
+            // Perhaps, this belongs in the common.
+            throw new ParameterNullOrEmptyException(Constants.NODE_EXCEPTION_JSON_EMPTY);
+        }
+        try {
+            nodeService.createNodeInfoBulk(bulkNodeInfoJson);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE,e.getMessage());
+            throw e;
+        }
+    }
+
+    @RequestMapping(
+        method = PUT,
+        value = {"/nodes", "/v4/nodes"})
+    @DurationStatistics
+    public void updateNodeInfo(@RequestBody NodeInfoJson nodeInfoJson) throws Exception {
+        try {
+            NodeInfo nodeInfo = nodeInfoJson.getNodeInfo();
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(nodeInfo);
+            nodeService.updateNodeInfo(nodeInfo);
+        } catch (ParameterNullOrEmptyException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new Exception(e);
+        }
+    }
+
+    @RequestMapping(
+        method = DELETE,
+        value = {"/nodes/{nodeid}", "/v4/nodes/{nodeid}"})
+    @DurationStatistics
+    public void deleteNodeInfo(@PathVariable String nodeid) throws Exception {
+        try {
+            nodeService.deleteNodeInfo(nodeid);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE,e.getMessage());
+            throw e;
+        }
+    }
+
+    @RequestMapping(
+        method = GET,
+        value = {"/nodes/{nodeid}", "/v4/nodes/{nodeid}"})
+    @DurationStatistics
+    public NodeInfoJson getNodeInfoById(@PathVariable String nodeid) throws Exception {
+        NodeInfo hostInfo = null;
+        try {
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(nodeid);
+            hostInfo = nodeService.getNodeInfo(nodeid);
+        } catch (ParameterNullOrEmptyException e) {
+            throw new Exception(e);
+        }
+        if (hostInfo == null) {
+            return new NodeInfoJson();
+        }
+        return new NodeInfoJson(hostInfo);
+    }
 }

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/NodeService.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/NodeService.java
@@ -1,0 +1,20 @@
+package com.futurewei.alcor.netwconfigmanager.service;
+
+import com.futurewei.alcor.web.entity.node.BulkNodeInfoJson;
+import com.futurewei.alcor.web.entity.node.NodeInfo;
+import com.futurewei.alcor.web.entity.node.NodeInfoJson;
+
+import java.util.List;
+
+public interface NodeService {
+
+    void createNodeInfo(NodeInfoJson nodeInfoJson) throws Exception;
+
+    void updateNodeInfo(NodeInfo nodeInfo) throws Exception;
+
+    void deleteNodeInfo(String nodeId) throws Exception;
+
+    void createNodeInfoBulk(BulkNodeInfoJson bulkNodeInfoJson) throws Exception;
+
+    NodeInfo getNodeInfo(String nodeId) throws Exception;
+}

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/impl/NodeServiceImpl.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/impl/NodeServiceImpl.java
@@ -1,0 +1,52 @@
+package com.futurewei.alcor.netwconfigmanager.service.impl;
+
+import com.futurewei.alcor.common.logging.Logger;
+import com.futurewei.alcor.common.logging.LoggerFactory;
+import com.futurewei.alcor.netwconfigmanager.cache.NodeInfoCache;
+import com.futurewei.alcor.netwconfigmanager.service.NodeService;
+import com.futurewei.alcor.web.entity.node.BulkNodeInfoJson;
+import com.futurewei.alcor.web.entity.node.NodeInfo;
+import com.futurewei.alcor.web.entity.node.NodeInfoJson;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * DPM, NMM and now NCM all are holding onto NodeInfo, by making copy of the code
+ * instead of sharing. Let this get working first and the re-factor as much as possible into
+ * common as shared module/package.
+ */
+@Service
+public class NodeServiceImpl implements NodeService {
+    private static final Logger LOG = LoggerFactory.getLogger();
+    @Autowired
+    private NodeInfoCache nodeInfoCache;
+
+    @Override
+    public void createNodeInfo(NodeInfoJson nodeInfoJson) throws Exception {
+        nodeInfoCache.addNodeInfo(nodeInfoJson.getNodeInfo());
+    }
+
+    @Override
+    public void updateNodeInfo(NodeInfo nodeInfo) throws Exception {
+        nodeInfoCache.updateNodeInfo(nodeInfo);
+    }
+
+    @Override
+    public void deleteNodeInfo(String nodeId) throws Exception {
+        nodeInfoCache.deleteNodeInfo(nodeId);
+    }
+
+    @Override
+    public void createNodeInfoBulk(BulkNodeInfoJson bulkNodeInfoJson) throws Exception {
+        List<NodeInfo> nodeInfos = bulkNodeInfoJson.getNodeInfos();
+        nodeInfoCache.addNodeInfoBulk(nodeInfos);
+    }
+
+    @Override
+    public NodeInfo getNodeInfo(String nodeId) throws Exception {
+        return nodeInfoCache.getNodeInfo(nodeId);
+    }
+}

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/util/Constants.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/util/Constants.java
@@ -1,0 +1,5 @@
+package com.futurewei.alcor.netwconfigmanager.util;
+
+public class Constants {
+        public final static String NODE_EXCEPTION_JSON_EMPTY = "Empty JSON object";
+}


### PR DESCRIPTION
* NCM has API to create, delete, update nodeinfo in NCM.
* Bulk API is not tested. 
* NCM needs to have a rest client for NMM to push NodeInfo into NCM and it will come in the next commit.