### PR TITLE
[Deploment] Add DPM service URL in NMM yaml file

### DIFF
--- a/kubernetes/services/node_manager.yaml
+++ b/kubernetes/services/node_manager.yaml
@@ -18,8 +18,8 @@ data:
     spring.servlet.multipart.file-size-threshold=2KB
     spring.servlet.multipart.max-file-size=200MB
     spring.servlet.multipart.max-request-size=215MB
-    microservices.dataplane.service.url=http://localhost:9010/network-configuration
-    microservices.dataplane.nodeservice.url=http://localhost:9010/nodes
+    microservices.dataplane.service.url=http://dataplanemanager-service.default.svc.cluster.local:9010/network-configuration
+    microservices.dataplane.nodeservice.url=http://dataplanemanager-service.default.svc.cluster.local:9010/nodes
 
 ---
 apiVersion: apps/v1

--- a/kubernetes/services/node_manager.yaml
+++ b/kubernetes/services/node_manager.yaml
@@ -18,8 +18,8 @@ data:
     spring.servlet.multipart.file-size-threshold=2KB
     spring.servlet.multipart.max-file-size=200MB
     spring.servlet.multipart.max-request-size=215MB
-    microservices.dataplane.service.url=http://dataplanemanager-service.default.svc.cluster.local:9010/network-configuration
-    microservices.dataplane.nodeservice.url=http://dataplanemanager-service.default.svc.cluster.local:9010/nodes
+    microservices.dataplane.service.url=http://dataplanemanager-service.default.svc.cluster.local:30010/network-configuration
+    microservices.dataplane.nodeservice.url=http://dataplanemanager-service.default.svc.cluster.local:30010/nodes
 
 ---
 apiVersion: apps/v1

--- a/kubernetes/services/node_manager.yaml
+++ b/kubernetes/services/node_manager.yaml
@@ -18,6 +18,8 @@ data:
     spring.servlet.multipart.file-size-threshold=2KB
     spring.servlet.multipart.max-file-size=200MB
     spring.servlet.multipart.max-request-size=215MB
+    microservices.dataplane.service.url=http://localhost:9010/network-configuration
+    microservices.dataplane.nodeservice.url=http://localhost:9010/nodes
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
The service URL was missing in node manager's kubernetes configuration. This PR adds the two missing URL.