### PR TITLE
Added in namespace field for ansible deploy script

### DIFF
--- a/kubernetes/services/api-gateway.yaml
+++ b/kubernetes/services/api-gateway.yaml
@@ -51,6 +51,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: api-configmap
+  namespace: default
 data:
   application.properties: |
     spring.application.name=alcor-api-gateway
@@ -110,6 +111,7 @@ metadata:
   labels:
     app: apimanager
   name: apimanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -148,6 +150,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: apimanager-service
+  namespace: default
   labels:
     name: apimanager-service
 spec:

--- a/kubernetes/services/dpm_manager.yaml
+++ b/kubernetes/services/dpm_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dpm-configmap
+  namespace: default
 data:
   application.properties: |
     dataplane.grpc.port = 50001
@@ -86,6 +87,7 @@ metadata:
   labels:
     app: dataplanemanager
   name: dataplanemanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -125,6 +127,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dataplanemanager-service
+  namespace: default
   labels:
     name: dataplanemanager-service
 spec:

--- a/kubernetes/services/elastic_ip_manager.yaml
+++ b/kubernetes/services/elastic_ip_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: eip-configmap
+  namespace: default
 data:
   application.properties: |
     microservices.port.service.url=http://portmanager-service.default.svc.cluster.local:9006
@@ -41,6 +42,7 @@ metadata:
   labels:
     app: eipmanager
   name: eipmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -78,6 +80,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: eipmanager-service
+  namespace: default
   labels:
     name: eipmanager-service
 spec:

--- a/kubernetes/services/gateway_manager.yaml
+++ b/kubernetes/services/gateway_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gateway-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -49,6 +50,7 @@ metadata:
   labels:
     app: gatewaymanager
   name: gatewaymanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -86,6 +88,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gatewaymanager-service
+  namespace: default
   labels:
     name: gatewaymanager-service
 spec:

--- a/kubernetes/services/mac_manager.yaml
+++ b/kubernetes/services/mac_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mac-configmap
+  namespace: default
 data:
   application.properties: |
     spring.redis.host=localhost
@@ -50,6 +51,7 @@ metadata:
   labels:
     app: macmanager
   name: macmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -87,6 +89,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: macmanager-service
+  namespace: default
   labels:
     name: macmanager-service
 spec:

--- a/kubernetes/services/network_config_manager.yaml
+++ b/kubernetes/services/network_config_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ncm-configmap
+  namespace: default
 data:
   application.properties: |
     dataplane.grpc.port = 50001
@@ -64,6 +65,7 @@ metadata:
   labels:
     app: netwconfigmanager
   name: netwconfigmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -103,6 +105,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: netwconfigmanager-service
+  namespace: default
   labels:
     name: netwconfigmanager-service
 spec:

--- a/kubernetes/services/node_manager.yaml
+++ b/kubernetes/services/node_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: node-configmap
+  namespace: default
 data:
   application.properties: |
     spring.redis.host=localhost
@@ -53,6 +54,7 @@ metadata:
   labels:
     app: nodemanager
   name: nodemanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -90,6 +92,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nodemanager-service
+  namespace: default
   labels:
     name: nodemanager-service
 spec:

--- a/kubernetes/services/port_manager.yaml
+++ b/kubernetes/services/port_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: port-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -61,6 +62,7 @@ metadata:
   labels:
     app: portmanager
   name: portmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -98,6 +100,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: portmanager-service
+  namespace: default
   labels:
     name: portmanager-service
 spec:

--- a/kubernetes/services/private_ip_manager.yaml
+++ b/kubernetes/services/private_ip_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ip-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -41,6 +42,7 @@ metadata:
   labels:
     app: ipmanager
   name: ipmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -78,6 +80,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ipmanager-service
+  namespace: default
   labels:
     name: ipmanager-service
 spec:

--- a/kubernetes/services/quota_manager.yaml
+++ b/kubernetes/services/quota_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: quota-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.kubeNamespace=ignite-alcor
@@ -53,6 +54,7 @@ metadata:
   labels:
     app: quotamanager
   name: quotamanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -90,6 +92,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: quotamanager-service
+  namespace: default
   labels:
     name: quotamanager-service
 spec:

--- a/kubernetes/services/route_manager.yaml
+++ b/kubernetes/services/route_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: route-configmap
+  namespace: default
 data:
   application.properties: |
     microservices.vpc.service.url=http://vpcmanager-service.default.svc.cluster.local:9001
@@ -50,6 +51,7 @@ metadata:
   labels:
     app: routemanager
   name: routemanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -87,6 +89,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: routemanager-service
+  namespace: default
   labels:
     name: routemanager-service
 spec:

--- a/kubernetes/services/sg_manager.yaml
+++ b/kubernetes/services/sg_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sg-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -41,6 +42,7 @@ metadata:
   labels:
     app: sgmanager
   name: sgmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -78,6 +80,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sgmanager-service
+  namespace: default
   labels:
     name: sgmanager-service
 spec:

--- a/kubernetes/services/subnet_manager.yaml
+++ b/kubernetes/services/subnet_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: subnet-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -52,6 +53,7 @@ metadata:
   labels:
     app: subnetmanager
   name: subnetmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -89,6 +91,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: subnetmanager-service
+  namespace: default
   labels:
     name: subnetmanager-service
 spec:

--- a/kubernetes/services/vpc_manager.yaml
+++ b/kubernetes/services/vpc_manager.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vpc-configmap
+  namespace: default
 data:
   application.properties: |
     ignite.thin.client.enable=true
@@ -50,6 +51,7 @@ metadata:
   labels:
     app: vpcmanager
   name: vpcmanager
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -87,6 +89,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vpcmanager-service
+  namespace: default
   labels:
     name: vpcmanager-service
 spec:


### PR DESCRIPTION
This PR added in the "namespace" field for alcor services on k8s.
Originally we don't need the  "namespace" field when we deploy with shell script, since they are all in the default namespace.
Now we want to switch use ansible deployment script, it need the "namespace" field in yaml. Since we can actually switch our "default" to other namespaces.