### PR TITLE
[Subnet] add try catch in delete subnet for subnet routing rule deletion if routing table is not exist

### DIFF
--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
@@ -540,7 +540,7 @@ public class SubnetController {
 
             // delete subnet routing rule in route manager
             try {
-                this.subnetService.deleteSubnetRoutingRuleInRM(projectId, subnetId);
+                this.subnetService.deleteSubnetRoutingTable(projectId, subnetId);
             } catch (HttpClientErrorException.NotFound e) {
                 logger.warn(e.getMessage());
             }

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
@@ -537,7 +537,11 @@ public class SubnetController {
             }
 
             // delete subnet routing rule in route manager
-            this.subnetService.deleteSubnetRoutingRuleInRM(projectId, subnetId);
+            try {
+                this.subnetService.deleteSubnetRoutingRuleInRM(projectId, subnetId);
+            } catch (HttpClientErrorException.NotFound e) {
+                logger.warn(e.getMessage());
+            }
 
             // TODO: delete gateway port in port manager. Temporary solution, need PM fix issue
             GatewayPortDetail gatewayPortDetail = subnetEntity.getGatewayPortDetail();

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/controller/SubnetController.java
@@ -58,6 +58,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.futurewei.alcor.common.constants.CommonConstants.QUERY_ATTR_HEADER;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
+import org.springframework.web.client.HttpClientErrorException;
+
 @RestController
 @ComponentScan(value = "com.futurewei.alcor.common.stats")
 public class SubnetController {

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/SubnetService.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/SubnetService.java
@@ -88,7 +88,7 @@ public interface SubnetService {
     public void updateSubnetHostRoutes (String subnetId, NewHostRoutes resource) throws ResourceNotFoundException, ResourcePersistenceException, DatabasePersistenceException, SubnetEntityNotFound, DestinationOrOperationTypeIsNull;
 
     // delete subnet routing rule in route manager
-    public void deleteSubnetRoutingRuleInRM (String projectId, String subnetId) throws SubnetIdIsNull;
+    public void deleteSubnetRoutingTable (String projectId, String subnetId) throws SubnetIdIsNull;
 
     // update subnet routing rule in route manager
     public void updateSubnetRoutingRuleInRM (String projectId, String subnetId, SubnetEntity subnetEntity) throws SubnetIdIsNull;

--- a/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetServiceImp.java
+++ b/services/subnet_manager/src/main/java/com/futurewei/alcor/subnet/service/implement/SubnetServiceImp.java
@@ -535,7 +535,7 @@ public class SubnetServiceImp implements SubnetService {
 
 
     @Override
-    public void deleteSubnetRoutingRuleInRM(String projectId, String subnetId) throws SubnetIdIsNull {
+    public void deleteSubnetRoutingTable(String projectId, String subnetId) throws SubnetIdIsNull {
 
         if (subnetId == null) {
             throw new SubnetIdIsNull();


### PR DESCRIPTION
added try catch to 'delete subnet routing rule in route manager'.
From second part of issue #648 