### PR TITLE
[CI/CD] Fix Jenkins workflow bug to avoid false positive

### DIFF
--- a/scripts/busybox-ping-test/prepare_payload.py
+++ b/scripts/busybox-ping-test/prepare_payload.py
@@ -39,6 +39,9 @@ def put_httprequest(url, data=""):
        response.raise_for_status()
   except requests.exceptions.HTTPError as err:
      print("PUT Failed for {} with error".format(url, response.text))
+     print(response.json)
+     print("ERROR",err)
+     raise SystemExit(err)
 
 
 def post_httprequest(url, data=""):


### PR DESCRIPTION
Handle the error from http put so that the test does not report success when put fails.