### PR TITLE
[Dependency] Upgrade Ignite to 2.10.0

### DIFF
--- a/kubernetes/db/ignite/ignite-deployment.yaml
+++ b/kubernetes/db/ignite/ignite-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: ignite
       containers:
       - name: ignite-node
-        image: apacheignite/ignite:2.8.1
+        image: apacheignite/ignite:2.10.0
         env:
         - name: OPTION_LIBS
           value: ignite-kubernetes

--- a/lib/Dockerfile
+++ b/lib/Dockerfile
@@ -14,7 +14,7 @@
 
 # Dockerfile for Ignite
 
-FROM apacheignite/ignite:2.8.1
+FROM apacheignite/ignite:2.10.0
 
 MAINTAINER Liguang Xie <lxie@futurewei.com>
 

--- a/lib/ignite.Dockerfile
+++ b/lib/ignite.Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu
 
-MAINTAINER xzhang2 <xzhang2@futurewei.com>
+MAINTAINER Liguang Xie <lxie@futurewei.com>
 
 EXPOSE 10800
 EXPOSE 10081
@@ -25,11 +25,11 @@ RUN apt-get update && apt-get install -y \
     wget openjdk-11-jdk unzip \
     && mkdir /code \
     && cd /code/ \
-    && wget https://downloads.apache.org//ignite/2.9.1/apache-ignite-2.9.1-bin.zip \
-    &&    unzip -d . apache-ignite-2.9.1-bin.zip \
-    && cd apache-ignite-2.9.1-bin/bin \
+    && wget https://archive.apache.org/dist/ignite/2.10.0/apache-ignite-2.10.0-bin.zip \
+    &&    unzip -d . apache-ignite-2.10.0-bin.zip \
+    && cd apache-ignite-2.10.0-bin/bin \
     && echo '<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"><bean class="org.apache.ignite.configuration.IgniteConfiguration"> <property name="peerClassLoadingEnabled" value="true"/> </bean></beans>' > config.xml
 
-COPY ./target/common-0.1.0-SNAPSHOT.jar /code/apache-ignite-2.9.1-bin/libs/common-0.1.0-SNAPSHOT.jar
+COPY ./target/common-0.1.0-SNAPSHOT.jar /code/apache-ignite-2.10.0-bin/libs/common-0.1.0-SNAPSHOT.jar
 
-ENTRYPOINT  /code/apache-ignite-2.9.1-bin/bin/ignite.sh /code/apache-ignite-2.9.1-bin/bin/config.xml
+ENTRYPOINT  /code/apache-ignite-2.10.0-bin/bin/ignite.sh /code/apache-ignite-2.10.0-bin/bin/config.xml

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -103,7 +103,7 @@ Copyright(c) 2020 Futurewei Cloud
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-core</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>ai.grakn</groupId>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@
 CtrlContainer="alcor-controller"
 RedisContainer="alcor-redis"
 IgniteContainer="alcor-ignite"
-IgniteImage="apacheignite/ignite:2.8.1"
+IgniteImage="apacheignite/ignite:2.10.0"
 DbType="redis"
 
 # Parse all params

--- a/scripts/test-prep.sh
+++ b/scripts/test-prep.sh
@@ -15,7 +15,7 @@
 
 d="$(docker ps -a |grep ignite|wc -l)"
 if [ $d -eq 0 ]; then
-  docker run -p 10800:10800 --name ignite -d apacheignite/ignite:2.8.1
+  docker run -p 10800:10800 --name ignite -d apacheignite/ignite:2.10.0
 fi
 d="$(docker ps |grep ignite|wc -l)"
 if [ $d -ne 0 ]; then

--- a/services/node_manager/pom.xml
+++ b/services/node_manager/pom.xml
@@ -33,7 +33,7 @@ Copyright(c) 2020 Futurewei Cloud
 
     <properties>
         <java.version>11</java.version>
-        <ignite.version>2.8.1</ignite.version>
+        <ignite.version>2.10.0</ignite.version>
         <swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
         <swagger2markup.version>1.2.0</swagger2markup.version>
     </properties>


### PR DESCRIPTION
Ignite v2.10.0 was released on March 2021 with a handful of desirable features to boost Alcor performance. 

Release Note: https://ignite.apache.org/releases/2.10.0/release_notes.html

This upgrade enables us to try out the following features in the next release:

* Java thin-client
         - Added thin client Java API - async API
         - Added thin client Kubernetes discovery
         - Added thin client continuous query
         - Added thin client transactions
* Ignite Control Center (https://www.gridgain.com/tryfree#controlcenter)