### PR TITLE
[Port Mgr] Fix router resource operation type

### DIFF
--- a/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
+++ b/services/port_manager/src/main/java/com/futurewei/alcor/portmanager/processor/DataPlaneProcessor.java
@@ -244,7 +244,7 @@ public class DataPlaneProcessor extends AbstractProcessor {
         }
 
         if (context.containRouters()) {
-            resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.NEIGHBOR, Common.OperationType.CREATE));
+            resourceOperationTypes.add(new ResourceOperation(Common.ResourceType.ROUTER, Common.OperationType.CREATE));
         }
 
         return resourceOperationTypes;


### PR DESCRIPTION
This PR proposes a fix to two "neighbor resource operation type" issue introduced by PR #603.

__Issue Description__

When the network configuration message is constructed, PM needs to initialize the value of ResourceOperationTypes. The previous PR wrongly put _Router_ type as a _Neighbor_ type, which further introduces duplicated neighbor entities in the List<ResourceOperation>.