### PR TITLE
[DPM] Remove hostIps hashset from MulticastGoalstateV2

### DIFF
--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/MulticastGoalStateV2.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/MulticastGoalStateV2.java
@@ -24,6 +24,7 @@ import com.futurewei.alcor.web.entity.dataplane.MulticastGoalStateByte;
 import java.util.*;
 
 public class MulticastGoalStateV2{
+    //    Map of <hostIp, vpcId> pair for each GoalState
     private Map<String, Set<String>> hostVpcMap;
 
     private GoalStateV2 goalState;

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/MulticastGoalStateV2.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/entity/MulticastGoalStateV2.java
@@ -24,49 +24,28 @@ import com.futurewei.alcor.web.entity.dataplane.MulticastGoalStateByte;
 import java.util.*;
 
 public class MulticastGoalStateV2{
-    private Set<String> hostIps;
     private Map<String, Set<String>> hostVpcMap;
 
     private GoalStateV2 goalState;
     private GoalStateV2.Builder goalStateBuilder;
 
     public MulticastGoalStateV2() {
-        this.hostIps = new HashSet<>();
         this.goalStateBuilder = GoalStateV2.newBuilder();
         this.hostVpcMap = new HashMap<>();
     }
 
     public MulticastGoalStateV2(GoalStateV2 goalState) {
-        this.hostIps = new HashSet<>();
         this.goalState = goalState;
         this.hostVpcMap = new HashMap<>();
     }
 
-    public MulticastGoalStateV2(Set<String> hostIps, GoalStateV2 goalState) {
-        this.hostIps = hostIps;
-        this.goalState = goalState;
-        this.hostVpcMap = new HashMap<>();
-    }
-
-    public MulticastGoalStateV2(Set<String> hostIps, Map<String, Set<String>> hostVpcMap, GoalStateV2 goalState) {
-        this.hostIps = hostIps;
+    public MulticastGoalStateV2(Map<String, Set<String>> hostVpcMap, GoalStateV2 goalState) {
         this.hostVpcMap = hostVpcMap;
         this.goalState = goalState;
     }
 
     public Set<String> getHostIps() {
-        return hostIps;
-    }
-
-    public void setHostIps(Set<String> hostIps) {
-        this.hostIps = hostIps;
-    }
-
-    public void addHostIp(String hostIp) {
-        if (this.hostIps == null) {
-            this.hostIps = new HashSet<>();
-        }
-        this.hostIps.add(hostIp);
+        return this.hostVpcMap.keySet();
     }
 
     public Map<String, Set<String>> getHostVpcMap() {

--- a/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/NeighborService.java
+++ b/services/data_plane_manager/src/main/java/com/futurewei/alcor/dataplane/service/impl/NeighborService.java
@@ -309,7 +309,7 @@ public class NeighborService extends ResourceService {
             }
 
             if (!multicastGoalState.getHostIps().contains(neighborInfo2.getHostIp())) {
-                multicastGoalState.getHostIps().add(neighborInfo2.getHostIp());
+                multicastGoalState.addHostVpcPair(neighborInfo2.getHostIp(), neighborInfo2.getVpcId());
             }
 
             if (!neighborInfoSet.contains(neighborInfo1)) {
@@ -357,12 +357,7 @@ public class NeighborService extends ResourceService {
                                 neighborStateMap.put(NEIGHBOR_STATE_L2_PREFIX + neighborState.getConfiguration().getId(), neighborState);
                                 multicastHostResourceBuilder.addResources(getRourceIdType(NEIGHBOR_STATE_L2_PREFIX + portHostInfo.getPortId()));
                             } else {
-                                multicastGoalStateV2.getHostIps().add(portHostInfo.getHostIp());
-                                try {
-                                    multicastGoalStateV2.addHostVpcPair(portHostInfo.getHostIp(), portState.getConfiguration().getVpcId());
-                                } catch (Exception e) {
-
-                                }
+                                multicastGoalStateV2.addHostVpcPair(portHostInfo.getHostIp(), portState.getConfiguration().getVpcId());
                             }
                             unicastHostResourceBuilder.addResources(getRourceIdType(NEIGHBOR_STATE_L2_PREFIX + portHostInfo.getPortId()));
 
@@ -425,7 +420,6 @@ public class NeighborService extends ResourceService {
                                     neighborStateMap.put(NEIGHBOR_STATE_L3_PREFIX + neighborState.getConfiguration().getId(), neighborState);
                                     multicastHostResourceBuilder.addResources(getRourceIdType(NEIGHBOR_STATE_L3_PREFIX + portHostInfo.getPortId()));
                                 } else {
-                                    multicastGoalStateV2.getHostIps().add(portHostInfo.getHostIp());
                                     multicastGoalStateV2.addHostVpcPair(portHostInfo.getHostIp(), vpcid);
                                     subnetStateMap.put(internalSubnetPort.getSubnetId(), subnetService.buildSubnetState(internalSubnetPort.getSubnetId()).build());
                                     if (!unicastGoalStateV2.getGoalStateBuilder().getSubnetStatesMap().containsKey(internalSubnetPort.getSubnetId())){
@@ -482,11 +476,6 @@ public class NeighborService extends ResourceService {
         portHostInfoCache.getPortHostInfos(subnetId)
                 .forEach(portState -> {
                     unicastGoalStates.put(portState.getHostIp(), new UnicastGoalStateV2(portState.getHostIp(), Goalstate.GoalStateV2.newBuilder()));
-                    try {
-                        multicastGoalState.addHostVpcPair(portState.getHostIp(), vpcid);
-                    } catch (Exception e) {
-
-                    }
                 });
         Subnet.SubnetState subnetState = subnetService.buildSubnetState(subnetId).build();
         Collection<InternalSubnetPorts> internalSubnetPorts  = subnetPortsCache.getSubnetPortsByRouterId(routerId).values();
@@ -507,7 +496,7 @@ public class NeighborService extends ResourceService {
                                 multicastGoalState.getGoalStateBuilder().putSubnetStates(subnetId, subnetState);
                             }
                         } else {
-                            multicastGoalState.getHostIps().add(portHostInfo.getHostIp());
+                            multicastGoalState.addHostVpcPair(portHostInfo.getHostIp(), vpcid);
                             unicastHostResourceBuilder.addResources(getRourceIdType(NEIGHBOR_STATE_L3_PREFIX + portHostInfo.getPortId()));
                             if (!subnetStateMap.containsKey(subnetId)) {
                                 Router.RouterConfiguration.SubnetRoutingTable.Builder subnetRoutingTableBuilder = Router.RouterConfiguration.SubnetRoutingTable.newBuilder();


### PR DESCRIPTION
In this PR,

1. Removed hashset for hostIps from MulticastGoalstateV2. The getter of hostIps replaced by `hostVpcMap.keySet()`
2. Add necessary comments in MulticastGoalstateV2.

These changes have passed the Jenkins test.