### PR TITLE
[Dependency] Upgrade guava package to 30.0+

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -146,7 +146,7 @@ Copyright(c) 2020 Futurewei Cloud
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>[30.0-jre,)</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Upgrade com.google.guava:guava to version 30.0-jre or later to address some potential security concern. 

Warning message from GitHub:
``
A temp directory creation vulnerability exist in Guava versions prior to 30.0 allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava com.google.common.io.Files.createTempDir(). The permissions granted to the directory created default to the standard unix-like /tmp ones, leaving the files open. We recommend updating Guava to version 30.0 or later, or update to Java 7 or later, or to explicitly change the permissions after the creation of the directory if neither are possible.
``

