### PR TITLE
[RM] Separate getOrCreateVPCRouter into GET and POST two APIs

### DIFF
--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -342,6 +342,11 @@ public class RouterController {
 
             routetables = this.routerService.getVpcRouteTables(projectid, vpcid);
 
+            if (routetables == null)
+            {
+                throw new RouterUnavailable();
+            }
+
         } catch (Exception e) {
             throw e;
         }

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -306,7 +306,7 @@ public class RouterController {
             InternalRouterInfo internalRouterInfo = this.neutronRouterService.constructInternalRouterInfo(router.getId(), internalSubnetRoutingTableList);
 
             // send InternalRouterInfo contract to DPM
-//            this.routerToDPMService.sendInternalRouterInfoToDPM(internalRouterInfo);
+            this.routerToDPMService.sendInternalRouterInfoToDPM(internalRouterInfo);
 
         } catch (ParameterNullOrEmptyException e) {
             throw e;
@@ -333,7 +333,7 @@ public class RouterController {
     @DurationStatistics
     public RouteTablesWebJson getVpcRouteTables(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
 
-        List<RouteTable> routetables = null;
+        List<RouteTable> routetables = new ArrayList<>();
 
         try {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(vpcid);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -344,7 +344,7 @@ public class RouterController {
 
             if (routetables == null)
             {
-                throw new RouterUnavailable();
+                throw new RouterTableNotExist();
             }
 
         } catch (Exception e) {

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -333,7 +333,7 @@ public class RouterController {
     @DurationStatistics
     public RouteTablesWebJson getVpcRouteTables(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
 
-        List<RouteTable> routetables = new ArrayList<>();
+        List<RouteTable> routetables = null;
 
         try {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(vpcid);
@@ -404,8 +404,6 @@ public class RouterController {
             throw e;
         } catch (OwnMultipleSubnetRouteTablesException e) {
             logger.log(Level.WARNING, e.getMessage() + " , subnetId: " + subnetid);
-            throw e;
-        } catch (DatabasePersistenceException e) {
             throw e;
         }
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -432,7 +432,7 @@ public class RouterController {
             RestPreconditionsUtil.verifyResourceFound(projectid);
 
             // check resource
-            if (!RouteManagerUtil.checkCreateNeutronSubnetRouteTableWebJsonResourceIsValid(resource)) {
+            if (!RouteManagerUtil.checkCreateSubnetRouteTableWebJsonResourceIsValid(resource)) {
                 throw new ResourceNotValidException("request resource is invalid");
             }
 
@@ -450,7 +450,7 @@ public class RouterController {
                     "0.0.0.0/0", null, 100, null, "192.168.0.1");
             routes.add(defaultRoute);
 
-            routeTable = this.routerService.createNeutronSubnetRouteTable(projectid, subnetid, resource, routes);
+            routeTable = this.routerService.createSubnetRouteTable(projectid, subnetid, resource, routes);
 
         } catch (ParameterNullOrEmptyException e) {
             throw e;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -450,10 +450,6 @@ public class RouterController {
                         routeEntry.getDestination(), null, 100, null, routeEntry.getNexthop());
                 routes.add(newRoute);
             }
-            String d_uuid = UUID.randomUUID().toString();
-            RouteEntry defaultRoute = new RouteEntry(projectid, d_uuid, "default-route-" + d_uuid, "Default Routing Rule",
-                    "0.0.0.0/0", null, 100, null, "192.168.0.1");
-            routes.add(defaultRoute);
 
             routeTable = this.routerService.createSubnetRouteTable(projectid, subnetid, resource, routes);
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/controller/RouterController.java
@@ -22,10 +22,7 @@ import com.futurewei.alcor.common.exception.ResourceNotValidException;
 import com.futurewei.alcor.common.logging.Logger;
 import com.futurewei.alcor.common.logging.LoggerFactory;
 import com.futurewei.alcor.common.stats.DurationStatistics;
-import com.futurewei.alcor.route.exception.CanNotFindVpc;
-import com.futurewei.alcor.route.exception.HostRoutesToSubnetIsNull;
-import com.futurewei.alcor.route.exception.OwnMultipleSubnetRouteTablesException;
-import com.futurewei.alcor.route.exception.VpcNonEmptyException;
+import com.futurewei.alcor.route.exception.*;
 import com.futurewei.alcor.route.service.*;
 import com.futurewei.alcor.route.utils.RestPreconditionsUtil;
 import com.futurewei.alcor.route.utils.RouteManagerUtil;
@@ -70,7 +67,7 @@ public class RouterController {
     private RouterToDPMService routerToDPMService;
 
     /**
-     * Get or Create VPC router
+     * Get VPC router
      * @param projectid
      * @param vpcid
      * @return
@@ -80,7 +77,7 @@ public class RouterController {
             method = GET,
             value = {"/project/{projectid}/vpcs/{vpcid}/router"})
     @DurationStatistics
-    public RouterWebJson getOrCreateVpcRouter(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
+    public RouterWebJson getVpcRouter(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
 
         Router router = null;
 
@@ -89,7 +86,46 @@ public class RouterController {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectid);
             RestPreconditionsUtil.verifyResourceFound(projectid);
 
-            router = this.routerService.getOrCreateVpcRouter(projectid, vpcid);
+            router = this.routerService.getVpcRouter(projectid, vpcid);
+
+        } catch (ParameterNullOrEmptyException e) {
+            throw e;
+        } catch (CanNotFindVpc e) {
+            logger.log(Level.WARNING, e.getMessage() + " : " + vpcid);
+            throw e;
+        } catch (DatabasePersistenceException e) {
+            throw e;
+        }
+
+        if (router == null)
+        {
+            throw new CanNotFindRouter();
+        }
+
+        return new RouterWebJson(router);
+    }
+
+    /**
+     * Create VPC router
+     * @param projectid
+     * @param vpcid
+     * @return
+     * @throws Exception
+     */
+    @RequestMapping(
+            method = POST,
+            value = {"/project/{projectid}/vpcs/{vpcid}/router"})
+    @DurationStatistics
+    public RouterWebJson createVpcRouter(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
+
+        Router router = null;
+
+        try {
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(vpcid);
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectid);
+            RestPreconditionsUtil.verifyResourceFound(projectid);
+
+            router = this.routerService.createVpcRouter(projectid, vpcid);
 
         } catch (ParameterNullOrEmptyException e) {
             throw e;
@@ -139,7 +175,7 @@ public class RouterController {
     }
 
     /**
-     * Get or Create VPC default route table
+     * Get VPC default route table
      * @param projectid
      * @param vpcid
      * @return
@@ -149,7 +185,7 @@ public class RouterController {
             method = GET,
             value = {"/project/{projectid}/vpcs/{vpcid}/vpcroutetable"})
     @DurationStatistics
-    public RouteTableWebJson getOrCreateVpcRouteTable(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
+    public RouteTableWebJson getVpcRouteTable(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
 
         RouteTable routetable = null;
 
@@ -158,7 +194,41 @@ public class RouterController {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectid);
             RestPreconditionsUtil.verifyResourceFound(projectid);
 
-            routetable = this.routerService.getOrCreateVpcRouteTable(projectid, vpcid);
+            routetable = this.routerService.getVpcRouteTable(projectid, vpcid);
+
+        } catch (ParameterNullOrEmptyException e) {
+            throw e;
+        } catch (CanNotFindVpc e) {
+            logger.log(Level.WARNING, e.getMessage() + " : " + vpcid);
+            throw e;
+        } catch (DatabasePersistenceException e) {
+            throw e;
+        }
+
+        return new RouteTableWebJson(routetable);
+    }
+
+    /**
+     * Create VPC default route table
+     * @param projectid
+     * @param vpcid
+     * @return
+     * @throws Exception
+     */
+    @RequestMapping(
+            method = POST,
+            value = {"/project/{projectid}/vpcs/{vpcid}/vpcroutetable"})
+    @DurationStatistics
+    public RouteTableWebJson createVpcRouteTable(@PathVariable String projectid, @PathVariable String vpcid) throws Exception {
+
+        RouteTable routetable = null;
+
+        try {
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(vpcid);
+            RestPreconditionsUtil.verifyParameterNotNullorEmpty(projectid);
+            RestPreconditionsUtil.verifyResourceFound(projectid);
+
+            routetable = this.routerService.createVpcRouteTable(projectid, vpcid);
 
         } catch (ParameterNullOrEmptyException e) {
             throw e;
@@ -217,7 +287,11 @@ public class RouterController {
             newRouteEntry.setRoutes(routes);
 
             // find subnets related to this vpc (getVpcRouteTables)
-            Router router = this.routerService.getOrCreateVpcRouter(projectid, vpcid);
+            Router router = this.routerService.getVpcRouter(projectid, vpcid);
+            if (router == null)
+            {
+                throw new CanNotFindRouter();
+            }
             List<RouteTable> vpcRouteTables = router.getVpcRouteTables();
 
             // sub-level routing rule update
@@ -305,7 +379,7 @@ public class RouterController {
     }
 
     /**
-     * Show Subnet route table or Create Subnet route table
+     * Show Subnet route table
      * @param projectid
      * @param subnetid
      * @return
@@ -315,7 +389,7 @@ public class RouterController {
             method = GET,
             value = {"/project/{projectid}/subnets/{subnetid}/routetable"})
     @DurationStatistics
-    public RouteTableWebJson getOrCreateSubnetRouteTable(@PathVariable String projectid, @PathVariable String subnetid) throws Exception {
+    public RouteTableWebJson getSubnetRouteTable(@PathVariable String projectid, @PathVariable String subnetid) throws Exception {
 
         RouteTable routeTable = null;
 
@@ -350,7 +424,7 @@ public class RouterController {
             method = POST,
             value = {"/project/{projectid}/subnets/{subnetid}/routetable"})
     @DurationStatistics
-    public RouteTableWebJson createNeutronSubnetRouteTable(@PathVariable String projectid, @PathVariable String subnetid, @RequestBody RouteTableWebJson resource) throws Exception {
+    public RouteTableWebJson createSubnetRouteTable(@PathVariable String projectid, @PathVariable String subnetid, @RequestBody RouteTableWebJson resource) throws Exception {
 
         RouteTable routeTable = resource.getRoutetable();
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/exception/CanNotFindRouter.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/exception/CanNotFindRouter.java
@@ -1,0 +1,20 @@
+/*
+MIT License
+Copyright(c) 2020 Futurewei Cloud
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.futurewei.alcor.route.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.NOT_FOUND, reason="can not find router")
+public class CanNotFindRouter extends Exception {
+}

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/exception/VpcRouterAlreadyExist.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/exception/VpcRouterAlreadyExist.java
@@ -1,0 +1,23 @@
+/*
+MIT License
+Copyright(c) 2020 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.futurewei.alcor.route.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code= HttpStatus.CONFLICT, reason="Vpc router already exist.")
+public class VpcRouterAlreadyExist extends Exception {
+}

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/NeutronRouterServiceImpl.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/NeutronRouterServiceImpl.java
@@ -813,9 +813,7 @@ public class NeutronRouterServiceImpl implements NeutronRouterService {
             RouteTable subnetRouteTable = null;
             try {
                 subnetRouteTable = this.routerService.getSubnetRouteTable(router.getProjectId(), entry.getValue());
-            } catch (CanNotFindSubnet | CacheException | OwnMultipleSubnetRouteTablesException |
-                    DatabasePersistenceException | ResourceNotFoundException | ResourcePersistenceException |
-                    OwnMultipleVpcRouterException | CanNotFindVpc canNotFindSubnet) {
+            } catch (Exception e) {
                 logger.log(Level.WARNING, "Subnet" + entry.getValue() + "'s routing table is empty!");;
             }
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
@@ -254,12 +254,12 @@ public class RouterServiceImpl implements RouterService {
     }
 
     @Override
-    public List<RouteTable> getVpcRouteTables(String projectId, String vpcId) throws CanNotFindVpc {
+    public List<RouteTable> getVpcRouteTables(String projectId, String vpcId) throws CanNotFindVpc, CanNotFindRouter {
         VpcWebJson vpcResponse = this.vpcRouterToVpcService.getVpcWebJson(projectId, vpcId);
         VpcEntity vpcEntity = vpcResponse.getNetwork();
         Router router = vpcEntity.getRouter();
         if (router == null) {
-            return null;
+            throw new CanNotFindRouter();
         }
         return router.getVpcRouteTables();
     }

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
@@ -219,7 +219,6 @@ public class RouterServiceImpl implements RouterService {
 
     @Override
     public RouteTable updateVpcRouteTable(String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException, CanNotFindRouter {
-        RouteTable routeTable = null;
         RouteTable inRoutetable = resource.getRoutetable();
 
         // Get router
@@ -232,7 +231,7 @@ public class RouterServiceImpl implements RouterService {
         // check if there is a vpc default routetable
         List<RouteTable> vpcRouteTables = router.getVpcRouteTables();
         String vpcDefaultRouteTableId = router.getVpcDefaultRouteTableId();
-        routeTable = this.routeTableDatabaseService.getByRouteTableId(vpcDefaultRouteTableId);
+        RouteTable routeTable = this.routeTableDatabaseService.getByRouteTableId(vpcDefaultRouteTableId);
 
         if (routeTable == null) {
             String routeTableId = inRoutetable.getId();
@@ -352,7 +351,7 @@ public class RouterServiceImpl implements RouterService {
     }
 
     @Override
-    public RouteTable createNeutronSubnetRouteTable(String projectId, String subnetId, RouteTableWebJson resource, List<RouteEntry> routes) throws DatabasePersistenceException {
+    public RouteTable createSubnetRouteTable(String projectId, String subnetId, RouteTableWebJson resource, List<RouteEntry> routes) throws DatabasePersistenceException {
 
         // configure a new route table
         RouteTable routeTable = new RouteTable();
@@ -361,7 +360,7 @@ public class RouterServiceImpl implements RouterService {
         routeTable.setDescription("");
         routeTable.setName("subnet-" + id + "-routetable");
         routeTable.setProjectId(projectId);
-        routeTable.setRouteTableType(RouteTableType.NEUTRON_SUBNET.getRouteTableType());
+        routeTable.setRouteTableType(resource.getRoutetable().getRouteTableType());
         routeTable.setOwner(subnetId);
 
         routeTable.setRouteEntities(routes);

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/Impl/RouterServiceImpl.java
@@ -171,7 +171,7 @@ public class RouterServiceImpl implements RouterService {
         List<RouteTable> vpcRouteTables = router.getVpcRouteTables();
         if (vpcRouteTables != null)
         {
-            return vpcRouteTables.stream().filter(vpcRouteTable -> RouteTableType.VPC.getRouteTableType().equals(vpcRouteTable.getRouteTableType())).findFirst().get();
+            return vpcRouteTables.stream().filter(vpcRouteTable -> RouteTableType.VPC.getRouteTableType().equals(vpcRouteTable.getRouteTableType())).findFirst().orElse(null);
         }
 
         return null;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -20,6 +20,7 @@ import com.futurewei.alcor.common.exception.DatabasePersistenceException;
 import com.futurewei.alcor.common.exception.ResourceNotFoundException;
 import com.futurewei.alcor.common.exception.ResourcePersistenceException;
 import com.futurewei.alcor.route.exception.*;
+import com.futurewei.alcor.web.entity.dataplane.MulticastGoalStateByte;
 import com.futurewei.alcor.web.entity.route.*;
 import com.futurewei.alcor.web.entity.vpc.VpcEntity;
 
@@ -31,13 +32,13 @@ public interface RouterService {
     public Router createVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
     public Router createDefaultVpcRouter (String projectId, VpcEntity vpcEntity) throws DatabasePersistenceException;
     public String deleteVpcRouter (String projectId, String vpcId) throws Exception;
-    public RouteTable getVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException;
-    public RouteTable createVpcRouteTable(String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException;
+    public RouteTable getVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
+    public RouteTable createVpcRouteTable(String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
     public RouteTable createDefaultVpcRouteTable (String projectId, Router router) throws DatabasePersistenceException;
-    public RouteTable updateVpcRouteTable (String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException;
+    public RouteTable updateVpcRouteTable (String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException, CanNotFindRouter;
     public List<RouteTable> getVpcRouteTables (String projectId, String vpcId) throws CanNotFindVpc;
-    public RouteTable getSubnetRouteTable(String projectId, String subnetId) throws CanNotFindSubnet, CacheException, OwnMultipleSubnetRouteTablesException, DatabasePersistenceException, ResourceNotFoundException, ResourcePersistenceException, OwnMultipleVpcRouterException, CanNotFindVpc;
-    public RouteTable updateSubnetRouteTable (String projectId, String subnetId, UpdateRoutingRuleResponse resource) throws CacheException, DatabasePersistenceException, OwnMultipleSubnetRouteTablesException, CanNotFindVpc, CanNotFindSubnet, ResourceNotFoundException, ResourcePersistenceException, OwnMultipleVpcRouterException;
+    public RouteTable getSubnetRouteTable(String projectId, String subnetId) throws CacheException, CanNotFindRouteTableByOwner, OwnMultipleSubnetRouteTablesException;
+    public RouteTable updateSubnetRouteTable (String projectId, String subnetId, UpdateRoutingRuleResponse resource) throws CacheException, DatabasePersistenceException, OwnMultipleSubnetRouteTablesException, CanNotFindRouteTableByOwner;
     public String deleteSubnetRouteTable (String projectId, String subnetId) throws Exception;
     public RouteTable createNeutronSubnetRouteTable(String projectId, String subnetId, RouteTableWebJson resource, List<RouteEntry> routes) throws DatabasePersistenceException;
 

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -36,7 +36,7 @@ public interface RouterService {
     public RouteTable createVpcRouteTable(String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
     public RouteTable createDefaultVpcRouteTable (String projectId, Router router) throws DatabasePersistenceException;
     public RouteTable updateVpcRouteTable (String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException, CanNotFindRouter;
-    public List<RouteTable> getVpcRouteTables (String projectId, String vpcId) throws CanNotFindVpc;
+    public List<RouteTable> getVpcRouteTables (String projectId, String vpcId) throws CanNotFindVpc, CanNotFindRouter;
     public RouteTable getSubnetRouteTable(String projectId, String subnetId) throws CacheException, CanNotFindRouteTableByOwner, OwnMultipleSubnetRouteTablesException;
     public RouteTable updateSubnetRouteTable (String projectId, String subnetId, UpdateRoutingRuleResponse resource) throws CacheException, DatabasePersistenceException, OwnMultipleSubnetRouteTablesException, CanNotFindRouteTableByOwner;
     public String deleteSubnetRouteTable (String projectId, String subnetId) throws Exception;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -33,7 +33,7 @@ public interface RouterService {
     public Router createDefaultVpcRouter (String projectId, VpcEntity vpcEntity) throws DatabasePersistenceException;
     public String deleteVpcRouter (String projectId, String vpcId) throws Exception;
     public RouteTable getVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
-    public RouteTable createVpcRouteTable(String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
+    public RouteTable createVpcRouteTable(String projectId, String vpcId) throws Exception;
     public RouteTable createDefaultVpcRouteTable (String projectId, Router router) throws DatabasePersistenceException;
     public RouteTable updateVpcRouteTable (String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException, CanNotFindRouter;
     public List<RouteTable> getVpcRouteTables (String projectId, String vpcId) throws CanNotFindVpc, CanNotFindRouter;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -40,6 +40,6 @@ public interface RouterService {
     public RouteTable getSubnetRouteTable(String projectId, String subnetId) throws CacheException, CanNotFindRouteTableByOwner, OwnMultipleSubnetRouteTablesException;
     public RouteTable updateSubnetRouteTable (String projectId, String subnetId, UpdateRoutingRuleResponse resource) throws CacheException, DatabasePersistenceException, OwnMultipleSubnetRouteTablesException, CanNotFindRouteTableByOwner;
     public String deleteSubnetRouteTable (String projectId, String subnetId) throws Exception;
-    public RouteTable createNeutronSubnetRouteTable(String projectId, String subnetId, RouteTableWebJson resource, List<RouteEntry> routes) throws DatabasePersistenceException;
+    public RouteTable createSubnetRouteTable(String projectId, String subnetId, RouteTableWebJson resource, List<RouteEntry> routes) throws DatabasePersistenceException;
 
 }

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -27,10 +27,12 @@ import java.util.List;
 
 public interface RouterService {
 
-    public Router getOrCreateVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
+    public Router getVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
+    public Router createVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
     public Router createDefaultVpcRouter (String projectId, VpcEntity vpcEntity) throws DatabasePersistenceException;
     public String deleteVpcRouter (String projectId, String vpcId) throws Exception;
-    public RouteTable getOrCreateVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException;
+    public RouteTable getVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException;
+    public RouteTable createVpcRouteTable(String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException;
     public RouteTable createDefaultVpcRouteTable (String projectId, Router router) throws DatabasePersistenceException;
     public RouteTable updateVpcRouteTable (String projectId, String vpcId, RouteTableWebJson resource) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, ResourceNotFoundException, ResourcePersistenceException;
     public List<RouteTable> getVpcRouteTables (String projectId, String vpcId) throws CanNotFindVpc;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/service/RouterService.java
@@ -28,8 +28,8 @@ import java.util.List;
 
 public interface RouterService {
 
-    public Router getVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
-    public Router createVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException;
+    public Router getVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;
+    public Router createVpcRouter (String projectId, String vpcId) throws CanNotFindVpc, DatabasePersistenceException, CacheException, VpcRouterAlreadyExist;
     public Router createDefaultVpcRouter (String projectId, VpcEntity vpcEntity) throws DatabasePersistenceException;
     public String deleteVpcRouter (String projectId, String vpcId) throws Exception;
     public RouteTable getVpcRouteTable (String projectId, String vpcId) throws DatabasePersistenceException, CanNotFindVpc, CacheException, OwnMultipleVpcRouterException, CanNotFindRouter;

--- a/services/route_manager/src/main/java/com/futurewei/alcor/route/utils/RouteManagerUtil.java
+++ b/services/route_manager/src/main/java/com/futurewei/alcor/route/utils/RouteManagerUtil.java
@@ -158,13 +158,13 @@ public class RouteManagerUtil {
         return true;
     }
 
-    public static boolean checkCreateNeutronSubnetRouteTableWebJsonResourceIsValid(RouteTableWebJson resource) {
+    public static boolean checkCreateSubnetRouteTableWebJsonResourceIsValid(RouteTableWebJson resource) {
         if (resource == null) {
             return false;
         }
 
         RouteTable routetable = resource.getRoutetable();
-        if (routetable == null) {
+        if (routetable == null || routetable.getRouteTableType() == null || routetable.getRouteTableType().trim().isEmpty()) {
             return false;
         }
 

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
@@ -86,13 +86,15 @@ public class VpcRouterTests {
     public void getVpcRouter_alreadyHaveVpcRouter_pass () throws Exception {
         Router router = new Router();
         router.setId(UnitTestConfig.routerId);
+        router.setOwner(UnitTestConfig.vpcId);
 
         Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
                 .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
         this.mockMvc.perform(get(vpcRouterUri))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.router.id").value(UnitTestConfig.routerId));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.router.id").value(UnitTestConfig.routerId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.router.owner").value(UnitTestConfig.vpcId));
     }
 
     @Test

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
@@ -198,8 +198,6 @@ public class VpcRouterTests {
         vpcEntity.setRouter(router);
         vpcWebJson.setNetwork(vpcEntity);
 
-        Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
-                .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
         Mockito.when(vpcRouterToVpcService.getVpcWebJson(UnitTestConfig.projectId, UnitTestConfig.vpcId))
                 .thenReturn(vpcWebJson);
 
@@ -214,21 +212,20 @@ public class VpcRouterTests {
 
         Router router = new Router();
         router.setId(UnitTestConfig.routerId);
-        router.setVpcRouteTables(new ArrayList<>(){{add(new RouteTable(){{setRouteTableType(RouteTableType.VPC.getRouteTableType());setId(UnitTestConfig.routeTableId);}});}});
 
         VpcWebJson vpcWebJson = new VpcWebJson();
         VpcEntity vpcEntity = new VpcEntity();
         vpcEntity.setId(UnitTestConfig.vpcId);
+        vpcEntity.setRouter(router);
         vpcWebJson.setNetwork(vpcEntity);
 
-        Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
-                .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
         Mockito.when(vpcRouterToVpcService.getVpcWebJson(UnitTestConfig.projectId, UnitTestConfig.vpcId))
                 .thenReturn(vpcWebJson);
 
         this.mockMvc.perform(get(vpcRouteTableUri))
                 .andDo(print())
-                .andExpect(status().isNotFound());
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.routetable").doesNotExist());
     }
 
     @Test
@@ -286,16 +283,22 @@ public class VpcRouterTests {
 
     @Test
     public void getVpcRouteTables_pass () throws Exception {
+        Router router = new Router();
+        router.setId(UnitTestConfig.routerId);
+        router.setVpcRouteTables(new ArrayList<>(){{add(new RouteTable(){{setRouteTableType(RouteTableType.VPC.getRouteTableType());setId(UnitTestConfig.routeTableId);}});}});
+
         VpcWebJson vpcWebJson = new VpcWebJson();
         VpcEntity vpcEntity = new VpcEntity();
         vpcEntity.setId(UnitTestConfig.vpcId);
+        vpcEntity.setRouter(router);
         vpcWebJson.setNetwork(vpcEntity);
 
         Mockito.when(vpcRouterToVpcService.getVpcWebJson(UnitTestConfig.projectId, UnitTestConfig.vpcId))
                 .thenReturn(vpcWebJson);
         this.mockMvc.perform(get(getVpcRouteTablesUri))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.routetables.length()").value(1));
     }
 
     @Test

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
@@ -188,14 +188,15 @@ public class VpcRouterTests {
 
     @Test
     public void getVpcRouteTable_pass () throws Exception {
-        VpcWebJson vpcWebJson = new VpcWebJson();
-        VpcEntity vpcEntity = new VpcEntity();
-        vpcEntity.setId(UnitTestConfig.vpcId);
-        vpcWebJson.setNetwork(vpcEntity);
-
         Router router = new Router();
         router.setId(UnitTestConfig.routerId);
         router.setVpcRouteTables(new ArrayList<>(){{add(new RouteTable(){{setRouteTableType(RouteTableType.VPC.getRouteTableType());setId(UnitTestConfig.routeTableId);}});}});
+
+        VpcWebJson vpcWebJson = new VpcWebJson();
+        VpcEntity vpcEntity = new VpcEntity();
+        vpcEntity.setId(UnitTestConfig.vpcId);
+        vpcEntity.setRouter(router);
+        vpcWebJson.setNetwork(vpcEntity);
 
         Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
                 .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
@@ -210,17 +211,24 @@ public class VpcRouterTests {
 
     @Test
     public void getVpcRouteTable_notpass () throws Exception {
+
         Router router = new Router();
         router.setId(UnitTestConfig.routerId);
         router.setVpcRouteTables(new ArrayList<>(){{add(new RouteTable(){{setRouteTableType(RouteTableType.VPC.getRouteTableType());setId(UnitTestConfig.routeTableId);}});}});
 
+        VpcWebJson vpcWebJson = new VpcWebJson();
+        VpcEntity vpcEntity = new VpcEntity();
+        vpcEntity.setId(UnitTestConfig.vpcId);
+        vpcWebJson.setNetwork(vpcEntity);
+
         Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
                 .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
+        Mockito.when(vpcRouterToVpcService.getVpcWebJson(UnitTestConfig.projectId, UnitTestConfig.vpcId))
+                .thenReturn(vpcWebJson);
 
         this.mockMvc.perform(get(vpcRouteTableUri))
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.routetable.id").value(UnitTestConfig.routeTableId));
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
+++ b/services/route_manager/src/test/java/com/futurewei/alcor/route/VpcRouterTests.java
@@ -83,7 +83,7 @@ public class VpcRouterTests {
     private String subnetRouteTableUri = "/project/" + UnitTestConfig.projectId + "/subnets/" + UnitTestConfig.subnetId + "/routetable";
 
     @Test
-    public void getOrCreateVpcRouter_alreadyHaveVpcRouter_pass () throws Exception {
+    public void getVpcRouter_alreadyHaveVpcRouter_pass () throws Exception {
         Router router = new Router();
         router.setId(UnitTestConfig.routerId);
 
@@ -96,7 +96,7 @@ public class VpcRouterTests {
     }
 
     @Test
-    public void getOrCreateVpcRouter_notHaveVpcRouter_pass () throws Exception {
+    public void getVpcRouter_notHaveVpcRouter_pass () throws Exception {
         VpcWebJson vpcWebJson = new VpcWebJson();
         VpcEntity vpcEntity = new VpcEntity();
         vpcEntity.setId(UnitTestConfig.vpcId);
@@ -108,12 +108,11 @@ public class VpcRouterTests {
                 .thenReturn(vpcWebJson);
         this.mockMvc.perform(get(vpcRouterUri))
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.router.name").value(UnitTestConfig.vpcRouterName));
+                .andExpect(status().isNotFound());
     }
 
     @Test
-    public void getOrCreateVpcRouter_ExistMultipleVpcRouter_notPass () throws Exception {
+    public void getVpcRouter_ExistMultipleVpcRouter_notPass () throws Exception {
         Router router1 = new Router();
         router1.setId(UnitTestConfig.routerId);
         Router router2 = new Router();
@@ -188,7 +187,7 @@ public class VpcRouterTests {
     }
 
     @Test
-    public void getOrCreateVpcRouteTable_pass () throws Exception {
+    public void getVpcRouteTable_pass () throws Exception {
         VpcWebJson vpcWebJson = new VpcWebJson();
         VpcEntity vpcEntity = new VpcEntity();
         vpcEntity.setId(UnitTestConfig.vpcId);
@@ -202,6 +201,21 @@ public class VpcRouterTests {
                 .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
         Mockito.when(vpcRouterToVpcService.getVpcWebJson(UnitTestConfig.projectId, UnitTestConfig.vpcId))
                 .thenReturn(vpcWebJson);
+
+        this.mockMvc.perform(get(vpcRouteTableUri))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.routetable.id").value(UnitTestConfig.routeTableId));
+    }
+
+    @Test
+    public void getVpcRouteTable_notpass () throws Exception {
+        Router router = new Router();
+        router.setId(UnitTestConfig.routerId);
+        router.setVpcRouteTables(new ArrayList<>(){{add(new RouteTable(){{setRouteTableType(RouteTableType.VPC.getRouteTableType());setId(UnitTestConfig.routeTableId);}});}});
+
+        Mockito.when(routerDatabaseService.getAllRouters(anyMap()))
+                .thenReturn(new HashMap<String, Router>(){{put(UnitTestConfig.routerId, router);}});
 
         this.mockMvc.perform(get(vpcRouteTableUri))
                 .andDo(print())
@@ -290,7 +304,7 @@ public class VpcRouterTests {
     }
 
     @Test
-    public void getOrCreateSubnetRouteTable_pass () throws Exception {
+    public void getSubnetRouteTable_pass () throws Exception {
         RouteTable routetable = new RouteTable();
         routetable.setId(UnitTestConfig.routeTableId);
 
@@ -303,7 +317,7 @@ public class VpcRouterTests {
     }
 
     @Test
-    public void getOrCreateSubnetRouteTable_ExistMultipleSubnetRouteTable_notPass () throws Exception {
+    public void getSubnetRouteTable_ExistMultipleSubnetRouteTable_notPass () throws Exception {
         RouteTable routetable1 = new RouteTable();
         routetable1.setId(UnitTestConfig.routeTableId);
         RouteTable routetable2 = new RouteTable();


### PR DESCRIPTION
Router controller:

getOrCreateVPCRouter
-> rename as 'getVPCRoutercreate', and delete 'create' operation related part
-> Add a new API 'createVPCRouter'

getOrCreateSubnetRouteTable
-> rename as 'getSubnetRouteTable', and delete 'create' operation related part

createNeutronSubnetRouteTable
-> rename as 'createSubnetRouteTable'

getOrCreateVpcRouteTable
-> rename as 'getVpcRouteTable', and delete 'create' operation related part

-> Add a new API 'createVpcRouteTable'