### PR TITLE
[Communication] gRPC channel/stub pool and keepalive for channels

### DIFF
--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/client/gRPC/GoalStateClientImpl.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/client/gRPC/GoalStateClientImpl.java
@@ -47,7 +47,7 @@ public class GoalStateClientImpl implements GoalStateClient {
 
     private final ExecutorService executor;
 
-    private SortedMap<String, GrpcChannelStub> hostIpGrpcChannelStubMap;
+    private ConcurrentHashMap<String, GrpcChannelStub> hostIpGrpcChannelStubMap;
 
 
     public static GoalStateClientImpl getInstance(){
@@ -75,7 +75,7 @@ public class GoalStateClientImpl implements GoalStateClient {
                 new DefaultThreadFactory("grpc-thread-pool"));
 
         //TODO: Setup a connection pool. one ACA, one client.
-        this.hostIpGrpcChannelStubMap = new TreeMap<>();
+        this.hostIpGrpcChannelStubMap = new ConcurrentHashMap();
     }
 
     @Override

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/client/gRPC/GoalStateClientImpl.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/client/gRPC/GoalStateClientImpl.java
@@ -24,6 +24,7 @@ import com.futurewei.alcor.netwconfigmanager.entity.HostGoalState;
 import com.futurewei.alcor.schema.GoalStateProvisionerGrpc;
 import com.futurewei.alcor.schema.Goalstate;
 import com.futurewei.alcor.schema.Goalstateprovisioner;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -37,11 +38,24 @@ import java.util.stream.Collectors;
 
 @Service("grpcGoalStateClient")
 public class GoalStateClientImpl implements GoalStateClient {
+
+    private static GoalStateClientImpl instance = null;
+
     private static final Logger logger = LoggerFactory.getLogger();
 
     private int hostAgentPort;
 
     private final ExecutorService executor;
+
+    private SortedMap<String, GrpcChannelStub> hostIpGrpcChannelStubMap;
+
+
+    public static GoalStateClientImpl getInstance(){
+        if (instance == null){
+            instance = new GoalStateClientImpl();
+        }
+        return instance;
+    }
 
     //    @Autowired
     public GoalStateClientImpl() {
@@ -61,6 +75,7 @@ public class GoalStateClientImpl implements GoalStateClient {
                 new DefaultThreadFactory("grpc-thread-pool"));
 
         //TODO: Setup a connection pool. one ACA, one client.
+        this.hostIpGrpcChannelStubMap = new TreeMap<>();
     }
 
     @Override
@@ -97,13 +112,42 @@ public class GoalStateClientImpl implements GoalStateClient {
         }).collect(Collectors.toList());
     }
 
+    private GrpcChannelStub getOrCreateGrpcChannel(String hostIp){
+        if(!this.hostIpGrpcChannelStubMap.containsKey(hostIp)){
+            ManagedChannel channel = ManagedChannelBuilder.forAddress(hostIp, this.hostAgentPort)
+                    .usePlaintext()
+                    .keepAliveWithoutCalls(true)
+                    .keepAliveTime(Long.MAX_VALUE, TimeUnit.SECONDS)
+                    .build();
+            GoalStateProvisionerGrpc.GoalStateProvisionerStub asyncStub = GoalStateProvisionerGrpc.newStub(channel);
+            this.hostIpGrpcChannelStubMap.put(hostIp, new GrpcChannelStub(channel, asyncStub));
+            logger.log(Level.INFO, "[getOrCreateGrpcChannel] Created a channel and stub to host IP: " + hostIp);
+        }
+        ManagedChannel chan = this.hostIpGrpcChannelStubMap.get(hostIp).channel;
+        //checks the channel status, reconnects if the channel is IDLE
+
+        ConnectivityState channelState =chan.getState(true);
+        if (channelState != ConnectivityState.READY && channelState != ConnectivityState.CONNECTING && channelState != ConnectivityState.IDLE){
+            // if the state is not good, we can always create another channel to replace the current one
+            ManagedChannel channel = ManagedChannelBuilder.forAddress(hostIp, this.hostAgentPort)
+                    .usePlaintext()
+                    .keepAliveWithoutCalls(true)
+                    .keepAliveTime(Long.MAX_VALUE, TimeUnit.SECONDS)
+                    .build();
+            GoalStateProvisionerGrpc.GoalStateProvisionerStub asyncStub = GoalStateProvisionerGrpc.newStub(channel);
+
+            this.hostIpGrpcChannelStubMap.put(hostIp, new GrpcChannelStub(channel, asyncStub));
+            logger.log(Level.INFO, "[getOrCreateGrpcChannel] Replaced a channel and stub to host IP: " + hostIp);
+        }
+        return this.hostIpGrpcChannelStubMap.get(hostIp);
+    }
+
     private void doSendGoalState(HostGoalState hostGoalState) throws InterruptedException {
 
         String hostIp = hostGoalState.getHostIp();
-        ManagedChannel channel = ManagedChannelBuilder.forAddress(hostIp, this.hostAgentPort)
-                .usePlaintext()
-                .build();
-        GoalStateProvisionerGrpc.GoalStateProvisionerStub asyncStub = GoalStateProvisionerGrpc.newStub(channel);
+
+        GrpcChannelStub channelStub = getOrCreateGrpcChannel(hostIp);
+        GoalStateProvisionerGrpc.GoalStateProvisionerStub asyncStub = channelStub.stub;
 
         Map<String, List<Goalstateprovisioner.GoalStateOperationReply.GoalStateOperationStatus>> result = new HashMap<>();
         StreamObserver<Goalstateprovisioner.GoalStateOperationReply> responseObserver = new StreamObserver<>() {
@@ -137,7 +181,8 @@ public class GoalStateClientImpl implements GoalStateClient {
         }
         // Mark the end of requests
         logger.log(Level.INFO, "Sending GS to Host " + hostIp + " is completed");
-        requestObserver.onCompleted();
+        // comment out onCompleted so that the same channel/stub and keep sending next time.
+        //        requestObserver.onCompleted();
 
 //        shutdown(channel);
     }
@@ -147,6 +192,16 @@ public class GoalStateClientImpl implements GoalStateClient {
             channel.shutdown().awaitTermination(Config.SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             logger.log(Level.WARNING,"Timed out forcefully shutting down connection: {}", e.getMessage());
+        }
+    }
+
+    private class GrpcChannelStub{
+        public ManagedChannel channel;
+        public GoalStateProvisionerGrpc.GoalStateProvisionerStub stub;
+
+        public GrpcChannelStub(ManagedChannel channel, GoalStateProvisionerGrpc.GoalStateProvisionerStub stub){
+            this.channel = channel;
+            this.stub = stub;
         }
     }
 }

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/server/grpc/GoalStateProvisionerServer.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/server/grpc/GoalStateProvisionerServer.java
@@ -158,7 +158,7 @@ public class GoalStateProvisionerServer implements NetworkConfigServer {
                     try {
                         Map<String, HostGoalState> filteredGoalStates = NetworkConfigManagerUtil.filterNeighbors(hostGoalStates);
 
-                        GoalStateClient grpcGoalStateClient = new GoalStateClientImpl();
+                        GoalStateClient grpcGoalStateClient = GoalStateClientImpl.getInstance();
                         grpcGoalStateClient.sendGoalStates(filteredGoalStates);
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -251,7 +251,7 @@ public class GoalStateProvisionerServer implements NetworkConfigServer {
                     }
                 }
 
-                GoalStateClient grpcGoalStateClient = new GoalStateClientImpl();
+                GoalStateClient grpcGoalStateClient = GoalStateClientImpl.getInstance();
                 grpcGoalStateClient.sendGoalStates(hostGoalStates);
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "[requestGoalStates] Retrieve from host fails. IP address = " + clientIpAddress);


### PR DESCRIPTION
This PR does the following:

1. Changes the `GoalStateClientImpl` to singleton model.
2. Implemneted gPRC channel and stub pool in `GoalStateClientImpl`, so that one host IP uses the same channel and stub, if they are healthy.
3. Implemented logic to check gRPC channel status and reconnection(if needed), before sending GoalState messages.

Comparison:
![image](https://user-images.githubusercontent.com/32083634/121446540-959f3780-c948-11eb-90de-268e2dc5c94a.png)
This is a few test result I did for comparing the NCM on master branch(without channel/stub pooling), and with different versions of NCM that I implemented on this branch. 

We can see from column I(Ping Speed(ms) Avg.) that, without any pooling, or even with channel pool(but not stub pool), which is from testcase 8 and 9, the average ping speed is at about ~400ms.

After adding stub pooling, the average ping speed increased to ~200, ~300ms.