### PR TITLE
Transaction Atomicity Mode changes [DO NOT MERGE YET]

### DIFF
--- a/config/ignite-config.xml
+++ b/config/ignite-config.xml
@@ -36,5 +36,28 @@ Copyright(c) 2020 Futurewei Cloud
       </property>
     </bean>
   </property>
+
+  <property name="cacheConfiguration">
+    <list>
+      <bean class="org.apache.ignite.configuration.CacheConfiguration">
+        <!-- Set the cache name. -->
+        <property name="name" value="dpm_nodeinfo_cache"/>
+        <!-- Set the cache mode. -->
+        <property name="atomicityMode" value="TRANSACTIONAL"/>
+        <!-- Other cache parameters. -->
+        <property name="cacheMode" value="PARTITIONED"/>
+      </bean>
+
+      <bean class="org.apache.ignite.configuration.CacheConfiguration">
+        <!-- Set the cache name. -->
+        <property name="name" value="ncm_nodeinfo_cache"/>
+        <!-- Set the cache mode. -->
+        <property name="atomicityMode" value="TRANSACTIONAL"/>
+        <!-- Other cache parameters. -->
+        <property name="cacheMode" value="PARTITIONED"/>
+      </bean>
+    </list>
+  </property>
+
 </bean>
 </beans>

--- a/legacy/src/com/futurewei/alcor/controller/db/ignite/IgniteCache.java
+++ b/legacy/src/com/futurewei/alcor/controller/db/ignite/IgniteCache.java
@@ -46,6 +46,7 @@ public class IgniteCache<K, V> implements ICache<K, V> {
 
         try {
             cache = igniteClient.getOrCreateCache(name);
+            logger.log(Level.INFO, "Cache " + name + " AtomicityMode is " + cache.getConfiguration().getAtomicityMode());
         } catch (ClientException e) {
             logger.log(Level.WARNING, "Create cache for vpc failed:" + e.getMessage());
         } catch (Exception e) {

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDbCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDbCache.java
@@ -52,6 +52,7 @@ public class IgniteClientDbCache<K, V> implements IgniteICache<K, V> {
     public IgniteClientDbCache(IgniteClient igniteClient, String name) {
         try {
             this.cache = igniteClient.getOrCreateCache(name);
+            logger.log(Level.INFO, "Cache " + name + " AtomicityMode is " + this.cache.getConfiguration().getAtomicityMode());
         } catch (ClientException e) {
             logger.log(Level.WARNING, "Create cache for client " + name + " failed:" + e.getMessage());
         }
@@ -63,6 +64,7 @@ public class IgniteClientDbCache<K, V> implements IgniteICache<K, V> {
     public IgniteClientDbCache(IgniteClient igniteClient, String name, ExpiryPolicy ep) {
         try {
             this.cache = igniteClient.getOrCreateCache(name).withExpirePolicy(ep);
+            logger.log(Level.INFO, "Cache " + name + " AtomicityMode is " + this.cache.getConfiguration().getAtomicityMode());
         } catch (ClientException e) {
             logger.log(Level.WARNING, "Create cache for client " + name + " failed:" + e.getMessage());
         }

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDistributedLock.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteClientDistributedLock.java
@@ -50,6 +50,7 @@ public class IgniteClientDistributedLock implements IDistributedLock {
             cfg.setName(name);
             cfg.setExpiryPolicy(ep);
             cache = igniteClient.getOrCreateCache(cfg);
+            logger.log(Level.INFO, "Cache " + name + " AtomicityMode is " + cache.getConfiguration().getAtomicityMode());
             this.tryInterval = tryInterval;
         } catch (ClientException e) {
             logger.log(Level.WARNING, "Create distributed lock cache failed:" + e.getMessage());

--- a/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/db/ignite/IgniteDbCache.java
@@ -57,6 +57,7 @@ public class IgniteDbCache<K, V> implements IgniteICache<K, V> {
         try {
             this.cache = ignite.getOrCreateCache(name);
         } catch (javax.cache.CacheException e) {
+            this.cache = ignite.getOrCreateCache(name);
             logger.log(Level.WARNING, "Create cache for client " + name + " failed:" + e.getMessage());
         } catch (Exception e) {
             logger.log(Level.WARNING, "Unexpected failure:" + e.getMessage());

--- a/lib/src/main/java/com/futurewei/alcor/common/service/IgniteCache.java
+++ b/lib/src/main/java/com/futurewei/alcor/common/service/IgniteCache.java
@@ -45,6 +45,7 @@ public class IgniteCache<K, V> implements ICache<K, V> {
 
         try {
             cache = igniteClient.getOrCreateCache(name);
+            logger.log(Level.INFO, "Cache " + name + " AtomicityMode is " + cache.getConfiguration().getAtomicityMode());
         } catch (ClientException e) {
             logger.log(Level.WARNING, "Create cache for vpc failed:" + e.getMessage());
         } catch (Exception e) {


### PR DESCRIPTION
The current cache operations are not transactional. Individual
put, delete operation either succeeds or fails by itself. If one such
operation succeeds but something else fails later, the previous
operation will have to be manually rolled back.

Same logic applies when operation on more than one cache has to be all
or nothing.

This change applies atomicity mode of TRANSACTIONAL to DPM and NCM
caches. Others will follow.

NOTE: For this have any effect, either the ignite cluster, or DPM and
NCM caches will have to be stopped and restarted.