### PR TITLE
[Data-Plane Mgr] Fix Port Operation Type Mismatch Issue

### DIFF
--- a/kubernetes/services/dpm_manager.yaml
+++ b/kubernetes/services/dpm_manager.yaml
@@ -18,7 +18,7 @@ data:
 
     #logging.file.path=./
     #logging.file.name=data-plane-manager.log
-    #logging.level.root=INFO
+    logging.level.root=DEBUG
 
     ignite.host=ignite-alcor-service.ignite-alcor.svc.cluster.local
     ignite.port=10800

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DpmController.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/controller/DpmController.java
@@ -52,6 +52,8 @@ public class DpmController {
         OperationType opType = networkConfiguration.getOpType();
         if (OperationType.UPDATE.equals(opType)) {
             return dpmService.updateNetworkConfiguration(networkConfiguration);
+        } else if (OperationType.CREATE.equals(opType)) {
+            return dpmService.createNetworkConfiguration(networkConfiguration);
         } else if (OperationType.DELETE.equals(opType)) {
             return this.deleteNetworkConfiguration(networkConfiguration);
         }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DhcpService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/DhcpService.java
@@ -46,7 +46,7 @@ public class DhcpService extends ResourceService {
                 //dhcpConfigBuilder.setDnsEntryList();
 
                 DHCP.DHCPState.Builder dhcpStateBuilder = DHCP.DHCPState.newBuilder();
-                dhcpStateBuilder.setOperationType(networkConfig.getOpType());
+                dhcpStateBuilder.setOperationType(portState.getOperationType());
                 dhcpStateBuilder.setConfiguration(dhcpConfigBuilder.build());
                 unicastGoalState.getGoalStateBuilder().addDhcpStates(dhcpStateBuilder.build());
             }

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/PortService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/PortService.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.schema.Common;
 import com.futurewei.alcor.schema.Port;
 import com.futurewei.alcor.web.entity.dataplane.InternalPortEntity;
 import com.futurewei.alcor.web.entity.dataplane.v2.NetworkConfiguration;
+import com.google.common.base.Strings;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.List;
 public class PortService extends ResourceService {
     public void buildPortState(NetworkConfiguration networkConfig, List<InternalPortEntity> portEntities,
                                UnicastGoalState unicastGoalState) {
-        for (InternalPortEntity portEntity: portEntities) {
+        for (InternalPortEntity portEntity : portEntities) {
             Port.PortConfiguration.Builder portConfigBuilder = Port.PortConfiguration.newBuilder();
             portConfigBuilder.setRevisionNumber(FORMAT_REVISION_NUMBER);
             portConfigBuilder.setId(portEntity.getId());
@@ -70,7 +71,7 @@ public class PortService extends ResourceService {
             }
 
             if (portEntity.getSecurityGroups() != null) {
-                portEntity.getSecurityGroups().forEach(securityGroupId-> {
+                portEntity.getSecurityGroups().forEach(securityGroupId -> {
                     Port.PortConfiguration.SecurityGroupId.Builder securityGroupIdBuilder = Port.PortConfiguration.SecurityGroupId.newBuilder();
                     securityGroupIdBuilder.setId(securityGroupId);
                     portConfigBuilder.addSecurityGroupIds(securityGroupIdBuilder.build());
@@ -79,9 +80,27 @@ public class PortService extends ResourceService {
 
             //PortState
             Port.PortState.Builder portStateBuilder = Port.PortState.newBuilder();
-            portStateBuilder.setOperationType(networkConfig.getOpType());
+            Common.OperationType portOpTypeToACA = determinePortOperationType(portEntity, networkConfig.getOpType());
+            portStateBuilder.setOperationType(portOpTypeToACA);
             portStateBuilder.setConfiguration(portConfigBuilder.build());
             unicastGoalState.getGoalStateBuilder().addPortStates(portStateBuilder.build());
         }
+    }
+
+    private Common.OperationType determinePortOperationType(InternalPortEntity portEntity, Common.OperationType operationTypeFromClient) {
+
+        // This is a temporary fix to address Issue #103.
+        // TODO:
+        //  1. Network configuration entity needs to include a resource-level operation type, not on message level
+        //  2. PM determines the operation type for port
+        if (operationTypeFromClient == Common.OperationType.UPDATE) {
+            if (!Strings.isNullOrEmpty(portEntity.getDeviceId()) && !Strings.isNullOrEmpty(portEntity.getDeviceOwner())) {
+                return Common.OperationType.CREATE;
+            } else if (Strings.isNullOrEmpty(portEntity.getDeviceId()) && Strings.isNullOrEmpty(portEntity.getDeviceOwner())) {
+                return Common.OperationType.DELETE;
+            }
+        }
+
+        return operationTypeFromClient;
     }
 }

--- a/services/data_plane_manager/src/main/resources/application.properties
+++ b/services/data_plane_manager/src/main/resources/application.properties
@@ -16,7 +16,7 @@ protobuf.goal-state-message.version = 102
 #####Logging configuration#####
 #logging.file.path=./
 #logging.file.name=data-plane-manager.log
-#logging.level.root=INFO
+logging.level.root=DEBUG
 
 #####Ignite configuration######
 ignite.host=localhost


### PR DESCRIPTION
This PR proposes temporary fix for the following scenarios:
- Nova sends port update operation with nonempty device_id and device_owner (of value compute:nova). This request should be treated as CREATE from Alcor perspective.
- Nova sends port update operation with empty device_id and device_owner. This request should be treated as DELETE (tracked by Issue #103).

The ultimate fix should be in Port Manager as the resource owner. We proposes this fix as a short-term solution to verify E2E success.