### PR TITLE
[Port Mgr] Support multiple ResourceOperation types

### DIFF
--- a/lib/src/main/java/com/futurewei/alcor/common/utils/CommonUtil.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/utils/CommonUtil.java
@@ -90,4 +90,13 @@ public class CommonUtil {
                     }
                 }).toArray(String[]::new);
     }
+
+    /**
+     * Determine if a given string is empty or null
+     * @param an input string
+     * @return a boolean value, true if null or empty
+     */
+    public static boolean isNullOrEmpty(String string) {
+        return string == null || string.trim().isEmpty();
+    }
 }

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -229,6 +229,16 @@ public class DataPlaneProcessor extends AbstractProcessor {
 
     }
 
+    private List<ResourceOperation> setResourceOperationTypes() {
+        List<ResourceOperation> resourceOperationTypes = new ArrayList<>();
+        resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.PORT, Common.OperationType.CREATE));
+        resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.NEIGHBOR, Common.OperationType.CREATE));
+        resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.SECURITYGROUP, Common.OperationType.CREATE));
+        resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.ROUTER, Common.OperationType.CREATE));
+
+        return resourceOperationTypes;
+    }
+
     private NetworkConfiguration buildNetworkConfig(PortContext context, List<PortEntity> portEntities) throws Exception {
         /**
          DataPlaneProcessor needs to wait for all previous Processor runs to
@@ -245,9 +255,11 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         setTheMissingFields(context, portEntities);
+        List<ResourceOperation> resourceOperationTypes = setResourceOperationTypes();
 
         NetworkConfiguration networkConfiguration = new NetworkConfiguration();
         networkConfiguration.setRsType(Common.ResourceType.PORT);
+        networkConfiguration.setRsOpTypes(resourceOperationTypes);
         networkConfiguration.setVpcs(networkConfig.getVpcEntities());
         networkConfiguration.setSubnets(networkConfig.getSubnetEntities());
         networkConfiguration.setSecurityGroups(networkConfig.getSecurityGroups());
@@ -267,8 +279,8 @@ public class DataPlaneProcessor extends AbstractProcessor {
             networkConfig.setOpType(Common.OperationType.CREATE);
             IRestRequest createNetworkConfigRequest =
                     new CreateNetworkConfigRequest(context, networkConfig);
-            context.getRequestManager().sendRequestAsync(createNetworkConfigRequest, request -> portService.updatePortStatus(request,networkConfig,null));
-            portService.updatePortStatus(createNetworkConfigRequest,networkConfig, StatusEnum.CREATED.getStatus());
+            context.getRequestManager().sendRequestAsync(createNetworkConfigRequest, request -> portService.updatePortStatus(request, networkConfig, null));
+            portService.updatePortStatus(createNetworkConfigRequest, networkConfig, StatusEnum.CREATED.getStatus());
         }
     }
 
@@ -278,8 +290,8 @@ public class DataPlaneProcessor extends AbstractProcessor {
             networkConfig.setOpType(Common.OperationType.UPDATE);
             IRestRequest updateNetworkConfigRequest =
                     new UpdateNetworkConfigRequest(context, networkConfig);
-            context.getRequestManager().sendRequestAsync(updateNetworkConfigRequest, request -> portService.updatePortStatus(request,networkConfig,null));
-            portService.updatePortStatus(updateNetworkConfigRequest,networkConfig, StatusEnum.PENDING.getStatus());
+            context.getRequestManager().sendRequestAsync(updateNetworkConfigRequest, request -> portService.updatePortStatus(request, networkConfig, null));
+            portService.updatePortStatus(updateNetworkConfigRequest, networkConfig, StatusEnum.PENDING.getStatus());
         }
     }
 

--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/PortContext.java
@@ -175,6 +175,14 @@ public class PortContext {
         return (this.routers != null) ? this.routers.get(vpcOrSubnetId) : null;
     }
 
+    public boolean containRouters() {
+        if (this.routers == null || this.routers.isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
+
     public void setRouters(Map<String, InternalRouterInfo> routers) {
         this.routers = routers;
     }

--- a/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/ResourceOperation.java
+++ b/web/src/main/java/com/futurewei/alcor/web/entity/dataplane/ResourceOperation.java
@@ -31,6 +31,11 @@ public class ResourceOperation {
     public ResourceOperation() {
     }
 
+    public ResourceOperation(ResourceType rsType, OperationType opType) {
+        this.rsType = rsType;
+        this.opType = opType;
+    }
+
     public ResourceType getRsType() {
         return this.rsType;
     }
@@ -43,12 +48,7 @@ public class ResourceOperation {
         return this.opType;
     }
 
-    public void setHostId(OperationType opType) {
-        this.opType = opType;
-    }
-
-    public ResourceOperation(ResourceType rsType, OperationType opType) {
-        this.rsType = rsType;
+    public void setOpType(OperationType opType) {
         this.opType = opType;
     }
 }


### PR DESCRIPTION
In PR #602, a new ResourceOperationType field was added in NetworkConfiguration. This PR sets the value of ResourceOperationTypes when building network configuration and passes down to DPM. 