### PR TITLE
Kustomize and Ignite DB yaml Command line args

### DIFF
--- a/kubernetes/db/ignite/ignite_alcor.yaml
+++ b/kubernetes/db/ignite/ignite_alcor.yaml
@@ -99,6 +99,7 @@ spec:
         - name: ignite-alcor-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           #resources:
             #requests:
               #cpu: "16"

--- a/kubernetes/db/ignite/ignite_alcor_dpm.yaml
+++ b/kubernetes/db/ignite/ignite_alcor_dpm.yaml
@@ -99,6 +99,7 @@ spec:
         - name: ignite-alcor-dpm-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           #resources:
             #requests:
               #cpu: "16"

--- a/kubernetes/db/ignite/ignite_alcor_ip.yaml
+++ b/kubernetes/db/ignite/ignite_alcor_ip.yaml
@@ -102,6 +102,7 @@ spec:
         - name: ignite-alcor-ip-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           #resources:
             #requests:
               #cpu: "16"

--- a/kubernetes/db/ignite/ignite_alcor_mac.yaml
+++ b/kubernetes/db/ignite/ignite_alcor_mac.yaml
@@ -101,6 +101,7 @@ spec:
         - name: ignite-alcor-mac-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           #resources:
             #requests:
               #cpu: "16"

--- a/kubernetes/db/ignite/ignite_alcor_ncm.yaml
+++ b/kubernetes/db/ignite/ignite_alcor_ncm.yaml
@@ -99,6 +99,7 @@ spec:
         - name: ignite-alcor-ncm-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           #resources:
             #requests:
               #cpu: "16"

--- a/kubernetes/db/ignite/ignite_alcor_port.yaml
+++ b/kubernetes/db/ignite/ignite_alcor_port.yaml
@@ -98,6 +98,7 @@ spec:
         - name: ignite-alcor-port-node
           image: ignite_alcor:lib8
           imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec", 'bash -ec "$IGNITE_HOME/run.sh &" && bash -ec "sleep 10 && /opt/ignite/apache-ignite/bin/control.sh --activate && tail -f /dev/null"']
           resources:
             requests:
               cpu: "4"

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,0 +1,37 @@
+# MIT License
+# Copyright(c) 2022 Futurewei Cloud
+#     Permission is hereby granted,
+#     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+#     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+#     to whom the Software is furnished to do so, subject to the following conditions:
+#     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+# DB
+- db/ignite_alcor_dpm.yaml
+- db/ignite_alcor_ip.yaml
+- db/ignite_alcor_mac.yaml
+- db/ignite_alcor_ncm.yaml
+- db/ignite_alcor_port.yaml
+- db/ignite_alcor.yaml
+
+# Services
+- services/api-gateway.yaml
+- services/dpm_manager.yaml
+- services/elastic_ip_manager.yaml
+- services/gateway_manager.yaml
+- services/mac_manager.yaml
+- services/network_config_manager.yaml
+- services/node_manager.yaml
+- services/port_manager.yaml
+- services/private_ip_manager.yaml
+- services/quota_manager.yaml
+- services/route_manager.yaml
+- services/sg_manager.yaml
+- services/subnet_manager.yaml
+- services/vpc_manager.yaml

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -13,12 +13,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # DB
-- db/ignite_alcor_dpm.yaml
-- db/ignite_alcor_ip.yaml
-- db/ignite_alcor_mac.yaml
-- db/ignite_alcor_ncm.yaml
-- db/ignite_alcor_port.yaml
-- db/ignite_alcor.yaml
+- db/ignite/ignite_alcor_dpm.yaml
+- db/ignite/ignite_alcor_ip.yaml
+- db/ignite/ignite_alcor_mac.yaml
+- db/ignite/ignite_alcor_ncm.yaml
+- db/ignite/ignite_alcor_port.yaml
+- db/ignite/ignite_alcor.yaml
 
 # Services
 - services/api-gateway.yaml


### PR DESCRIPTION
This PR adds the following changes:

- Single Kustomize file to deploy Alcor on Kubernetes.
- Fix ignite DB deployment that required the extra step of activating the DB with Kubectl