### PR TITLE
[Network Config Mgr] Cache Writing Optimization

### DIFF
--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/cache/HostResourceMetadataCache.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/cache/HostResourceMetadataCache.java
@@ -22,6 +22,8 @@ import com.futurewei.alcor.netwconfigmanager.entity.ResourceMeta;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.stereotype.Repository;
+import com.futurewei.alcor.common.db.CacheException;
+import com.futurewei.alcor.common.db.Transaction;
 
 @Repository
 @ComponentScan(value = "com.futurewei.alcor.common.db")
@@ -29,6 +31,18 @@ public class HostResourceMetadataCache {
 
     // Map <HostId, List<ResoruceIDType>>
     private ICache<String, ResourceMeta> hostResourceMetas;
+
+    public Transaction getTransaction() throws CacheException {
+        return hostResourceMetas.getTransaction().start();
+    }
+
+    public void commit() throws CacheException {
+        hostResourceMetas.getTransaction().commit();
+    }
+
+    public void rollback() throws CacheException {
+        hostResourceMetas.getTransaction().rollback();
+    }
 
     @Autowired
     public HostResourceMetadataCache(CacheFactory cacheFactory) {

--- a/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/impl/GoalStatePersistenceServiceImpl.java
+++ b/services/network_config_manager/src/main/java/com/futurewei/alcor/netwconfigmanager/service/impl/GoalStatePersistenceServiceImpl.java
@@ -56,6 +56,7 @@ public class GoalStatePersistenceServiceImpl implements GoalStatePersistenceServ
 
         // TODO: Use Ignite transaction here
         hostResourceMetadataCache.getTransaction();
+
         // Step 1: Populate host resource metadata cache
         ResourceMeta existing = hostResourceMetadataCache.getResourceMeta(hostId);
         ResourceMeta latest = NetworkConfigManagerUtil.convertGoalStateToHostResourceMeta(
@@ -154,6 +155,7 @@ public class GoalStatePersistenceServiceImpl implements GoalStatePersistenceServ
     private void populateVpcResourceCache(HostGoalState hostGoalState, Map<String, Integer> vpcIdToVniMap) throws Exception {
         Map<String, Port.PortState> portStatesMap = hostGoalState.getGoalState().getPortStatesMap();
         HashMap<String, VpcResourceMeta> vniToVpcReourceMetaDataMap = new HashMap<>();
+
         // Retrieve all needed VpcResourceMeta from cache to memory
         for (String resourceId : portStatesMap.keySet()){
             Port.PortState portState = portStatesMap.get(resourceId);
@@ -169,6 +171,7 @@ public class GoalStatePersistenceServiceImpl implements GoalStatePersistenceServ
                 vniToVpcReourceMetaDataMap.put(vni, vpcResourceMeta);
             }
         }
+
         // Edit the in-memory VpcResourceData, instead of getting it from cache every time.
         for (String resourceId : portStatesMap.keySet()) {
             Port.PortState portState = portStatesMap.get(resourceId);
@@ -202,6 +205,7 @@ public class GoalStatePersistenceServiceImpl implements GoalStatePersistenceServ
                 vpcResourceMeta.setResourceMeta(portPrivateIp, portResourceMeta);
             }
         }
+
         // Commit the changes to the database. This is safe, it is wrapped by a transaction in updateGoalState
         for(String vni : vniToVpcReourceMetaDataMap.keySet()){
             vpcResourceCache.addResourceMeta(vniToVpcReourceMetaDataMap.get(vni));


### PR DESCRIPTION
When DPM/TC sends GoalStates, NCM needs to write these GoalStates into its cache, and it was very slow.

For a test with 200 ports on each host and with 2 hosts in total, putting the GoalState into cache took:
```
pushGoalStatesStream : finished putting GS into cache, elapsed time in milliseconds: 1185
...
pushGoalStatesStream : finished putting GS into cache, elapsed time in milliseconds: 9175
```

With this change, which allows transactional support for cache update, and minimizing cache access, the same actions took:
```
pushGoalStatesStream : finished putting GS into cache, elapsed time in milliseconds: 715
.....
pushGoalStatesStream : finished putting GS into cache, elapsed time in milliseconds: 710

```
