### PR TITLE
[Deployment] Add info in k8s yaml

### DIFF
--- a/kubernetes/services/dpm_manager.yaml
+++ b/kubernetes/services/dpm_manager.yaml
@@ -80,6 +80,12 @@ data:
     opentracing.jaeger.enable-b3-propagation=true
     opentracing.jaeger.service-name=alcor-dpm
 
+    ####Path switch configuration####
+    path.mode=GRPC
+    #"GRPC", "MQ", "AUTO" are available.
+    path.UPPER_VPC_SIZE = 1000
+    path.LOWER_VPC_SIZE = 100
+
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Added additional info for commit #742 
For the DPM application.properties change in #742 , also added them to DPM k8s yaml file. So Alcor in k8s can work smoothly. Other wise we will observe the bellow error when creating subnets.

> Error: Failed to create subnet "10.6.0.0/16" for network "n1": 500 : [{"timestamp":"2022-03-24T21:12:36.151+0000","status":500,"error":"Internal Server Error","message":"502 Bad Gateway: [no body]","path":"/project/ea7140424ac04a4fbc613138c9fec9b7/subnets/1a020230-84f9-4d73-b65e-776f15d81d78/routetable"}]
